### PR TITLE
Fix GCC build error by correctly including `<utility>` header

### DIFF
--- a/include/helpers.hpp
+++ b/include/helpers.hpp
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <iostream>
 #include <iterator>
+#include <type_traits>
 #include <utility>
 #include <vector>
 #include "termcolor.hpp"

--- a/include/helpers.hpp
+++ b/include/helpers.hpp
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <iostream>
 #include <iterator>
+#include <utility>
 #include <vector>
 #include "termcolor.hpp"
 


### PR DESCRIPTION
This is needed to not rely on implementation defined behavior regarding transitive header includes, here for std::integer_sequence.