### PR TITLE
hle: Add proper type for result code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ add_compile_definitions(BOOST_NO_CXX98_FUNCTION_BASE) # Forbid Boost from using 
 add_library(boost INTERFACE)
 target_include_directories(boost SYSTEM INTERFACE ${Boost_INCLUDE_DIR})
 
-set(CRYPTOPP_BUILD_TESTING OFF) 
+set(CRYPTOPP_BUILD_TESTING OFF)
 add_subdirectory(third_party/cryptopp)
 
 # Check for x64
@@ -114,7 +114,9 @@ set(HEADER_FILES include/emulator.hpp include/helpers.hpp include/opengl.hpp inc
                  include/fs/archive_ext_save_data.hpp include/services/shared_font.hpp include/fs/archive_ncch.hpp
                  include/renderer_gl/textures.hpp include/colour.hpp include/services/y2r.hpp include/services/cam.hpp
                  include/services/ldr_ro.hpp include/ipc.hpp include/services/act.hpp include/services/nfc.hpp
-                 include/system_models.hpp include/services/dlp_srvr.hpp
+                 include/system_models.hpp include/services/dlp_srvr.hpp include/result/result.hpp
+                 include/result/result_common.hpp include/result/result_fs.hpp include/result/result_fnd.hpp
+                 include/result/result_gsp.hpp include/result/result_kernel.hpp include/result/result_os.hpp
 )
 
 set(THIRD_PARTY_SOURCE_FILES third_party/imgui/imgui.cpp

--- a/include/fs/archive_ext_save_data.hpp
+++ b/include/fs/archive_ext_save_data.hpp
@@ -9,11 +9,11 @@ public:
 	u64 getFreeBytes() override { Helpers::panic("ExtSaveData::GetFreeBytes unimplemented"); return 0;  }
 	std::string name() override { return "ExtSaveData::" + backingFolder; }
 
-	FSResult createFile(const FSPath& path, u64 size) override;
-	FSResult deleteFile(const FSPath& path) override;
+	HorizonResult createFile(const FSPath& path, u64 size) override;
+	HorizonResult deleteFile(const FSPath& path) override;
 
-	Rust::Result<ArchiveBase*, FSResult> openArchive(const FSPath& path) override;
-	Rust::Result<DirectorySession, FSResult> openDirectory(const FSPath& path) override;
+	Rust::Result<ArchiveBase*, HorizonResult> openArchive(const FSPath& path) override;
+	Rust::Result<DirectorySession, HorizonResult> openDirectory(const FSPath& path) override;
 	FileDescriptor openFile(const FSPath& path, const FilePerms& perms) override;
 	std::optional<u32> readFile(FileSession* file, u64 offset, u32 size, u32 dataPointer) override;
 

--- a/include/fs/archive_ncch.hpp
+++ b/include/fs/archive_ncch.hpp
@@ -8,10 +8,10 @@ public:
 	u64 getFreeBytes() override { Helpers::panic("NCCH::GetFreeBytes unimplemented"); return 0;  }
 	std::string name() override { return "NCCH"; }
 
-	FSResult createFile(const FSPath& path, u64 size) override;
-	FSResult deleteFile(const FSPath& path) override;
+	HorizonResult createFile(const FSPath& path, u64 size) override;
+	HorizonResult deleteFile(const FSPath& path) override;
 
-	Rust::Result<ArchiveBase*, FSResult> openArchive(const FSPath& path) override;
+	Rust::Result<ArchiveBase*, HorizonResult> openArchive(const FSPath& path) override;
 	FileDescriptor openFile(const FSPath& path, const FilePerms& perms) override;
 	std::optional<u32> readFile(FileSession* file, u64 offset, u32 size, u32 dataPointer) override;
 

--- a/include/fs/archive_save_data.hpp
+++ b/include/fs/archive_save_data.hpp
@@ -8,17 +8,17 @@ public:
 	u64 getFreeBytes() override { Helpers::panic("SaveData::GetFreeBytes unimplemented"); return 0; }
 	std::string name() override { return "SaveData"; }
 
-	FSResult createDirectory(const FSPath& path) override;
-	FSResult createFile(const FSPath& path, u64 size) override;
-	FSResult deleteFile(const FSPath& path) override;
+	HorizonResult createDirectory(const FSPath& path) override;
+	HorizonResult createFile(const FSPath& path, u64 size) override;
+	HorizonResult deleteFile(const FSPath& path) override;
 
-	Rust::Result<ArchiveBase*, FSResult> openArchive(const FSPath& path) override;
-	Rust::Result<DirectorySession, FSResult> openDirectory(const FSPath& path) override;
+	Rust::Result<ArchiveBase*, HorizonResult> openArchive(const FSPath& path) override;
+	Rust::Result<DirectorySession, HorizonResult> openDirectory(const FSPath& path) override;
 	FileDescriptor openFile(const FSPath& path, const FilePerms& perms) override;
 	std::optional<u32> readFile(FileSession* file, u64 offset, u32 size, u32 dataPointer) override;
 
 	void format(const FSPath& path, const FormatInfo& info) override;
-	Rust::Result<FormatInfo, FSResult> getFormatInfo(const FSPath& path) override;
+	Rust::Result<FormatInfo, HorizonResult> getFormatInfo(const FSPath& path) override;
 
 	std::filesystem::path getFormatInfoPath() {
 		return IOFile::getAppData() / "FormatInfo" / "SaveData.format";

--- a/include/fs/archive_sdmc.hpp
+++ b/include/fs/archive_sdmc.hpp
@@ -1,5 +1,8 @@
 #pragma once
 #include "archive_base.hpp"
+#include "result/result.hpp"
+
+using Result::HorizonResult;
 
 class SDMCArchive : public ArchiveBase {
 public:
@@ -8,10 +11,10 @@ public:
 	u64 getFreeBytes() override { Helpers::panic("SDMC::GetFreeBytes unimplemented"); return 0;  }
 	std::string name() override { return "SDMC"; }
 
-	FSResult createFile(const FSPath& path, u64 size) override;
-	FSResult deleteFile(const FSPath& path) override;
+	HorizonResult createFile(const FSPath& path, u64 size) override;
+	HorizonResult deleteFile(const FSPath& path) override;
 
-	Rust::Result<ArchiveBase*, FSResult> openArchive(const FSPath& path) override;
+	Rust::Result<ArchiveBase*, HorizonResult> openArchive(const FSPath& path) override;
 	FileDescriptor openFile(const FSPath& path, const FilePerms& perms) override;
 	std::optional<u32> readFile(FileSession* file, u64 offset, u32 size, u32 dataPointer) override;
 };

--- a/include/fs/archive_self_ncch.hpp
+++ b/include/fs/archive_self_ncch.hpp
@@ -8,10 +8,10 @@ public:
 	u64 getFreeBytes() override { return 0; }
 	std::string name() override { return "SelfNCCH"; }
 
-	FSResult createFile(const FSPath& path, u64 size) override;
-	FSResult deleteFile(const FSPath& path) override;
+	HorizonResult createFile(const FSPath& path, u64 size) override;
+	HorizonResult deleteFile(const FSPath& path) override;
 
-	Rust::Result<ArchiveBase*, FSResult> openArchive(const FSPath& path) override;
+	Rust::Result<ArchiveBase*, HorizonResult> openArchive(const FSPath& path) override;
 	FileDescriptor openFile(const FSPath& path, const FilePerms& perms) override;
 	std::optional<u32> readFile(FileSession* file, u64 offset, u32 size, u32 dataPointer) override;
 

--- a/include/kernel/kernel_types.hpp
+++ b/include/kernel/kernel_types.hpp
@@ -4,33 +4,7 @@
 #include "fs/archive_base.hpp"
 #include "handles.hpp"
 #include "helpers.hpp"
-
-namespace SVCResult {
-	enum : u32 {
-		Success = 0,
-		Failure = 0xFFFFFFFF,
-        ObjectNotFound = 0xD88007FA,
-
-        // Different calls return a different value for these ones
-        InvalidEnumValue = 0xD8E007ED,
-        InvalidEnumValueAlt = 0xD8E093ED,
-        BadHandle = 0xD8E007F7,
-        BadHandleAlt = 0xD9001BF7,
-
-        InvalidCombination = 0xE0E01BEE, // Used for invalid memory permission combinations
-        UnalignedAddr = 0xE0E01BF1,
-        UnalignedSize = 0xE0E01BF2,
-
-        BadThreadPriority = 0xE0E01BFD,
-        PortNameTooLong = 0xE0E0181E,
-
-        // Returned when a thread stops waiting due to timing out
-        Timeout = 0x9401BFE,
-
-        // Returned when a thread releases a mutex it does not own
-        InvalidMutexRelease = 0xD8E0041F
-	};
-}
+#include "result/result.hpp"
 
 enum class KernelObjectType : u8 {
     AddressArbiter, Archive, Directory, File, MemoryBlock, Process, ResourceLimit, Session, Dummy,
@@ -125,7 +99,7 @@ struct Thread {
     ThreadStatus status;
     Handle handle;  // OS handle for this thread
     int index; // Index of the thread. 0 for the first thread, 1 for the second, and so on
- 
+
     // The waiting address for threads that are waiting on an AddressArbiter
     u32 waitingAddress;
 

--- a/include/result/result.hpp
+++ b/include/result/result.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "result_common.hpp"
+#include "result_kernel.hpp"
+#include "result_os.hpp"
+#include "result_fnd.hpp"
+#include "result_fs.hpp"
+#include "result_gsp.hpp"

--- a/include/result/result_common.hpp
+++ b/include/result/result_common.hpp
@@ -1,0 +1,206 @@
+#pragma once
+
+#include <climits>
+#include <cstdint>
+#include <type_traits>
+
+namespace Result {
+	enum class HorizonResultLevel : uint32_t {
+		Success = 0,
+		Info = 1,
+		Status = 25,
+		Temporary = 26,
+		Permanent = 27,
+		Usage = 28,
+		Reinitialize = 29,
+		Reset = 30,
+		Fatal = 31,
+	};
+
+	enum class HorizonResultSummary : uint32_t {
+		Success = 0,
+		NothingHappened = 1,
+		WouldBlock = 2,
+		OutOfResource = 3,
+		NotFound = 4,
+		InvalidState = 5,
+		NotSupported = 6,
+		InvalidArgument = 7,
+		WrongArgument = 8,
+		Canceled = 9,
+		StatusChanged = 10,
+		Internal = 11,
+	};
+
+	enum class HorizonResultModule : uint32_t {
+		Common = 0,
+		Kernel = 1,
+		Util = 2,
+		FileServer = 3,
+		LoaderServer = 4,
+		TCB = 5,
+		OS = 6,
+		DBG = 7,
+		DMNT = 8,
+		PDN = 9 ,
+		GSP = 10,
+		I2C = 11,
+		GPIO = 12,
+		DD = 13,
+		CODEC = 14,
+		SPI = 15,
+		PXI = 16,
+		FS = 17,
+		DI = 18,
+		HID = 19,
+		CAM = 20,
+		PI = 21,
+		PM = 22,
+		PM_LOW = 23,
+		FSI = 24,
+		SRV = 25,
+		NDM = 26,
+		NWM = 27,
+		SOC = 28,
+		LDR = 29,
+		ACC = 30,
+		RomFS = 31,
+		AM = 32,
+		HIO = 33,
+		Updater = 34,
+		MIC = 35,
+		FND = 36,
+		MP = 37,
+		MPWL = 38,
+		AC = 39,
+		HTTP = 40,
+		DSP = 41,
+		SND = 42,
+		DLP = 43,
+		HIO_LOW = 44,
+		CSND = 45,
+		SSL = 46,
+		AM_LOW = 47,
+		NEX = 48,
+		Friends = 49,
+		RDT = 50,
+		Applet = 51,
+		NIM = 52,
+		PTM = 53,
+		MIDI = 54,
+		MC = 55,
+		SWC = 56,
+		FatFS = 57,
+		NGC = 58,
+		CARD = 59,
+		CARDNOR = 60,
+		SDMC = 61,
+		BOSS = 62,
+		DBM = 63,
+		Config = 64,
+		PS = 65,
+		CEC = 66,
+		IR = 67,
+		UDS = 68,
+		PL = 69,
+		CUP = 70,
+		Gyroscope = 71,
+		MCU = 72,
+		NS = 73,
+		News = 74,
+		RO = 75,
+		GD = 76,
+		CardSPI = 77,
+		EC = 78,
+		WebBrowser = 79,
+		Test = 80,
+		ENC = 81,
+		PIA = 82,
+		ACT = 83,
+		VCTL = 84,
+		OLV = 85,
+		NEIA = 86,
+		NPNS = 87,
+		AVD = 90,
+		L2B = 91,
+		MVD = 92,
+		NFC = 93,
+		UART = 94,
+		SPM = 95,
+		QTM = 96,
+		NFP = 97,
+	};
+
+	class HorizonResult {
+	private:
+		static const uint32_t DescriptionBits = 10;
+		static const uint32_t ModuleBits = 8;
+		static const uint32_t ReservedBits = 3;
+		static const uint32_t SummaryBits = 6;
+		static const uint32_t LevelBits = 5;
+
+		static const uint32_t DescriptionOffset = 0;
+		static const uint32_t ModuleOffset = DescriptionOffset + DescriptionBits;
+		static const uint32_t SummaryOffset = ModuleOffset + ModuleBits + ReservedBits;
+		static const uint32_t LevelOffset = SummaryOffset + SummaryBits;
+
+		static_assert(DescriptionBits + ModuleBits + SummaryBits + LevelBits + ReservedBits == sizeof(uint32_t) * CHAR_BIT, "Invalid Result size");
+
+		uint32_t m_value;
+
+		constexpr inline uint32_t getBitsValue(int offset, int amount) {
+			return (m_value >> offset) & ~(~0 << amount);
+		}
+
+		static constexpr inline uint32_t makeValue(uint32_t description, uint32_t module, uint32_t summary, uint32_t level) {
+			return (description << DescriptionOffset) | (module << ModuleOffset) | (summary << SummaryOffset) | (level << LevelOffset);
+		}
+
+	public:
+		constexpr HorizonResult() {}
+		constexpr HorizonResult(uint32_t value) : m_value(value) {}
+		constexpr HorizonResult(uint32_t description, HorizonResultModule module, HorizonResultSummary summary, HorizonResultLevel level) : m_value(makeValue(description, static_cast<uint32_t>(module), static_cast<uint32_t>(summary), static_cast<uint32_t>(level))) {}
+		constexpr operator uint32_t() const { return m_value; }
+
+		constexpr inline uint32_t getDescription() {
+			return getBitsValue(DescriptionOffset, DescriptionBits);
+		}
+
+		constexpr inline HorizonResultModule getModule() {
+			return static_cast<HorizonResultModule>(getBitsValue(ModuleOffset, ModuleBits));
+		}
+
+		constexpr inline HorizonResultSummary getSummary() {
+			return static_cast<HorizonResultSummary>(getBitsValue(SummaryOffset, SummaryBits));
+		}
+
+		constexpr inline HorizonResultLevel getLevel() {
+			return static_cast<HorizonResultLevel>(getBitsValue(LevelOffset, LevelBits));
+		}
+
+		constexpr inline uint32_t getRawValue() {
+			return m_value;
+		}
+
+		constexpr inline bool isSuccess() {
+			return m_value == 0;
+		}
+
+		constexpr inline bool isFailure() {
+			return m_value != 0;
+		}
+	};
+
+	static_assert(std::is_trivially_destructible<HorizonResult>::value, "std::is_trivially_destructible<HorizonResult>::value");
+
+	#define DEFINE_HORIZON_RESULT_MODULE(ns, value) \
+		namespace ns::Detail  {\
+			static constexpr HorizonResultModule ModuleId = HorizonResultModule::value; \
+		}
+
+	#define DEFINE_HORIZON_RESULT(name, description, summary, level) \
+		static constexpr HorizonResult name(description, Detail::ModuleId, HorizonResultSummary::summary, HorizonResultLevel::level);
+
+	static constexpr HorizonResult Success(0);
+	static constexpr HorizonResult FailurePlaceholder(UINT32_MAX);
+};

--- a/include/result/result_fnd.hpp
+++ b/include/result/result_fnd.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include "result_common.hpp"
+
+DEFINE_HORIZON_RESULT_MODULE(Result::FND, FND);
+
+namespace Result::FND {
+    DEFINE_HORIZON_RESULT(InvalidEnumValue, 1005, InvalidArgument, Permanent);
+};

--- a/include/result/result_fs.hpp
+++ b/include/result/result_fs.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include "result_common.hpp"
+
+DEFINE_HORIZON_RESULT_MODULE(Result::FS, FS);
+
+namespace Result::FS {
+    // TODO: Verify this
+    DEFINE_HORIZON_RESULT(FileNotFound, 100, NotFound, Status);
+    // TODO: Verify this
+    DEFINE_HORIZON_RESULT(FileNotFoundAlt, 112, NotFound, Status);
+    // Also a not found error code used here and there in the FS module.
+    DEFINE_HORIZON_RESULT(NotFoundInvalid, 120, InvalidState, Status);
+    DEFINE_HORIZON_RESULT(AlreadyExists, 190, NothingHappened, Info);
+    DEFINE_HORIZON_RESULT(FileTooLarge, 210, OutOfResource, Info);
+    // Trying to access an archive that needs formatting and has not been formatted
+    DEFINE_HORIZON_RESULT(NotFormatted, 340, InvalidState, Status);
+    DEFINE_HORIZON_RESULT(UnexpectedFileOrDir, 770, NotSupported, Usage);
+};

--- a/include/result/result_gsp.hpp
+++ b/include/result/result_gsp.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include "result_common.hpp"
+
+DEFINE_HORIZON_RESULT_MODULE(Result::GSP, GSP);
+
+namespace Result::GSP {
+    DEFINE_HORIZON_RESULT(SuccessRegisterIRQ, 519, Success, Success);
+};

--- a/include/result/result_kernel.hpp
+++ b/include/result/result_kernel.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include "result_common.hpp"
+
+DEFINE_HORIZON_RESULT_MODULE(Result::Kernel, Kernel);
+
+namespace Result::Kernel {
+    // Returned when a thread releases a mutex it does not own
+    DEFINE_HORIZON_RESULT(InvalidMutexRelease, 31, InvalidArgument, Permanent);
+    DEFINE_HORIZON_RESULT(NotFound, 1018, NotFound, Permanent);
+    DEFINE_HORIZON_RESULT(InvalidEnumValue, 1005, InvalidArgument, Permanent);
+    DEFINE_HORIZON_RESULT(InvalidHandle, 1015, InvalidArgument, Permanent);
+
+
+    static_assert(InvalidHandle == 0xD8E007F7, "conversion broken");
+};

--- a/include/result/result_os.hpp
+++ b/include/result/result_os.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include "result_common.hpp"
+
+DEFINE_HORIZON_RESULT_MODULE(Result::OS, OS);
+
+namespace Result::OS {
+    DEFINE_HORIZON_RESULT(PortNameTooLong, 30, InvalidArgument, Usage);
+    DEFINE_HORIZON_RESULT(InvalidHandle, 1015, WrongArgument, Permanent);
+    DEFINE_HORIZON_RESULT(InvalidCombination, 1006, InvalidArgument, Usage);
+    DEFINE_HORIZON_RESULT(MisalignedAddress, 1009, InvalidArgument, Usage);
+    DEFINE_HORIZON_RESULT(MisalignedSize, 1010, InvalidArgument, Usage);
+    DEFINE_HORIZON_RESULT(OutOfRange, 1021, InvalidArgument, Usage);
+    DEFINE_HORIZON_RESULT(Timeout, 1022, StatusChanged, Info);
+};

--- a/include/services/ac.hpp
+++ b/include/services/ac.hpp
@@ -3,6 +3,7 @@
 #include "kernel_types.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
+#include "result/result.hpp"
 
 class ACService {
 	Handle handle = KernelHandles::AC;

--- a/include/services/act.hpp
+++ b/include/services/act.hpp
@@ -3,6 +3,7 @@
 #include "kernel_types.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
+#include "result/result.hpp"
 
 class ACTService {
 	Handle handle = KernelHandles::ACT;

--- a/include/services/am.hpp
+++ b/include/services/am.hpp
@@ -3,6 +3,7 @@
 #include "kernel_types.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
+#include "result/result.hpp"
 
 class AMService {
 	Handle handle = KernelHandles::AM;

--- a/include/services/apt.hpp
+++ b/include/services/apt.hpp
@@ -4,6 +4,7 @@
 #include "kernel_types.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
+#include "result/result.hpp"
 
 // Yay, more circular dependencies
 class Kernel;

--- a/include/services/boss.hpp
+++ b/include/services/boss.hpp
@@ -3,6 +3,7 @@
 #include "kernel_types.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
+#include "result/result.hpp"
 
 class BOSSService {
 	Handle handle = KernelHandles::BOSS;

--- a/include/services/cam.hpp
+++ b/include/services/cam.hpp
@@ -3,6 +3,7 @@
 #include "kernel_types.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
+#include "result/result.hpp"
 
 class CAMService {
 	Handle handle = KernelHandles::CAM;

--- a/include/services/cecd.hpp
+++ b/include/services/cecd.hpp
@@ -4,6 +4,7 @@
 #include "kernel_types.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
+#include "result/result.hpp"
 
 class Kernel;
 

--- a/include/services/cfg.hpp
+++ b/include/services/cfg.hpp
@@ -4,6 +4,7 @@
 #include "logger.hpp"
 #include "memory.hpp"
 #include "region_codes.hpp"
+#include "result/result.hpp"
 
 class CFGService {
 	Handle handle = KernelHandles::CFG;

--- a/include/services/dlp_srvr.hpp
+++ b/include/services/dlp_srvr.hpp
@@ -3,6 +3,7 @@
 #include "kernel_types.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
+#include "result/result.hpp"
 
 // Please forgive me for how everything in this file is named
 // "dlp:SRVR" is not a nice name to work with

--- a/include/services/dsp.hpp
+++ b/include/services/dsp.hpp
@@ -4,6 +4,7 @@
 #include "helpers.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
+#include "result/result.hpp"
 
 namespace DSPPipeType {
 	enum : u32 {

--- a/include/services/frd.hpp
+++ b/include/services/frd.hpp
@@ -4,6 +4,7 @@
 #include "kernel_types.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
+#include "result/result.hpp"
 
 // It's important to keep this struct to 16 bytes as we use its sizeof in the service functions in frd.cpp
 struct FriendKey {

--- a/include/services/fs.hpp
+++ b/include/services/fs.hpp
@@ -8,6 +8,7 @@
 #include "kernel_types.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
+#include "result/result.hpp"
 
 // Yay, more circular dependencies
 class Kernel;
@@ -29,8 +30,8 @@ class FSService {
 	ExtSaveDataArchive sharedExtSaveData_nand;
 
 	ArchiveBase* getArchiveFromID(u32 id, const FSPath& archivePath);
-	Rust::Result<Handle, FSResult> openArchiveHandle(u32 archiveID, const FSPath& path);
-	Rust::Result<Handle, FSResult> openDirectoryHandle(ArchiveBase* archive, const FSPath& path);
+	Rust::Result<Handle, HorizonResult> openArchiveHandle(u32 archiveID, const FSPath& path);
+	Rust::Result<Handle, HorizonResult> openDirectoryHandle(ArchiveBase* archive, const FSPath& path);
 	std::optional<Handle> openFileHandle(ArchiveBase* archive, const FSPath& path, const FSPath& archivePath, const FilePerms& perms);
 	FSPath readPath(u32 type, u32 pointer, u32 size);
 
@@ -62,7 +63,7 @@ public:
 		sharedExtSaveData_nand(mem, "../SharedFiles/NAND", true), extSaveData_sdmc(mem, "SDMC"),
 		sdmc(mem), selfNcch(mem), ncch(mem), kernel(kernel)
 	{}
-	
+
 	void reset();
 	void handleSyncRequest(u32 messagePointer);
 	// Creates directories for NAND, ExtSaveData, etc if they don't already exist. Should be executed after loading a new ROM.

--- a/include/services/gsp_gpu.hpp
+++ b/include/services/gsp_gpu.hpp
@@ -6,6 +6,7 @@
 #include "kernel_types.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
+#include "result/result.hpp"
 
 enum class GPUInterrupt : u8 {
 	PSC0 = 0, // Memory fill completed

--- a/include/services/gsp_lcd.hpp
+++ b/include/services/gsp_lcd.hpp
@@ -3,6 +3,7 @@
 #include "kernel_types.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
+#include "result/result.hpp"
 
 class LCDService {
 	Handle handle = KernelHandles::LCD;

--- a/include/services/hid.hpp
+++ b/include/services/hid.hpp
@@ -5,6 +5,7 @@
 #include "kernel_types.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
+#include "result/result.hpp"
 
 namespace HID::Keys {
 	enum : u32 {

--- a/include/services/ldr_ro.hpp
+++ b/include/services/ldr_ro.hpp
@@ -3,6 +3,7 @@
 #include "kernel_types.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
+#include "result/result.hpp"
 
 class LDRService {
 	Handle handle = KernelHandles::LDR_RO;

--- a/include/services/mic.hpp
+++ b/include/services/mic.hpp
@@ -3,6 +3,7 @@
 #include "kernel_types.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
+#include "result/result.hpp"
 
 class MICService {
 	Handle handle = KernelHandles::MIC;

--- a/include/services/ndm.hpp
+++ b/include/services/ndm.hpp
@@ -3,6 +3,7 @@
 #include "kernel_types.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
+#include "result/result.hpp"
 
 class NDMService {
 	Handle handle = KernelHandles::NDM;

--- a/include/services/nfc.hpp
+++ b/include/services/nfc.hpp
@@ -3,6 +3,7 @@
 #include "kernel_types.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
+#include "result/result.hpp"
 
 // You know the drill
 class Kernel;

--- a/include/services/nim.hpp
+++ b/include/services/nim.hpp
@@ -3,6 +3,7 @@
 #include "kernel_types.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
+#include "result/result.hpp"
 
 class NIMService {
 	Handle handle = KernelHandles::NIM;

--- a/include/services/ptm.hpp
+++ b/include/services/ptm.hpp
@@ -3,6 +3,7 @@
 #include "kernel_types.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
+#include "result/result.hpp"
 
 class PTMService {
 	Handle handle = KernelHandles::PTM;

--- a/src/core/fs/archive_ncch.cpp
+++ b/src/core/fs/archive_ncch.cpp
@@ -21,14 +21,14 @@ namespace MediaType {
 	};
 };
 
-FSResult NCCHArchive::createFile(const FSPath& path, u64 size) {
+HorizonResult NCCHArchive::createFile(const FSPath& path, u64 size) {
 	Helpers::panic("[NCCH] CreateFile not yet supported");
-	return FSResult::Success;
+	return Result::Success;
 }
 
-FSResult NCCHArchive::deleteFile(const FSPath& path) {
+HorizonResult NCCHArchive::deleteFile(const FSPath& path) {
 	Helpers::panic("[NCCH] Unimplemented DeleteFile");
-	return FSResult::Success;
+	return Result::Success;
 }
 
 FileDescriptor NCCHArchive::openFile(const FSPath& path, const FilePerms& perms) {
@@ -48,7 +48,7 @@ FileDescriptor NCCHArchive::openFile(const FSPath& path, const FilePerms& perms)
 	return NoFile;
 }
 
-Rust::Result<ArchiveBase*, FSResult> NCCHArchive::openArchive(const FSPath& path) {
+Rust::Result<ArchiveBase*, HorizonResult> NCCHArchive::openArchive(const FSPath& path) {
 	if (path.type != PathType::Binary || path.binary.size() != 16) {
 		Helpers::panic("NCCHArchive::OpenArchive: Invalid path");
 	}

--- a/src/core/fs/archive_sdmc.cpp
+++ b/src/core/fs/archive_sdmc.cpp
@@ -1,14 +1,14 @@
 #include "fs/archive_sdmc.hpp"
 #include <memory>
 
-FSResult SDMCArchive::createFile(const FSPath& path, u64 size) {
+HorizonResult SDMCArchive::createFile(const FSPath& path, u64 size) {
 	Helpers::panic("[SDMC] CreateFile not yet supported");
-	return FSResult::Success;
+	return Result::Success;
 }
 
-FSResult SDMCArchive::deleteFile(const FSPath& path) {
+HorizonResult SDMCArchive::deleteFile(const FSPath& path) {
 	Helpers::panic("[SDMC] Unimplemented DeleteFile");
-	return FSResult::Success;
+	return Result::Success;
 }
 
 FileDescriptor SDMCArchive::openFile(const FSPath& path, const FilePerms& perms) {
@@ -16,9 +16,9 @@ FileDescriptor SDMCArchive::openFile(const FSPath& path, const FilePerms& perms)
 	return FileError;
 }
 
-Rust::Result<ArchiveBase*, FSResult> SDMCArchive::openArchive(const FSPath& path) {
+Rust::Result<ArchiveBase*, HorizonResult> SDMCArchive::openArchive(const FSPath& path) {
 	printf("SDMCArchive::OpenArchive: Failed\n");
-	return Err(FSResult::NotFormatted);
+	return Err(Result::FS::NotFormatted);
 }
 
 std::optional<u32> SDMCArchive::readFile(FileSession* file, u64 offset, u32 size, u32 dataPointer) {

--- a/src/core/fs/archive_self_ncch.cpp
+++ b/src/core/fs/archive_self_ncch.cpp
@@ -9,14 +9,14 @@ namespace PathType {
 	};
 };
 
-FSResult SelfNCCHArchive::createFile(const FSPath& path, u64 size) {
+HorizonResult SelfNCCHArchive::createFile(const FSPath& path, u64 size) {
 	Helpers::panic("[SelfNCCH] CreateFile not yet supported");
-	return FSResult::Success;
+	return Result::Success;
 }
 
-FSResult SelfNCCHArchive::deleteFile(const FSPath& path) {
+HorizonResult SelfNCCHArchive::deleteFile(const FSPath& path) {
 	Helpers::panic("[SelfNCCH] Unimplemented DeleteFile");
-	return FSResult::Success;
+	return Result::Success;
 }
 
 FileDescriptor SelfNCCHArchive::openFile(const FSPath& path, const FilePerms& perms) {
@@ -40,10 +40,10 @@ FileDescriptor SelfNCCHArchive::openFile(const FSPath& path, const FilePerms& pe
 	return NoFile; // No file descriptor needed for RomFS
 }
 
-Rust::Result<ArchiveBase*, FSResult> SelfNCCHArchive::openArchive(const FSPath& path) {
+Rust::Result<ArchiveBase*, HorizonResult> SelfNCCHArchive::openArchive(const FSPath& path) {
 	if (path.type != PathType::Empty) {
 		Helpers::panic("Invalid path type for SelfNCCH archive: %d\n", path.type);
-		return Err(FSResult::NotFoundInvalid);
+		return Err(Result::FS::NotFoundInvalid);
 	}
 
 	return Ok((ArchiveBase*)this);

--- a/src/core/kernel/address_arbiter.cpp
+++ b/src/core/kernel/address_arbiter.cpp
@@ -26,7 +26,7 @@ Handle Kernel::makeArbiter() {
 // Result CreateAddressArbiter(Handle* arbiter)
 void Kernel::createAddressArbiter() {
 	logSVC("CreateAddressArbiter\n");
-	regs[0] = SVCResult::Success;
+	regs[0] = Result::Success;
 	regs[1] = makeArbiter();
 }
 
@@ -43,7 +43,7 @@ void Kernel::arbitrateAddress() {
 
 	const auto arbiter = getObject(handle, KernelObjectType::AddressArbiter);
 	if (arbiter == nullptr) [[unlikely]] {
-		regs[0] = SVCResult::BadHandle;
+		regs[0] = Result::Kernel::InvalidHandle;
 		return;
 	}
 
@@ -52,16 +52,16 @@ void Kernel::arbitrateAddress() {
 	}
 
 	if (type > 4) [[unlikely]] {
-		regs[0] = SVCResult::InvalidEnumValueAlt;
+		regs[0] = Result::FND::InvalidEnumValue;
 		return;
 	}
 	// This needs to put the error code in r0 before we change threads
-	regs[0] = SVCResult::Success;
+	regs[0] = Result::Success;
 
 	switch (static_cast<ArbitrationType>(type)) {
 		// Puts this thread to sleep if word < value until another thread arbitrates the address using SIGNAL
 		case ArbitrationType::WaitIfLess: {
-			s32 word = static_cast<s32>(mem.read32(address)); // Yes this is meant to be signed 
+			s32 word = static_cast<s32>(mem.read32(address)); // Yes this is meant to be signed
 			if (word < value) {
 				sleepThreadOnArbiter(address);
 			}
@@ -71,7 +71,7 @@ void Kernel::arbitrateAddress() {
 		// Puts this thread to sleep if word < value until another thread arbitrates the address using SIGNAL
 		// If the thread is put to sleep, the arbiter address is decremented
 		case ArbitrationType::DecrementAndWaitIfLess: {
-			s32 word = static_cast<s32>(mem.read32(address)); // Yes this is meant to be signed 
+			s32 word = static_cast<s32>(mem.read32(address)); // Yes this is meant to be signed
 			if (word < value) {
 				mem.write32(address, word - 1);
 				sleepThreadOnArbiter(address);

--- a/src/core/kernel/directory_operations.cpp
+++ b/src/core/kernel/directory_operations.cpp
@@ -7,12 +7,6 @@ namespace DirectoryOps {
 	};
 }
 
-namespace Result {
-	enum : u32 {
-		Success = 0
-	};
-}
-
 void Kernel::handleDirectoryOperation(u32 messagePointer, Handle directory) {
 	const u32 cmd = mem.read32(messagePointer);
 	switch (cmd) {

--- a/src/core/kernel/file_operations.cpp
+++ b/src/core/kernel/file_operations.cpp
@@ -14,12 +14,6 @@ namespace FileOps {
 	};
 }
 
-namespace Result {
-	enum : u32 {
-		Success = 0
-	};
-}
-
 
 void Kernel::handleFileOperation(u32 messagePointer, Handle file) {
 	const u32 cmd = mem.read32(messagePointer);
@@ -90,7 +84,7 @@ void Kernel::readFile(u32 messagePointer, Handle fileHandle) {
 	if (!file->isOpen) {
 		Helpers::panic("Tried to read closed file");
 	}
-	
+
 	// Handle files with their own file descriptors by just fread'ing the data
 	if (file->fd) {
 		std::unique_ptr<u8[]> data(new u8[size]);

--- a/src/core/kernel/kernel.cpp
+++ b/src/core/kernel/kernel.cpp
@@ -149,7 +149,7 @@ u32 Kernel::getTLSPointer() {
 // Result CloseHandle(Handle handle)
 void Kernel::svcCloseHandle() {
 	logSVC("CloseHandle(handle = %d) (Unimplemented)\n", regs[0]);
-	regs[0] = SVCResult::Success;
+	regs[0] = Result::Success;
 }
 
 // u64 GetSystemTick()
@@ -169,7 +169,7 @@ void Kernel::outputDebugString() {
 
 	std::string message = mem.readString(pointer, size);
 	logDebugString("[OutputDebugString] %s\n", message.c_str());
-	regs[0] = SVCResult::Success;
+	regs[0] = Result::Success;
 }
 
 void Kernel::getProcessID() {
@@ -178,11 +178,11 @@ void Kernel::getProcessID() {
 	logSVC("GetProcessID(process: %s)\n", getProcessName(pid).c_str());
 
 	if (process == nullptr) [[unlikely]] {
-		regs[0] = SVCResult::BadHandle;
+		regs[0] = Result::Kernel::InvalidHandle;
 		return;
 	}
 
-	regs[0] = SVCResult::Success;
+	regs[0] = Result::Success;
 	regs[1] = process->getData<Process>()->id;
 }
 
@@ -194,7 +194,7 @@ void Kernel::getProcessInfo() {
 	logSVC("GetProcessInfo(process: %s, type = %d)\n", getProcessName(pid).c_str(), type);
 
 	if (process == nullptr) [[unlikely]] {
-		regs[0] = SVCResult::BadHandle;
+		regs[0] = Result::Kernel::InvalidHandle;
 		return;
 	}
 
@@ -215,7 +215,7 @@ void Kernel::getProcessInfo() {
 			Helpers::panic("GetProcessInfo: unimplemented type %d", type);
 	}
 
-	regs[0] = SVCResult::Success;
+	regs[0] = Result::Success;
 }
 
 // Result DuplicateHandle(Handle* out, Handle original)
@@ -224,7 +224,7 @@ void Kernel::duplicateHandle() {
 	logSVC("DuplicateHandle(handle = %X)\n", original);
 
 	if (original == KernelHandles::CurrentThread) {
-		regs[0] = SVCResult::Success;
+		regs[0] = Result::Success;
 		Handle ret = makeObject(KernelObjectType::Thread);
 		objects[ret].data = &threads[currentThreadIndex];
 

--- a/src/core/kernel/resource_limits.cpp
+++ b/src/core/kernel/resource_limits.cpp
@@ -10,13 +10,13 @@ void Kernel::getResourceLimit() {
 	logSVC("GetResourceLimit (handle pointer = %08X, process: %s)\n", handlePointer, getProcessName(pid).c_str());
 
 	if (process == nullptr) [[unlikely]] {
-		regs[0] = SVCResult::BadHandle;
+		regs[0] = Result::Kernel::InvalidHandle;
 		return;
 	}
 
 	const auto processData = static_cast<Process*>(process->data);
 
-	regs[0] = SVCResult::Success;
+	regs[0] = Result::Success;
 	regs[1] = processData->limits.handle;
 }
 
@@ -29,7 +29,7 @@ void Kernel::getResourceLimitLimitValues() {
 
 	const KernelObject* limit = getObject(resourceLimit, KernelObjectType::ResourceLimit);
 	if (limit == nullptr) [[unlikely]] {
-		regs[0] = SVCResult::BadHandle;
+		regs[0] = Result::Kernel::InvalidHandle;
 		return;
 	}
 
@@ -46,7 +46,7 @@ void Kernel::getResourceLimitLimitValues() {
 		count--;
 	}
 
-	regs[0] = SVCResult::Success;
+	regs[0] = Result::Success;
 }
 
 // Result GetResourceLimitCurrentValues(s64* values, Handle resourceLimit, LimitableResource* names, s32 nameCount)
@@ -59,7 +59,7 @@ void Kernel::getResourceLimitCurrentValues() {
 
 	const KernelObject* limit = getObject(resourceLimit, KernelObjectType::ResourceLimit);
 	if (limit == nullptr) [[unlikely]] {
-		regs[0] = SVCResult::BadHandle;
+		regs[0] = Result::Kernel::InvalidHandle;
 		return;
 	}
 
@@ -75,7 +75,7 @@ void Kernel::getResourceLimitCurrentValues() {
 		count--;
 	}
 
-	regs[0] = SVCResult::Success;
+	regs[0] = Result::Success;
 }
 
 s32 Kernel::getCurrentResourceValue(const KernelObject* limit, u32 resourceName) {

--- a/src/core/kernel/threads.cpp
+++ b/src/core/kernel/threads.cpp
@@ -47,7 +47,7 @@ void Kernel::sortThreads() {
 bool Kernel::canThreadRun(const Thread& t) {
 	if (t.status == ThreadStatus::Ready) {
 		return true;
-	} else if (t.status == ThreadStatus::WaitSleep || t.status == ThreadStatus::WaitSync1 
+	} else if (t.status == ThreadStatus::WaitSleep || t.status == ThreadStatus::WaitSync1
 		|| t.status == ThreadStatus::WaitSyncAny || t.status == ThreadStatus::WaitSyncAll) {
 		const u64 elapsedTicks = cpu.getTicks() - t.sleepTick;
 
@@ -81,7 +81,7 @@ std::optional<int> Kernel::getNextThread() {
 
 void Kernel::switchToNextThread() {
 	std::optional<int> newThreadIndex = getNextThread();
-	
+
 	if (!newThreadIndex.has_value()) {
 		log("Kernel tried to switch to the next thread but none found. Switching to random thread\n");
 		assert(aliveThreadCount != 0);
@@ -101,7 +101,7 @@ void Kernel::switchToNextThread() {
 // See if there;s a higher priority, ready thread and switch to that
 void Kernel::rescheduleThreads() {
 	std::optional<int> newThreadIndex = getNextThread();
-	
+
 	if (newThreadIndex.has_value() && newThreadIndex.value() != currentThreadIndex) {
 		threads[currentThreadIndex].status = ThreadStatus::Ready;
 		switchThread(newThreadIndex.value());
@@ -273,12 +273,12 @@ int Kernel::wakeupOneThread(u64 waitlist, Handle handle) {
 	switch (t.status) {
 		case ThreadStatus::WaitSync1:
 			t.status = ThreadStatus::Ready;
-			t.gprs[0] = SVCResult::Success; // The thread did not timeout, so write success to r0
+			t.gprs[0] = Result::Success; // The thread did not timeout, so write success to r0
 			break;
 
 		case ThreadStatus::WaitSyncAny:
 			t.status = ThreadStatus::Ready;
-			t.gprs[0] = SVCResult::Success; // The thread did not timeout, so write success to r0
+			t.gprs[0] = Result::Success; // The thread did not timeout, so write success to r0
 
 			// Get the index of the event in the object's waitlist, write it to r1
 			for (size_t i = 0; i < t.waitList.size(); i++) {
@@ -308,12 +308,12 @@ void Kernel::wakeupAllThreads(u64 waitlist, Handle handle) {
 		switch (t.status) {
 		case ThreadStatus::WaitSync1:
 			t.status = ThreadStatus::Ready;
-			t.gprs[0] = SVCResult::Success; // The thread did not timeout, so write success to r0
+			t.gprs[0] = Result::Success; // The thread did not timeout, so write success to r0
 			break;
 
 		case ThreadStatus::WaitSyncAny:
 			t.status = ThreadStatus::Ready;
-			t.gprs[0] = SVCResult::Success; // The thread did not timeout, so write success to r0
+			t.gprs[0] = Result::Success; // The thread did not timeout, so write success to r0
 
 			// Get the index of the event in the object's waitlist, write it to r1
 			for (size_t i = 0; i < t.waitList.size(); i++) {
@@ -352,7 +352,7 @@ void Kernel::sleepThread(s64 ns) {
 	}
 }
 
-// Result CreateThread(s32 priority, ThreadFunc entrypoint, u32 arg, u32 stacktop, s32 threadPriority, s32 processorID)	
+// Result CreateThread(s32 priority, ThreadFunc entrypoint, u32 arg, u32 stacktop, s32 threadPriority, s32 processorID)
 void Kernel::createThread() {
 	u32 priority = regs[0];
 	u32 entrypoint = regs[1];
@@ -365,11 +365,11 @@ void Kernel::createThread() {
 
 	if (priority > 0x3F) [[unlikely]] {
 		Helpers::panic("Created thread with bad priority value %X", priority);
-		regs[0] = SVCResult::BadThreadPriority;
+		regs[0] = Result::OS::OutOfRange;
 		return;
 	}
 
-	regs[0] = SVCResult::Success;
+	regs[0] = Result::Success;
 	regs[1] = makeThread(entrypoint, initialSP, priority, id, arg, ThreadStatus::Ready);
 	rescheduleThreads();
 }
@@ -379,7 +379,7 @@ void Kernel::svcSleepThread() {
 	const s64 ns = s64(u64(regs[0]) | (u64(regs[1]) << 32));
 	//logSVC("SleepThread(ns = %lld)\n", ns);
 
-	regs[0] = SVCResult::Success;
+	regs[0] = Result::Success;
 	sleepThread(ns);
 }
 
@@ -388,18 +388,18 @@ void Kernel::getThreadID() {
 	logSVC("GetThreadID(handle = %X)\n", handle);
 
 	if (handle == KernelHandles::CurrentThread) {
-		regs[0] = SVCResult::Success;
+		regs[0] = Result::Success;
 		regs[1] = currentThreadIndex;
 		return;
 	}
 
 	const auto thread = getObject(handle, KernelObjectType::Thread);
 	if (thread == nullptr) [[unlikely]] {
-		regs[0] = SVCResult::BadHandle;
+		regs[0] = Result::Kernel::InvalidHandle;
 		return;
 	}
 
-	regs[0] = SVCResult::Success;
+	regs[0] = Result::Success;
 	regs[1] = thread->getData<Thread>()->index;
 }
 
@@ -408,14 +408,14 @@ void Kernel::getThreadPriority() {
 	logSVC("GetThreadPriority (handle = %X)\n", handle);
 
 	if (handle == KernelHandles::CurrentThread) {
-		regs[0] = SVCResult::Success;
+		regs[0] = Result::Success;
 		regs[1] = threads[currentThreadIndex].priority;
 	} else {
 		auto object = getObject(handle, KernelObjectType::Thread);
 		if (object == nullptr) [[unlikely]] {
-			regs[0] = SVCResult::BadHandle;
+			regs[0] = Result::Kernel::InvalidHandle;
 		} else {
-			regs[0] = SVCResult::Success;
+			regs[0] = Result::Success;
 			regs[1] = object->getData<Thread>()->priority;
 		}
 	}
@@ -427,20 +427,20 @@ void Kernel::setThreadPriority() {
 	logSVC("SetThreadPriority (handle = %X, priority = %X)\n", handle, priority);
 
 	if (priority > 0x3F) {
-		regs[0] = SVCResult::BadThreadPriority;
+		regs[0] = Result::OS::OutOfRange;
 		return;
 	}
 
 	if (handle == KernelHandles::CurrentThread) {
-		regs[0] = SVCResult::Success;
+		regs[0] = Result::Success;
 		threads[currentThreadIndex].priority = priority;
 	} else {
 		auto object = getObject(handle, KernelObjectType::Thread);
 		if (object == nullptr) [[unlikely]] {
-			regs[0] = SVCResult::BadHandle;
+			regs[0] = Result::Kernel::InvalidHandle;
 			return;
 		} else {
-			regs[0] = SVCResult::Success;
+			regs[0] = Result::Success;
 			object->getData<Thread>()->priority = priority;
 		}
 	}
@@ -476,7 +476,7 @@ void Kernel::svcCreateMutex() {
 	bool locked = regs[1] != 0;
 	logSVC("CreateMutex (locked = %s)\n", locked ? "yes" : "no");
 
-	regs[0] = SVCResult::Success;
+	regs[0] = Result::Success;
 	regs[1] = makeMutex(locked);
 }
 
@@ -487,18 +487,18 @@ void Kernel::svcReleaseMutex() {
 	const auto object = getObject(handle, KernelObjectType::Mutex);
 	if (object == nullptr) [[unlikely]] {
 		Helpers::panic("Tried to release non-existent mutex");
-		regs[0] = SVCResult::BadHandle;
+		regs[0] = Result::Kernel::InvalidHandle;
 		return;
 	}
 
 	Mutex* moo = object->getData<Mutex>();
 	// A thread can't release a mutex it does not own
 	if (!moo->locked || moo->ownerThread != currentThreadIndex) {
-		regs[0] = SVCResult::InvalidMutexRelease;
+		regs[0] = Result::Kernel::InvalidMutexRelease;
 		return;
 	}
 
-	regs[0] = SVCResult::Success;
+	regs[0] = Result::Success;
 	releaseMutex(moo);
 }
 
@@ -513,7 +513,7 @@ void Kernel::svcCreateSemaphore() {
 	if (initialCount < 0 || maxCount < 0)
 		Helpers::panic("CreateSemaphore: Negative count value");
 
-	regs[0] = SVCResult::Success;
+	regs[0] = Result::Success;
 	regs[1] = makeSemaphore(initialCount, maxCount);
 }
 
@@ -525,7 +525,7 @@ void Kernel::svcReleaseSemaphore() {
 	const auto object = getObject(handle, KernelObjectType::Semaphore);
 	if (object == nullptr) [[unlikely]] {
 		Helpers::panic("Tried to release non-existent semaphore");
-		regs[0] = SVCResult::BadHandle;
+		regs[0] = Result::Kernel::InvalidHandle;
 		return;
 	}
 
@@ -537,7 +537,7 @@ void Kernel::svcReleaseSemaphore() {
 		Helpers::panic("ReleaseSemaphore: Release count too high");
 
 	// Write success and old available count to r0 and r1 respectively
-	regs[0] = SVCResult::Success;
+	regs[0] = Result::Success;
 	regs[1] = s->availableCount;
 	// Bump available count
 	s->availableCount += releaseCount;

--- a/src/core/services/ac.cpp
+++ b/src/core/services/ac.cpp
@@ -7,12 +7,6 @@ namespace ACCommands {
 	};
 }
 
-namespace Result {
-	enum : u32 {
-		Success = 0,
-	};
-}
-
 void ACService::reset() {}
 
 void ACService::handleSyncRequest(u32 messagePointer) {

--- a/src/core/services/act.cpp
+++ b/src/core/services/act.cpp
@@ -7,12 +7,6 @@ namespace ACTCommands {
 	};
 }
 
-namespace Result {
-	enum : u32 {
-		Success = 0,
-	};
-}
-
 void ACTService::reset() {}
 
 void ACTService::handleSyncRequest(u32 messagePointer) {

--- a/src/core/services/am.cpp
+++ b/src/core/services/am.cpp
@@ -8,12 +8,6 @@ namespace AMCommands {
 	};
 }
 
-namespace Result {
-	enum : u32 {
-		Success = 0,
-	};
-}
-
 void AMService::reset() {}
 
 void AMService::handleSyncRequest(u32 messagePointer) {

--- a/src/core/services/apt.cpp
+++ b/src/core/services/apt.cpp
@@ -25,12 +25,6 @@ namespace APTCommands {
 	};
 }
 
-namespace Result {
-	enum : u32 {
-		Success = 0,
-	};
-}
-
 // https://www.3dbrew.org/wiki/NS_and_APT_Services#Command
 namespace APTTransitions {
 	enum : u32 {
@@ -154,7 +148,7 @@ void APTService::inquireNotification(u32 messagePointer) {
 
 	mem.write32(messagePointer, IPC::responseHeader(0xB, 2, 0));
 	mem.write32(messagePointer + 4, Result::Success);
-	mem.write32(messagePointer + 8, static_cast<u32>(NotificationType::None)); 
+	mem.write32(messagePointer + 8, static_cast<u32>(NotificationType::None));
 }
 
 void APTService::getLockHandle(u32 messagePointer) {

--- a/src/core/services/boss.cpp
+++ b/src/core/services/boss.cpp
@@ -14,12 +14,6 @@ namespace BOSSCommands {
 	};
 }
 
-namespace Result {
-	enum : u32 {
-		Success = 0,
-	};
-}
-
 void BOSSService::reset() {
 	optoutFlag = 0;
 }

--- a/src/core/services/cam.cpp
+++ b/src/core/services/cam.cpp
@@ -8,12 +8,6 @@ namespace CAMCommands {
 	};
 }
 
-namespace Result {
-	enum : u32 {
-		Success = 0,
-	};
-}
-
 void CAMService::reset() {}
 
 void CAMService::handleSyncRequest(u32 messagePointer) {

--- a/src/core/services/cecd.cpp
+++ b/src/core/services/cecd.cpp
@@ -8,12 +8,6 @@ namespace CECDCommands {
 	};
 }
 
-namespace Result {
-	enum : u32 {
-		Success = 0,
-	};
-}
-
 void CECDService::reset() {
 	infoEvent = std::nullopt;
 }

--- a/src/core/services/cfg.cpp
+++ b/src/core/services/cfg.cpp
@@ -16,12 +16,6 @@ namespace CFGCommands {
 	};
 }
 
-namespace Result {
-	enum : u32 {
-		Success = 0,
-	};
-}
-
 void CFGService::reset() {}
 
 void CFGService::handleSyncRequest(u32 messagePointer) {
@@ -89,7 +83,7 @@ void CFGService::getConfigInfoBlk2(u32 messagePointer) {
 	} else if (size == 4 && blockID == 0xD0000) { // Agreed EULA version (first 2 bytes) and latest EULA version (next 2 bytes)
 		log("Read EULA info\n");
 		mem.write16(output, 0x0202); // Agreed EULA version = 2.2 (Random number. TODO: Check)
-		mem.write16(output + 2, 0x0202); // Latest EULA version = 2.2 
+		mem.write16(output + 2, 0x0202); // Latest EULA version = 2.2
 	} else if (size == 0x800 && blockID == 0xB0001) { // UTF-16 name for our country in every language at 0x80 byte intervals
 		constexpr size_t languageCount = 16;
 		constexpr size_t nameSize = 0x80; // Max size of each name in bytes
@@ -105,7 +99,7 @@ void CFGService::getConfigInfoBlk2(u32 messagePointer) {
 		std::u16string name = u"Pandington"; // Note: This + the null terminator needs to fit in 0x80 bytes
 
 		for (int i = 0; i < languageCount; i++) {
-			u32 pointer = output + i * nameSize; 
+			u32 pointer = output + i * nameSize;
 			writeStringU16(pointer, name);
 		}
 	} else if (size == 4 && blockID == 0xB0003) { // Coordinates (latidude and longtitude) as s16

--- a/src/core/services/dlp_srvr.cpp
+++ b/src/core/services/dlp_srvr.cpp
@@ -7,12 +7,6 @@ namespace DlpSrvrCommands {
 	};
 }
 
-namespace Result {
-	enum : u32 {
-		Success = 0,
-	};
-}
-
 void DlpSrvrService::reset() {}
 
 void DlpSrvrService::handleSyncRequest(u32 messagePointer) {

--- a/src/core/services/dsp.cpp
+++ b/src/core/services/dsp.cpp
@@ -25,7 +25,6 @@ namespace DSPCommands {
 
 namespace Result {
 	enum : u32 {
-		Success = 0,
 		HeadphonesNotInserted = 0,
 		HeadphonesInserted = 1
 	};
@@ -215,7 +214,7 @@ void DSPService::registerInterruptEvents(u32 messagePointer) {
 	const u32 channel = mem.read32(messagePointer + 8);
 	const u32 eventHandle = mem.read32(messagePointer + 16);
 	log("DSP::RegisterInterruptEvents (interrupt = %d, channel = %d, event = %d)\n", interrupt, channel, eventHandle);
-	
+
 	// The event handle being 0 means we're removing an event
 	if (eventHandle == 0) {
 		DSPEvent& e = getEventRef(interrupt, channel); // Get event

--- a/src/core/services/frd.cpp
+++ b/src/core/services/frd.cpp
@@ -17,12 +17,6 @@ namespace FRDCommands {
 	};
 }
 
-namespace Result {
-	enum : u32 {
-		Success = 0,
-	};
-}
-
 void FRDService::reset() {}
 
 void FRDService::handleSyncRequest(u32 messagePointer) {
@@ -91,7 +85,7 @@ void FRDService::getMyProfile(u32 messagePointer) {
 	mem.write32(messagePointer + 4, Result::Success);
 
 	// TODO: Should maybe make these user-configurable. Not super important though
-	mem.write8(messagePointer + 8, static_cast<u8>(Regions::USA));            // Region 
+	mem.write8(messagePointer + 8, static_cast<u8>(Regions::USA));            // Region
 	mem.write8(messagePointer + 9, static_cast<u8>(CountryCodes::US));        // Country
 	mem.write8(messagePointer + 10, 2);                                       // Area (this should be Washington)
 	mem.write8(messagePointer + 11, static_cast<u8>(LanguageCodes::English)); // Language

--- a/src/core/services/gsp_gpu.cpp
+++ b/src/core/services/gsp_gpu.cpp
@@ -30,13 +30,6 @@ namespace GXCommands {
 	};
 }
 
-namespace Result {
-	enum : u32 {
-		Success = 0,
-		SuccessRegisterIRQ = 0x2A07 // TODO: Is this a reference to the Ricoh 2A07 used in PAL NES systems?
-	};
-}
-
 void GPUService::reset() {
 	privilegedProcess = 0xFFFFFFFF; // Set the privileged process to an invalid handle
 	interruptEvent = std::nullopt;
@@ -100,7 +93,7 @@ void GPUService::registerInterruptRelayQueue(u32 messagePointer) {
 	}
 
 	mem.write32(messagePointer, IPC::responseHeader(0x13, 2, 2));
-	mem.write32(messagePointer + 4, Result::SuccessRegisterIRQ); // First init returns a unique result
+	mem.write32(messagePointer + 4, Result::GSP::SuccessRegisterIRQ); // First init returns a unique result
 	mem.write32(messagePointer + 8, 0); // TODO: GSP module thread index
 	mem.write32(messagePointer + 12, 0); // Translation descriptor
 	mem.write32(messagePointer + 16, KernelHandles::GSPSharedMemHandle);
@@ -120,7 +113,7 @@ void GPUService::requestInterrupt(GPUInterrupt type) {
 	u8& interruptCount = sharedMem[1];
 	u8 flagIndex = (index + interruptCount) % 0x34;
 	interruptCount++;
-	
+
 	sharedMem[2] = 0; // Set error code to 0
 	sharedMem[0xC + flagIndex] = static_cast<u8>(type); // Write interrupt type to queue
 
@@ -187,7 +180,7 @@ void GPUService::writeHwRegsWithMask(u32 messagePointer) {
 	u32 dataPointer = mem.read32(messagePointer + 16); // Data pointer
 	u32 maskPointer = mem.read32(messagePointer + 24); // Mask pointer
 
-	log("GSP::GPU::writeHwRegsWithMask (GPU address = %08X, size = %X, data address = %08X, mask address = %08X)\n", 
+	log("GSP::GPU::writeHwRegsWithMask (GPU address = %08X, size = %X, data address = %08X, mask address = %08X)\n",
 		ioAddr, size, dataPointer, maskPointer);
 
 	// Check for alignment
@@ -202,7 +195,7 @@ void GPUService::writeHwRegsWithMask(u32 messagePointer) {
 	if (ioAddr >= 0x420000) {
 		Helpers::panic("GSP::GPU::writeHwRegs offset too big");
 	}
-	
+
 	ioAddr += 0x1EB00000;
 	for (u32 i = 0; i < size; i += 4) {
 		const u32 current = gpu.readReg(ioAddr);
@@ -301,13 +294,13 @@ void GPUService::processCommandBuffer() {
 
 			commandsLeft--;
 		}
-	}	
+	}
 }
 
 // Fill 2 GPU framebuffers, buf0 and buf1, using a specific word value
 void GPUService::memoryFill(u32* cmd) {
 	u32 control = cmd[7];
-	
+
 	// buf0 parameters
 	u32 start0 = cmd[1]; // Start address for the fill. If 0, don't fill anything
 	u32 value0 = cmd[2]; // Value to fill the framebuffer with

--- a/src/core/services/gsp_lcd.cpp
+++ b/src/core/services/gsp_lcd.cpp
@@ -6,12 +6,6 @@ namespace LCDCommands {
 	};
 }
 
-namespace Result {
-	enum : u32 {
-		Success = 0,
-	};
-}
-
 void LCDService::reset() {}
 
 void LCDService::handleSyncRequest(u32 messagePointer) {

--- a/src/core/services/hid.cpp
+++ b/src/core/services/hid.cpp
@@ -13,13 +13,6 @@ namespace HIDCommands {
 	};
 }
 
-namespace Result {
-	enum : u32 {
-		Success = 0,
-		Failure = 0xFFFFFFFF
-	};
-}
-
 void HIDService::reset() {
 	sharedMem = nullptr;
 	accelerometerEnabled = false;
@@ -155,7 +148,7 @@ void HIDService::updateInputs(u64 currentTick) {
 		writeSharedMem<u16>(touchEntryOffset, touchScreenX);
 		writeSharedMem<u16>(touchEntryOffset + 2, touchScreenY);
 		writeSharedMem<u8>(touchEntryOffset + 4, touchScreenPressed ? 1 : 0);
-		
+
 		// Next, update accelerometer state
 		if (nextAccelerometerIndex == 0) {
 			writeSharedMem<u64>(0x110, readSharedMem<u64>(0x108)); // Copy previous tick count

--- a/src/core/services/ldr_ro.cpp
+++ b/src/core/services/ldr_ro.cpp
@@ -8,12 +8,6 @@ namespace LDRCommands {
 	};
 }
 
-namespace Result {
-	enum : u32 {
-		Success = 0,
-	};
-}
-
 void LDRService::reset() {}
 
 void LDRService::handleSyncRequest(u32 messagePointer) {

--- a/src/core/services/mic.cpp
+++ b/src/core/services/mic.cpp
@@ -13,12 +13,6 @@ namespace MICCommands {
 	};
 }
 
-namespace Result {
-	enum : u32 {
-		Success = 0,
-	};
-}
-
 void MICService::reset() {
 	micEnabled = false;
 	shouldClamp = false;

--- a/src/core/services/ndm.cpp
+++ b/src/core/services/ndm.cpp
@@ -11,12 +11,6 @@ namespace NDMCommands {
 	};
 }
 
-namespace Result {
-	enum : u32 {
-		Success = 0,
-	};
-}
-
 void NDMService::reset() {}
 
 void NDMService::handleSyncRequest(u32 messagePointer) {

--- a/src/core/services/nfc.cpp
+++ b/src/core/services/nfc.cpp
@@ -10,12 +10,6 @@ namespace NFCCommands {
 	};
 }
 
-namespace Result {
-	enum : u32 {
-		Success = 0,
-	};
-}
-
 void NFCService::reset() {
 	tagInRangeEvent = std::nullopt;
 	tagOutOfRangeEvent = std::nullopt;

--- a/src/core/services/nim.cpp
+++ b/src/core/services/nim.cpp
@@ -7,12 +7,6 @@ namespace NIMCommands {
 	};
 }
 
-namespace Result {
-	enum : u32 {
-		Success = 0,
-	};
-}
-
 void NIMService::reset() {}
 
 void NIMService::handleSyncRequest(u32 messagePointer) {

--- a/src/core/services/ptm.cpp
+++ b/src/core/services/ptm.cpp
@@ -3,15 +3,9 @@
 
 namespace PTMCommands {
 	enum : u32 {
-		GetStepHistory = 0x000B00C2, 
+		GetStepHistory = 0x000B00C2,
 		GetTotalStepCount = 0x000C0000,
 		ConfigureNew3DSCPU = 0x08180040
-	};
-}
-
-namespace Result {
-	enum : u32 {
-		Success = 0,
 	};
 }
 

--- a/src/core/services/service_manager.cpp
+++ b/src/core/services/service_manager.cpp
@@ -58,12 +58,6 @@ namespace Commands {
 	};
 }
 
-namespace Result {
-	enum : u32 {
-		Success = 0
-	};
-}
-
 // Handle an IPC message issued using the SendSyncRequest SVC
 // The parameters are stored in thread-local storage in this format: https://www.3dbrew.org/wiki/IPC#Message_Structure
 // messagePointer: The base pointer for the IPC message

--- a/src/core/services/y2r.cpp
+++ b/src/core/services/y2r.cpp
@@ -29,12 +29,6 @@ namespace Y2RCommands {
 	};
 }
 
-namespace Result {
-	enum : u32 {
-		Success = 0,
-	};
-}
-
 void Y2RService::reset() {
 	transferEndInterruptEnabled = false;
 	transferEndEvent = std::nullopt;


### PR DESCRIPTION
This should clean up all HLE errorcode in the codebase.

I didn't removed Rust::Result as this should be a cleanup for another iteration.