### PR TITLE
Add `.clang-format`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,10 +5,10 @@ AccessModifierOffset: -2
 TabWidth: 4
 NamespaceIndentation: All
 UseTab: ForContinuationAndIndentation
-AllowShortEnumsOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: true
-AllowShortFunctionsOnASingleLine: false
-AllowShortIfStatementsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: true
 Cpp11BracedListStyle: true
 PackConstructorInitializers: BinPack
 AlignAfterOpenBracket: BlockIndent

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,14 @@
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 120
+AccessModifierOffset: -2
+TabWidth: 4
+NamespaceIndentation: All
+UseTab: ForContinuationAndIndentation
+AllowShortEnumsOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+Cpp11BracedListStyle: true
+PackConstructorInitializers: BinPack
+AlignAfterOpenBracket: BlockIndent


### PR DESCRIPTION
Used the command `clang-format -i tests/**/*.c src/**/*.cpp include/**/*.hpp` to process all of the project's files.
Using the one from [pcsx-redux](https://github.com/grumpycoders/pcsx-redux/blob/main/src/.clang-format)as a basis and then made additional edits to be the _least_ disruptiveto the pre-existing formatting patterns.

Open to additional edits.