### PR TITLE
fix: fix build on Linux with gcc

### DIFF
--- a/include/helpers.hpp
+++ b/include/helpers.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <cstdarg>
 #include <climits>
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <iterator>


### PR DESCRIPTION
Tested on Fedora 38, helpers.hpp was missing an import.