### PR TITLE
Use `std::span` to pass vertex data

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 BasedOnStyle: Google
 IndentWidth: 4
-ColumnLimit: 120
+ColumnLimit: 150
 AccessModifierOffset: -2
 TabWidth: 4
 NamespaceIndentation: All

--- a/include/opengl.hpp
+++ b/include/opengl.hpp
@@ -23,13 +23,25 @@
 #include <functional>
 #include <initializer_list>
 #include <iostream>
-#include <span>
 #include <stdexcept>
 #include <string_view>
 #include <type_traits>
 #include <utility>
 
 #include "gl3w.h"
+
+// Check if we have C++20. If yes, we can add C++20 std::span support
+#ifdef _MSVC_LANG // MSVC does not properly define __cplusplus without a compiler flag...
+#if _MSVC_LANG >= 202002L
+#define OPENGL_HAVE_CPP20
+#endif
+#elif __cplusplus >= 202002L
+#define OPENGL_HAVE_CPP20
+#endif // MSVC_LANG
+
+#ifdef OPENGL_HAVE_CPP20
+#include <span>
+#endif
 
 // Uncomment the following define if you want GL objects to automatically free themselves when their lifetime ends
 // #define OPENGL_DESTRUCTORS
@@ -389,17 +401,30 @@ namespace OpenGL {
         void bind() { glBindBuffer(GL_ARRAY_BUFFER, m_handle); }
         void free() { glDeleteBuffers(1, &m_handle); }
 
-		// Reallocates the buffer on every call. Prefer the sub version if possible.
+        // Reallocates the buffer on every call. Prefer the sub version if possible.
+		template <typename VertType>
+		void bufferVerts(VertType* vertices, int vertCount, GLenum usage = GL_DYNAMIC_DRAW) {
+			glBufferData(GL_ARRAY_BUFFER, sizeof(VertType) * vertCount, vertices, usage);
+		}
+
+		// Only use if you used createFixedSize
+		template <typename VertType>
+		void bufferVertsSub(VertType* vertices, int vertCount, GLintptr offset = 0) {
+			glBufferSubData(GL_ARRAY_BUFFER, offset, sizeof(VertType) * vertCount, vertices);
+		}
+
+        // If C++20 is available, add overloads that take std::span instead of raw pointers
+#ifdef OPENGL_HAVE_CPP20
 		template <typename VertType>
 		void bufferVerts(std::span<const VertType> vertices, GLenum usage = GL_DYNAMIC_DRAW) {
 			glBufferData(GL_ARRAY_BUFFER, sizeof(VertType) * vertices.size(), vertices.data(), usage);
 		}
 
-		// Only use if you used createFixedSize
 		template <typename VertType>
 		void bufferVertsSub(std::span<const VertType> vertices, GLintptr offset = 0) {
 			glBufferSubData(GL_ARRAY_BUFFER, offset, sizeof(VertType) * vertices.size(), vertices.data());
 		}
+#endif
 	};
 
     enum DepthFunc {

--- a/include/opengl.hpp
+++ b/include/opengl.hpp
@@ -23,6 +23,7 @@
 #include <functional>
 #include <initializer_list>
 #include <iostream>
+#include <span>
 #include <stdexcept>
 #include <string_view>
 #include <type_traits>
@@ -388,18 +389,18 @@ namespace OpenGL {
         void bind() { glBindBuffer(GL_ARRAY_BUFFER, m_handle); }
         void free() { glDeleteBuffers(1, &m_handle); }
 
-        // Reallocates the buffer on every call. Prefer the sub version if possible.
-        template <typename VertType>
-        void bufferVerts(VertType* vertices, int vertCount, GLenum usage = GL_DYNAMIC_DRAW) {
-            glBufferData(GL_ARRAY_BUFFER, sizeof(VertType) * vertCount, vertices, usage);
-        }
+		// Reallocates the buffer on every call. Prefer the sub version if possible.
+		template <typename VertType>
+		void bufferVerts(std::span<const VertType> vertices, GLenum usage = GL_DYNAMIC_DRAW) {
+			glBufferData(GL_ARRAY_BUFFER, sizeof(VertType) * vertices.size(), vertices.data(), usage);
+		}
 
-        // Only use if you used createFixedSize
-        template <typename VertType>
-        void bufferVertsSub(VertType* vertices, int vertCount, GLintptr offset = 0) {
-            glBufferSubData(GL_ARRAY_BUFFER, offset, sizeof(VertType) * vertCount, vertices);
-        }
-    };
+		// Only use if you used createFixedSize
+		template <typename VertType>
+		void bufferVertsSub(std::span<const VertType> vertices, GLintptr offset = 0) {
+			glBufferSubData(GL_ARRAY_BUFFER, offset, sizeof(VertType) * vertices.size(), vertices.data());
+		}
+	};
 
     enum DepthFunc {
         Never = GL_NEVER,       // Depth test never passes

--- a/include/renderer_gl/renderer_gl.hpp
+++ b/include/renderer_gl/renderer_gl.hpp
@@ -26,7 +26,7 @@ class Renderer {
 	OpenGL::VertexBuffer vbo;
 	GLint alphaControlLoc = -1;
 	GLint texUnitConfigLoc = -1;
-	
+
 	// Depth configuration uniform locations
 	GLint depthOffsetLoc = -1;
 	GLint depthScaleLoc = -1;
@@ -43,11 +43,11 @@ class Renderer {
 	SurfaceCache<ColourBuffer, 10> colourBufferCache;
 	SurfaceCache<Texture, 256> textureCache;
 
-	OpenGL::uvec2 fbSize; // The size of the framebuffer (ie both the colour and depth buffer)'
+	OpenGL::uvec2 fbSize;  // The size of the framebuffer (ie both the colour and depth buffer)'
 
-	u32 colourBufferLoc; // Location in 3DS VRAM for the colour buffer
-	ColourBuffer::Formats colourBufferFormat; // Format of the colours stored in the colour buffer
-	
+	u32 colourBufferLoc;                       // Location in 3DS VRAM for the colour buffer
+	ColourBuffer::Formats colourBufferFormat;  // Format of the colours stored in the colour buffer
+
 	// Same for the depth/stencil buffer
 	u32 depthBufferLoc;
 	DepthBuffer::Formats depthBufferFormat;
@@ -56,7 +56,7 @@ class Renderer {
 	OpenGL::VertexArray dummyVAO;
 	OpenGL::VertexBuffer dummyVBO;
 
-	static constexpr u32 regNum = 0x300; // Number of internal PICA registers
+	static constexpr u32 regNum = 0x300;  // Number of internal PICA registers
 	const std::array<u32, regNum>& regs;
 
 	OpenGL::Framebuffer getColourFBO();
@@ -66,18 +66,16 @@ class Renderer {
 	void setupBlending();
 	void bindDepthBuffer();
 
-public:
+  public:
 	Renderer(GPU& gpu, const std::array<u32, regNum>& internalRegs) : gpu(gpu), regs(internalRegs) {}
 
 	void reset();
-	void display();              // Display the 3DS screen contents to the window
-	void initGraphicsContext();  // Initialize graphics context
-	void getGraphicsContext();   // Set up graphics context for rendering
-	void clearBuffer(u32 startAddress, u32 endAddress, u32 value, u32 control);  // Clear a GPU buffer in VRAM
-	void displayTransfer(
-		u32 inputAddr, u32 outputAddr, u32 inputSize, u32 outputSize, u32 flags
-	);                                                                            // Perform display transfer
-	void drawVertices(OpenGL::Primitives primType, std::span<const Vertex> vertices);  // Draw the given vertices
+	void display();                                                                                 // Display the 3DS screen contents to the window
+	void initGraphicsContext();                                                                     // Initialize graphics context
+	void getGraphicsContext();                                                                      // Set up graphics context for rendering
+	void clearBuffer(u32 startAddress, u32 endAddress, u32 value, u32 control);                     // Clear a GPU buffer in VRAM
+	void displayTransfer(u32 inputAddr, u32 outputAddr, u32 inputSize, u32 outputSize, u32 flags);  // Perform display transfer
+	void drawVertices(OpenGL::Primitives primType, std::span<const Vertex> vertices);               // Draw the given vertices
 
 	void setFBSize(u32 width, u32 height) {
 		fbSize.x() = width;

--- a/include/renderer_gl/renderer_gl.hpp
+++ b/include/renderer_gl/renderer_gl.hpp
@@ -1,5 +1,7 @@
 #pragma once
 #include <array>
+#include <span>
+
 #include "helpers.hpp"
 #include "logger.hpp"
 #include "opengl.hpp"
@@ -68,12 +70,14 @@ public:
 	Renderer(GPU& gpu, const std::array<u32, regNum>& internalRegs) : gpu(gpu), regs(internalRegs) {}
 
 	void reset();
-	void display(); // Display the 3DS screen contents to the window
-	void initGraphicsContext(); // Initialize graphics context
-	void getGraphicsContext();  // Set up graphics context for rendering
-	void clearBuffer(u32 startAddress, u32 endAddress, u32 value, u32 control); // Clear a GPU buffer in VRAM
-	void displayTransfer(u32 inputAddr, u32 outputAddr, u32 inputSize, u32 outputSize, u32 flags); // Perform display transfer
-	void drawVertices(OpenGL::Primitives primType, Vertex* vertices, u32 count); // Draw the given vertices
+	void display();              // Display the 3DS screen contents to the window
+	void initGraphicsContext();  // Initialize graphics context
+	void getGraphicsContext();   // Set up graphics context for rendering
+	void clearBuffer(u32 startAddress, u32 endAddress, u32 value, u32 control);  // Clear a GPU buffer in VRAM
+	void displayTransfer(
+		u32 inputAddr, u32 outputAddr, u32 inputSize, u32 outputSize, u32 flags
+	);                                                                            // Perform display transfer
+	void drawVertices(OpenGL::Primitives primType, std::span<const Vertex> vertices);  // Draw the given vertices
 
 	void setFBSize(u32 width, u32 height) {
 		fbSize.x() = width;

--- a/src/core/PICA/gpu.cpp
+++ b/src/core/PICA/gpu.cpp
@@ -1,7 +1,10 @@
 #include "PICA/gpu.hpp"
+
+#include <array>
+#include <cstdio>
+
 #include "PICA/float_types.hpp"
 #include "PICA/regs.hpp"
-#include <cstdio>
 
 using namespace Floats;
 
@@ -41,7 +44,7 @@ void GPU::drawArrays(bool indexed) {
 		drawArrays<false>();
 }
 
-Vertex* vertices = new Vertex[Renderer::vertexBufferSize];
+static std::array<Vertex, Renderer::vertexBufferSize> vertices;
 
 template <bool indexed>
 void GPU::drawArrays() {
@@ -205,7 +208,7 @@ void GPU::drawArrays() {
 		OpenGL::Triangle, OpenGL::TriangleStrip, OpenGL::TriangleFan, OpenGL::Triangle
 	};
 	const auto shape = primTypes[primType];
-	renderer.drawVertices(shape, vertices, vertexCount);
+	renderer.drawVertices(shape, std::span(vertices).first(vertexCount));
 }
 
 Vertex GPU::getImmediateModeVertex() {

--- a/src/core/PICA/regs.cpp
+++ b/src/core/PICA/regs.cpp
@@ -157,7 +157,7 @@ void GPU::writeInternalReg(u32 index, u32 value, u32 mask) {
 						// If we've reached 3 verts, issue a draw call
 						// Handle rendering depending on the primitive type
 						if (immediateModeVertIndex == 3) {
-							renderer.drawVertices(OpenGL::Triangle, &immediateModeVertices[0], 3);
+							renderer.drawVertices(OpenGL::Triangle, immediateModeVertices);
 
 							switch (primType) {
 								// Triangle or geometry primitive. Draw a triangle and discard all vertices

--- a/src/core/renderer_gl/renderer_gl.cpp
+++ b/src/core/renderer_gl/renderer_gl.cpp
@@ -213,7 +213,6 @@ void Renderer::initGraphicsContext() {
 
 void Renderer::getGraphicsContext() {
 	OpenGL::disableScissor();
-	OpenGL::setViewport(400, 240);
 
 	vbo.bind();
 	vao.bind();

--- a/src/core/renderer_gl/renderer_gl.cpp
+++ b/src/core/renderer_gl/renderer_gl.cpp
@@ -265,7 +265,7 @@ void Renderer::setupBlending() {
 	}
 }
 
-void Renderer::drawVertices(OpenGL::Primitives primType, Vertex* vertices, u32 count) {
+void Renderer::drawVertices(OpenGL::Primitives primType, std::span<const Vertex> vertices) {
 	// Adjust alpha test if necessary
 	const u32 alphaControl = regs[PICAInternalRegs::AlphaTestConfig];
 	if (alphaControl != oldAlphaControl) {
@@ -352,8 +352,8 @@ void Renderer::drawVertices(OpenGL::Primitives primType, Vertex* vertices, u32 c
 		}
 	}
 
-	vbo.bufferVertsSub(vertices, count);
-	OpenGL::draw(primType, count);
+	vbo.bufferVertsSub(vertices);
+	OpenGL::draw(primType, vertices.size());
 }
 
 constexpr u32 topScreenBuffer = 0x1f000000;


### PR DESCRIPTION
Starts utilizing [std::span](https://en.cppreference.com/w/cpp/container/span) to indicate a non-owning view of a contiguous array of elements rather than `T* data, usize count`.