### PR TITLE
Use `std::span` for CPU register-state

### DIFF
--- a/include/cpu_dynarmic.hpp
+++ b/include/cpu_dynarmic.hpp
@@ -138,9 +138,7 @@ public:
 
 	// Get reference to array of FPRs. This array consists of the FPRs as single precision values
 	// Hence why its base type is u32
-	// Note: Dynarmic keeps 64 VFP registers as VFPv3 extends the VFP register set to 64 registers.
-	// However the 3DS ARM11 is an ARMv6k processor with VFPv2, so only the first 32 registers are actually used
-	std::span<u32, 64> fprs() { return jit->ExtRegs(); }
+	std::span<u32, 32> fprs() { return std::span(jit->ExtRegs()).first<32>(); }
 
     void setCPSR(u32 value) {
         jit->SetCpsr(value);

--- a/include/cpu_dynarmic.hpp
+++ b/include/cpu_dynarmic.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <span>
+
 #include "dynarmic/interface/A32/a32.h"
 #include "dynarmic/interface/A32/config.h"
 #include "dynarmic/interface/exclusive_monitor.h"
@@ -132,17 +134,13 @@ public:
         return jit->Regs()[index];
     }
 
-    std::array<u32, 16>& regs() {
-        return jit->Regs();
-    }
+	std::span<u32, 16> regs() { return jit->Regs(); }
 
-    // Get reference to array of FPRs. This array consists of the FPRs as single precision values
-    // Hence why its base type is u32
-    // Note: Dynarmic keeps 64 VFP registers as VFPv3 extends the VFP register set to 64 registers.
-    // However the 3DS ARM11 is an ARMv6k processor with VFPv2, so only the first 32 registers are actually used
-    std::array<u32, 64>& fprs() {
-        return jit->ExtRegs();
-    }
+	// Get reference to array of FPRs. This array consists of the FPRs as single precision values
+	// Hence why its base type is u32
+	// Note: Dynarmic keeps 64 VFP registers as VFPv3 extends the VFP register set to 64 registers.
+	// However the 3DS ARM11 is an ARMv6k processor with VFPv2, so only the first 32 registers are actually used
+	std::span<u32, 64> fprs() { return jit->ExtRegs(); }
 
     void setCPSR(u32 value) {
         jit->SetCpsr(value);

--- a/include/kernel/kernel.hpp
+++ b/include/kernel/kernel.hpp
@@ -2,10 +2,12 @@
 #include <array>
 #include <cassert>
 #include <limits>
+#include <span>
 #include <string>
 #include <vector>
-#include "kernel_types.hpp"
+
 #include "helpers.hpp"
+#include "kernel_types.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
 #include "resource_limits.hpp"
@@ -14,7 +16,7 @@
 class CPU;
 
 class Kernel {
-	std::array<u32, 16>& regs;
+	std::span<u32, 16> regs;
 	CPU& cpu;
 	Memory& mem;
 

--- a/include/services/service_manager.hpp
+++ b/include/services/service_manager.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <array>
 #include <optional>
+#include <span>
+
 #include "kernel_types.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
@@ -14,16 +16,16 @@
 #include "services/cfg.hpp"
 #include "services/dlp_srvr.hpp"
 #include "services/dsp.hpp"
-#include "services/hid.hpp"
 #include "services/frd.hpp"
 #include "services/fs.hpp"
 #include "services/gsp_gpu.hpp"
 #include "services/gsp_lcd.hpp"
+#include "services/hid.hpp"
 #include "services/ldr_ro.hpp"
 #include "services/mic.hpp"
+#include "services/ndm.hpp"
 #include "services/nfc.hpp"
 #include "services/nim.hpp"
-#include "services/ndm.hpp"
 #include "services/ptm.hpp"
 #include "services/y2r.hpp"
 
@@ -31,7 +33,7 @@
 class Kernel;
 
 class ServiceManager {
-	std::array<u32, 16>& regs;
+	std::span<u32, 16> regs;
 	Memory& mem;
 	Kernel& kernel;
 
@@ -69,8 +71,8 @@ class ServiceManager {
 	void registerClient(u32 messagePointer);
 	void subscribe(u32 messagePointer);
 
-public:
-	ServiceManager(std::array<u32, 16>& regs, Memory& mem, GPU& gpu, u32& currentPID, Kernel& kernel);
+  public:
+	ServiceManager(std::span<u32, 16> regs, Memory& mem, GPU& gpu, u32& currentPID, Kernel& kernel);
 	void reset();
 	void initializeFS() { fs.initializeFilesystem(); }
 	void handleSyncRequest(u32 messagePointer);

--- a/src/core/kernel/threads.cpp
+++ b/src/core/kernel/threads.cpp
@@ -1,8 +1,10 @@
 #include <cassert>
 #include <cstring>
-#include "kernel.hpp"
+
 #include "arm_defs.hpp"
-// This header needs to be included because I did stupid forward decl hack so the kernel and CPU can both access each other
+#include "kernel.hpp"
+// This header needs to be included because I did stupid forward decl hack so the kernel and CPU can both access each
+// other
 #include "cpu.hpp"
 #include "resource_limits.hpp"
 
@@ -20,17 +22,17 @@ void Kernel::switchThread(int newThreadIndex) {
 	}
 
 	// Backup context
-	std::memcpy(&oldThread.gprs[0], &cpu.regs()[0], 16 * sizeof(u32)); // Backup the 16 GPRs
-	std::memcpy(&oldThread.fprs[0], &cpu.fprs()[0], 32 * sizeof(u32)); // Backup the 32 FPRs
-	oldThread.cpsr = cpu.getCPSR();   // Backup CPSR
-	oldThread.fpscr = cpu.getFPSCR(); // Backup FPSCR
+	std::memcpy(oldThread.gprs.data(), cpu.regs().data(), cpu.regs().size_bytes());  // Backup the 16 GPRs
+	std::memcpy(oldThread.fprs.data(), cpu.fprs().data(), cpu.fprs().size_bytes());  // Backup the 32 FPRs
+	oldThread.cpsr = cpu.getCPSR();                                                  // Backup CPSR
+	oldThread.fpscr = cpu.getFPSCR();                                                // Backup FPSCR
 
 	// Load new context
-	std::memcpy(&cpu.regs()[0], &newThread.gprs[0], 16 * sizeof(u32)); // Load 16 GPRs
-	std::memcpy(&cpu.fprs()[0], &newThread.fprs[0], 32 * sizeof(u32)); // Load 32 FPRs
-	cpu.setCPSR(newThread.cpsr);   // Load CPSR
-	cpu.setFPSCR(newThread.fpscr); // Load FPSCR
-	cpu.setTLSBase(newThread.tlsBase); // Load CP15 thread-local-storage pointer register
+	std::memcpy(cpu.regs().data(), newThread.gprs.data(), cpu.regs().size_bytes());  // Load 16 GPRs
+	std::memcpy(cpu.fprs().data(), newThread.fprs.data(), cpu.fprs().size_bytes());  // Load 32 FPRs
+	cpu.setCPSR(newThread.cpsr);                                                     // Load CPSR
+	cpu.setFPSCR(newThread.fpscr);                                                   // Load FPSCR
+	cpu.setTLSBase(newThread.tlsBase);  // Load CP15 thread-local-storage pointer register
 
 	currentThreadIndex = newThreadIndex;
 }

--- a/src/core/services/service_manager.cpp
+++ b/src/core/services/service_manager.cpp
@@ -1,13 +1,15 @@
 #include "services/service_manager.hpp"
+
 #include <map>
+
 #include "ipc.hpp"
 #include "kernel.hpp"
 
-ServiceManager::ServiceManager(std::array<u32, 16>& regs, Memory& mem, GPU& gpu, u32& currentPID, Kernel& kernel)
+ServiceManager::ServiceManager(std::span<u32, 16> regs, Memory& mem, GPU& gpu, u32& currentPID, Kernel& kernel)
 	: regs(regs), mem(mem), kernel(kernel), ac(mem), am(mem), boss(mem), act(mem), apt(mem, kernel), cam(mem),
-	cecd(mem, kernel), cfg(mem), dlp_srvr(mem), dsp(mem, kernel), hid(mem, kernel), frd(mem), fs(mem, kernel),
-	gsp_gpu(mem, gpu, kernel, currentPID), gsp_lcd(mem), ldr(mem), mic(mem), nfc(mem, kernel), nim(mem), ndm(mem),
-	ptm(mem), y2r(mem, kernel) {}
+	  cecd(mem, kernel), cfg(mem), dlp_srvr(mem), dsp(mem, kernel), hid(mem, kernel), frd(mem), fs(mem, kernel),
+	  gsp_gpu(mem, gpu, kernel, currentPID), gsp_lcd(mem), ldr(mem), mic(mem), nfc(mem, kernel), nim(mem), ndm(mem),
+	  ptm(mem), y2r(mem, kernel) {}
 
 static constexpr int MAX_NOTIFICATION_COUNT = 16;
 


### PR DESCRIPTION
Following the trend of #33: `std::span` provides some useful utility functions like `size_bytes()` and `as_bytes()` and serves as a better non-owning "chunk of data"-type over just passing around an `std::array&`.