### PR TITLE
Add PICA texel-format and topology types

### DIFF
--- a/include/PICA/gpu.hpp
+++ b/include/PICA/gpu.hpp
@@ -47,7 +47,7 @@ class GPU {
 	};
 
 	u64 getVertexShaderInputConfig() {
-		return u64(regs[PICAInternalRegs::VertexShaderInputCfgLow]) | (u64(regs[PICAInternalRegs::VertexShaderInputCfgHigh]) << 32);
+		return u64(regs[PICA::InternalRegs::VertexShaderInputCfgLow]) | (u64(regs[PICA::InternalRegs::VertexShaderInputCfgHigh]) << 32);
 	}
 
 	std::array<AttribInfo, maxAttribCount> attributeInfo; // Info for each of the 12 attributes

--- a/include/PICA/regs.hpp
+++ b/include/PICA/regs.hpp
@@ -128,3 +128,50 @@ namespace PICAInternalRegs {
 		VertexShaderOpDescriptorData7 = 0x2DD,
 	};
 }
+
+enum class PICAColorFmt : u32 {
+	RGBA8 = 0,
+	BGR8 = 1,
+	RGB5A1 = 2,
+	RGB565 = 3,
+	RGBA4 = 4,
+
+	// Technically selectable, but their function is unknown
+	Unknown5 = 5,
+	Unknown6 = 6,
+	Unknown7 = 7,
+};
+
+enum class PICADepthFmt : u32 {
+	Depth16 = 0,
+	Unknown1 = 1,  // Technically selectable, but function is unknown
+	Depth24 = 2,
+	Depth24Stencil8 = 3,
+};
+
+// Size occupied by each pixel in bytes
+
+// All formats are 16BPP except for RGBA8 (32BPP) and BGR8 (24BPP)
+inline constexpr usize sizePerPixel(PICAColorFmt format) {
+	switch (format) {
+		case PICAColorFmt::BGR8: return 3;
+		case PICAColorFmt::RGBA8: return 4;
+		default: return 2;
+	}
+}
+
+inline constexpr usize sizePerPixel(PICADepthFmt format) {
+	switch (format) {
+		case PICADepthFmt::Depth16: return 2;
+		case PICADepthFmt::Depth24: return 3;
+		case PICADepthFmt::Depth24Stencil8: return 4;
+		default: return 1;  // Invalid format
+	}
+}
+
+enum class PICAPrimType : u32 {
+	TriangleList = 0,
+	TriangleStrip = 1,
+	TriangleFan = 2,
+	GeometryPrimitive = 3,
+};

--- a/include/PICA/regs.hpp
+++ b/include/PICA/regs.hpp
@@ -131,16 +131,20 @@ namespace PICA {
 	}
 
 	enum class ColorFmt : u32 {
-		RGBA8 = 0,
-		BGR8 = 1,
-		RGB5A1 = 2,
-		RGB565 = 3,
-		RGBA4 = 4,
-
-		// Technically selectable, but their function is unknown
-		Unknown5 = 5,
-		Unknown6 = 6,
-		Unknown7 = 7,
+		RGBA8 = 0x0,
+		RGB8 = 0x1,
+		RGBA5551 = 0x2,
+		RGB565 = 0x3,
+		RGBA4 = 0x4,
+		IA8 = 0x5,
+		RG8 = 0x6,
+		I8 = 0x7,
+		A8 = 0x8,
+		IA4 = 0x9,
+		I4 = 0xA,
+		A4 = 0xB,
+		ETC1 = 0xC,
+		ETC1A4 = 0xD,
 	};
 
 	enum class DepthFmt : u32 {
@@ -150,6 +154,27 @@ namespace PICA {
 		Depth24Stencil8 = 3,
 	};
 
+	// Returns the string representation of a texture format
+	inline constexpr const char* textureFormatToString(ColorFmt fmt) {
+		switch (fmt) {
+			case ColorFmt::RGBA8: return "RGBA8";
+			case ColorFmt::RGB8: return "RGB8";
+			case ColorFmt::RGBA5551: return "RGBA5551";
+			case ColorFmt::RGB565: return "RGB565";
+			case ColorFmt::RGBA4: return "RGBA4";
+			case ColorFmt::IA8: return "IA8";
+			case ColorFmt::RG8: return "RG8";
+			case ColorFmt::I8: return "I8";
+			case ColorFmt::A8: return "A8";
+			case ColorFmt::IA4: return "IA4";
+			case ColorFmt::I4: return "I4";
+			case ColorFmt::A4: return "A4";
+			case ColorFmt::ETC1: return "ETC1";
+			case ColorFmt::ETC1A4: return "ETC1A4";
+			default: return "Unknown";
+		}
+	}
+
 	inline constexpr bool hasStencil(DepthFmt format) { return format == PICA::DepthFmt::Depth24Stencil8; }
 
 	// Size occupied by each pixel in bytes
@@ -157,7 +182,7 @@ namespace PICA {
 	// All formats are 16BPP except for RGBA8 (32BPP) and BGR8 (24BPP)
 	inline constexpr usize sizePerPixel(ColorFmt format) {
 		switch (format) {
-			case ColorFmt::BGR8: return 3;
+			case ColorFmt::RGB8: return 3;
 			case ColorFmt::RGBA8: return 4;
 			default: return 2;
 		}

--- a/include/PICA/regs.hpp
+++ b/include/PICA/regs.hpp
@@ -150,6 +150,8 @@ namespace PICA {
 		Depth24Stencil8 = 3,
 	};
 
+	inline constexpr bool hasStencil(DepthFmt format) { return format == PICA::DepthFmt::Depth24Stencil8; }
+
 	// Size occupied by each pixel in bytes
 
 	// All formats are 16BPP except for RGBA8 (32BPP) and BGR8 (24BPP)

--- a/include/PICA/regs.hpp
+++ b/include/PICA/regs.hpp
@@ -130,7 +130,7 @@ namespace PICA {
 		};
 	}
 
-	enum class ColorFmt : u32 {
+	enum class TextureFmt : u32 {
 		RGBA8 = 0x0,
 		RGB8 = 0x1,
 		RGBA5551 = 0x2,
@@ -147,6 +147,14 @@ namespace PICA {
 		ETC1A4 = 0xD,
 	};
 
+	enum class ColorFmt : u32 {
+		RGBA8 = 0x0,
+		RGB8 = 0x1,
+		RGBA5551 = 0x2,
+		RGB565 = 0x3,
+		RGBA4 = 0x4,
+	};
+
 	enum class DepthFmt : u32 {
 		Depth16 = 0,
 		Unknown1 = 1,  // Technically selectable, but function is unknown
@@ -155,24 +163,28 @@ namespace PICA {
 	};
 
 	// Returns the string representation of a texture format
-	inline constexpr const char* textureFormatToString(ColorFmt fmt) {
+	inline constexpr const char* textureFormatToString(TextureFmt fmt) {
 		switch (fmt) {
-			case ColorFmt::RGBA8: return "RGBA8";
-			case ColorFmt::RGB8: return "RGB8";
-			case ColorFmt::RGBA5551: return "RGBA5551";
-			case ColorFmt::RGB565: return "RGB565";
-			case ColorFmt::RGBA4: return "RGBA4";
-			case ColorFmt::IA8: return "IA8";
-			case ColorFmt::RG8: return "RG8";
-			case ColorFmt::I8: return "I8";
-			case ColorFmt::A8: return "A8";
-			case ColorFmt::IA4: return "IA4";
-			case ColorFmt::I4: return "I4";
-			case ColorFmt::A4: return "A4";
-			case ColorFmt::ETC1: return "ETC1";
-			case ColorFmt::ETC1A4: return "ETC1A4";
+			case TextureFmt::RGBA8: return "RGBA8";
+			case TextureFmt::RGB8: return "RGB8";
+			case TextureFmt::RGBA5551: return "RGBA5551";
+			case TextureFmt::RGB565: return "RGB565";
+			case TextureFmt::RGBA4: return "RGBA4";
+			case TextureFmt::IA8: return "IA8";
+			case TextureFmt::RG8: return "RG8";
+			case TextureFmt::I8: return "I8";
+			case TextureFmt::A8: return "A8";
+			case TextureFmt::IA4: return "IA4";
+			case TextureFmt::I4: return "I4";
+			case TextureFmt::A4: return "A4";
+			case TextureFmt::ETC1: return "ETC1";
+			case TextureFmt::ETC1A4: return "ETC1A4";
 			default: return "Unknown";
 		}
+	}
+
+	inline constexpr const char* textureFormatToString(ColorFmt fmt) {
+		return textureFormatToString(static_cast<TextureFmt>(fmt));
 	}
 
 	inline constexpr bool hasStencil(DepthFmt format) { return format == PICA::DepthFmt::Depth24Stencil8; }
@@ -180,12 +192,16 @@ namespace PICA {
 	// Size occupied by each pixel in bytes
 
 	// All formats are 16BPP except for RGBA8 (32BPP) and BGR8 (24BPP)
-	inline constexpr usize sizePerPixel(ColorFmt format) {
+	inline constexpr usize sizePerPixel(TextureFmt format) {
 		switch (format) {
-			case ColorFmt::RGB8: return 3;
-			case ColorFmt::RGBA8: return 4;
+			case TextureFmt::RGB8: return 3;
+			case TextureFmt::RGBA8: return 4;
 			default: return 2;
 		}
+	}
+
+	inline constexpr usize sizePerPixel(ColorFmt format) {
+		return sizePerPixel(static_cast<TextureFmt>(format));
 	}
 
 	inline constexpr usize sizePerPixel(DepthFmt format) {

--- a/include/PICA/regs.hpp
+++ b/include/PICA/regs.hpp
@@ -1,177 +1,180 @@
 #pragma once
 #include "helpers.hpp"
 
-namespace PICAInternalRegs {
-	enum : u32 {
-		// Rasterizer registers
-		ViewportWidth = 0x41,
-		ViewportInvw = 0x42,
-		ViewportHeight = 0x43,
-		ViewportInvh = 0x44,
+namespace PICA {
+	namespace InternalRegs {
+		enum : u32 {
+			// Rasterizer registers
+			ViewportWidth = 0x41,
+			ViewportInvw = 0x42,
+			ViewportHeight = 0x43,
+			ViewportInvh = 0x44,
 
-		DepthScale = 0x4D,
-		DepthOffset = 0x4E,
-		ShaderOutputCount = 0x4F,
+			DepthScale = 0x4D,
+			DepthOffset = 0x4E,
+			ShaderOutputCount = 0x4F,
 
-		DepthmapEnable = 0x6D,
-		TexUnitCfg = 0x80,
+			DepthmapEnable = 0x6D,
+			TexUnitCfg = 0x80,
 
-		// Framebuffer registers
-		ColourOperation = 0x100,
-		BlendFunc = 0x101,
-		BlendColour = 0x103,
-		AlphaTestConfig = 0x104,
-		DepthAndColorMask = 0x107,
-		DepthBufferFormat = 0x116,
-		ColourBufferFormat = 0x117,
-		DepthBufferLoc = 0x11C,
-		ColourBufferLoc = 0x11D,
-		FramebufferSize = 0x11E,
+			// Framebuffer registers
+			ColourOperation = 0x100,
+			BlendFunc = 0x101,
+			BlendColour = 0x103,
+			AlphaTestConfig = 0x104,
+			DepthAndColorMask = 0x107,
+			DepthBufferFormat = 0x116,
+			ColourBufferFormat = 0x117,
+			DepthBufferLoc = 0x11C,
+			ColourBufferLoc = 0x11D,
+			FramebufferSize = 0x11E,
 
-		// Geometry pipeline registers
-		VertexAttribLoc = 0x200,
-		AttribFormatLow = 0x201,
-		AttribFormatHigh = 0x202,
-		IndexBufferConfig = 0x227,
-		VertexCountReg = 0x228,
-		VertexOffsetReg = 0x22A,
-		SignalDrawArrays = 0x22E,
-		SignalDrawElements = 0x22F,
+			// Geometry pipeline registers
+			VertexAttribLoc = 0x200,
+			AttribFormatLow = 0x201,
+			AttribFormatHigh = 0x202,
+			IndexBufferConfig = 0x227,
+			VertexCountReg = 0x228,
+			VertexOffsetReg = 0x22A,
+			SignalDrawArrays = 0x22E,
+			SignalDrawElements = 0x22F,
 
-		Attrib0Offset = 0x203,
-		Attrib1Offset = 0x206,
-		Attrib2Offset = 0x209,
-		Attrib3Offset = 0x20C,
-		Attrib4Offset = 0x20F,
-		Attrib5Offset = 0x212,
-		Attrib6Offset = 0x215,
-		Attrib7Offset = 0x218,
-		Attrib8Offset = 0x21B,
-		Attrib9Offset = 0x21E,
-		Attrib10Offset = 0x221,
-		Attrib11Offset = 0x224,
+			Attrib0Offset = 0x203,
+			Attrib1Offset = 0x206,
+			Attrib2Offset = 0x209,
+			Attrib3Offset = 0x20C,
+			Attrib4Offset = 0x20F,
+			Attrib5Offset = 0x212,
+			Attrib6Offset = 0x215,
+			Attrib7Offset = 0x218,
+			Attrib8Offset = 0x21B,
+			Attrib9Offset = 0x21E,
+			Attrib10Offset = 0x221,
+			Attrib11Offset = 0x224,
 
-		Attrib0Config2 = 0x205,
-		Attrib1Config2 = 0x208,
-		Attrib2Config2 = 0x20B,
-		Attrib3Config2 = 0x20E,
-		Attrib4Config2 = 0x211,
-		Attrib5Config2 = 0x214,
-		Attrib6Config2 = 0x217,
-		Attrib7Config2 = 0x21A,
-		Attrib8Config2 = 0x21D,
-		Attrib9Config2 = 0x220,
-		Attrib10Config2 = 0x223,
-		Attrib11Config2 = 0x226,
+			Attrib0Config2 = 0x205,
+			Attrib1Config2 = 0x208,
+			Attrib2Config2 = 0x20B,
+			Attrib3Config2 = 0x20E,
+			Attrib4Config2 = 0x211,
+			Attrib5Config2 = 0x214,
+			Attrib6Config2 = 0x217,
+			Attrib7Config2 = 0x21A,
+			Attrib8Config2 = 0x21D,
+			Attrib9Config2 = 0x220,
+			Attrib10Config2 = 0x223,
+			Attrib11Config2 = 0x226,
 
-		AttribInfoStart = Attrib0Offset,
-		AttribInfoEnd = Attrib11Config2,
+			AttribInfoStart = Attrib0Offset,
+			AttribInfoEnd = Attrib11Config2,
 
-		// Fixed attribute registers
-		FixedAttribIndex = 0x232,
-		FixedAttribData0 = 0x233,
-		FixedAttribData1 = 0x234,
-		FixedAttribData2 = 0x235,
+			// Fixed attribute registers
+			FixedAttribIndex = 0x232,
+			FixedAttribData0 = 0x233,
+			FixedAttribData1 = 0x234,
+			FixedAttribData2 = 0x235,
 
-		// Command processor registers
-		CmdBufSize0 = 0x238,
-		CmdBufSize1 = 0x239,
-		CmdBufAddr0 = 0x23A,
-		CmdBufAddr1 = 0x23B,
-		CmdBufTrigger0 = 0x23C,
-		CmdBufTrigger1 = 0x23D,
+			// Command processor registers
+			CmdBufSize0 = 0x238,
+			CmdBufSize1 = 0x239,
+			CmdBufAddr0 = 0x23A,
+			CmdBufAddr1 = 0x23B,
+			CmdBufTrigger0 = 0x23C,
+			CmdBufTrigger1 = 0x23D,
 
-		PrimitiveConfig = 0x25E,
-		PrimitiveRestart = 0x25F,
+			PrimitiveConfig = 0x25E,
+			PrimitiveRestart = 0x25F,
 
-		// Vertex shader registers
-		VertexShaderAttrNum = 0x242,
-		VertexBoolUniform = 0x2B0,
-		VertexIntUniform0 = 0x2B1,
-		VertexIntUniform1 = 0x2B2,
-		VertexIntUniform2 = 0x2B3,
-		VertexIntUniform3 = 0x2B4,
+			// Vertex shader registers
+			VertexShaderAttrNum = 0x242,
+			VertexBoolUniform = 0x2B0,
+			VertexIntUniform0 = 0x2B1,
+			VertexIntUniform1 = 0x2B2,
+			VertexIntUniform2 = 0x2B3,
+			VertexIntUniform3 = 0x2B4,
 
-		VertexShaderEntrypoint = 0x2BA,
-		VertexShaderTransferEnd = 0x2BF,
-		VertexFloatUniformIndex = 0x2C0,
-		VertexFloatUniformData0 = 0x2C1,
-		VertexFloatUniformData1 = 0x2C2,
-		VertexFloatUniformData2 = 0x2C3,
-		VertexFloatUniformData3 = 0x2C4,
-		VertexFloatUniformData4 = 0x2C5,
-		VertexFloatUniformData5 = 0x2C6,
-		VertexFloatUniformData6 = 0x2C7,
-		VertexFloatUniformData7 = 0x2C8,
+			VertexShaderEntrypoint = 0x2BA,
+			VertexShaderTransferEnd = 0x2BF,
+			VertexFloatUniformIndex = 0x2C0,
+			VertexFloatUniformData0 = 0x2C1,
+			VertexFloatUniformData1 = 0x2C2,
+			VertexFloatUniformData2 = 0x2C3,
+			VertexFloatUniformData3 = 0x2C4,
+			VertexFloatUniformData4 = 0x2C5,
+			VertexFloatUniformData5 = 0x2C6,
+			VertexFloatUniformData6 = 0x2C7,
+			VertexFloatUniformData7 = 0x2C8,
 
-		VertexShaderInputBufferCfg = 0x2B9,
-		VertexShaderInputCfgLow = 0x2BB,
-		VertexShaderInputCfgHigh = 0x2BC,
+			VertexShaderInputBufferCfg = 0x2B9,
+			VertexShaderInputCfgLow = 0x2BB,
+			VertexShaderInputCfgHigh = 0x2BC,
 
-		VertexShaderTransferIndex = 0x2CB,
-		VertexShaderData0 = 0x2CC,
-		VertexShaderData1 = 0x2CD,
-		VertexShaderData2 = 0x2CE,
-		VertexShaderData3 = 0x2CF,
-		VertexShaderData4 = 0x2D0,
-		VertexShaderData5 = 0x2D1,
-		VertexShaderData6 = 0x2D2,
-		VertexShaderData7 = 0x2D3,
-		VertexShaderOpDescriptorIndex = 0x2D5,
-		VertexShaderOpDescriptorData0 = 0x2D6,
-		VertexShaderOpDescriptorData1 = 0x2D7,
-		VertexShaderOpDescriptorData2 = 0x2D8,
-		VertexShaderOpDescriptorData3 = 0x2D9,
-		VertexShaderOpDescriptorData4 = 0x2DA,
-		VertexShaderOpDescriptorData5 = 0x2DB,
-		VertexShaderOpDescriptorData6 = 0x2DC,
-		VertexShaderOpDescriptorData7 = 0x2DD,
+			VertexShaderTransferIndex = 0x2CB,
+			VertexShaderData0 = 0x2CC,
+			VertexShaderData1 = 0x2CD,
+			VertexShaderData2 = 0x2CE,
+			VertexShaderData3 = 0x2CF,
+			VertexShaderData4 = 0x2D0,
+			VertexShaderData5 = 0x2D1,
+			VertexShaderData6 = 0x2D2,
+			VertexShaderData7 = 0x2D3,
+			VertexShaderOpDescriptorIndex = 0x2D5,
+			VertexShaderOpDescriptorData0 = 0x2D6,
+			VertexShaderOpDescriptorData1 = 0x2D7,
+			VertexShaderOpDescriptorData2 = 0x2D8,
+			VertexShaderOpDescriptorData3 = 0x2D9,
+			VertexShaderOpDescriptorData4 = 0x2DA,
+			VertexShaderOpDescriptorData5 = 0x2DB,
+			VertexShaderOpDescriptorData6 = 0x2DC,
+			VertexShaderOpDescriptorData7 = 0x2DD,
+		};
+	}
+
+	enum class ColorFmt : u32 {
+		RGBA8 = 0,
+		BGR8 = 1,
+		RGB5A1 = 2,
+		RGB565 = 3,
+		RGBA4 = 4,
+
+		// Technically selectable, but their function is unknown
+		Unknown5 = 5,
+		Unknown6 = 6,
+		Unknown7 = 7,
 	};
-}
 
-enum class PICAColorFmt : u32 {
-	RGBA8 = 0,
-	BGR8 = 1,
-	RGB5A1 = 2,
-	RGB565 = 3,
-	RGBA4 = 4,
+	enum class DepthFmt : u32 {
+		Depth16 = 0,
+		Unknown1 = 1,  // Technically selectable, but function is unknown
+		Depth24 = 2,
+		Depth24Stencil8 = 3,
+	};
 
-	// Technically selectable, but their function is unknown
-	Unknown5 = 5,
-	Unknown6 = 6,
-	Unknown7 = 7,
-};
+	// Size occupied by each pixel in bytes
 
-enum class PICADepthFmt : u32 {
-	Depth16 = 0,
-	Unknown1 = 1,  // Technically selectable, but function is unknown
-	Depth24 = 2,
-	Depth24Stencil8 = 3,
-};
-
-// Size occupied by each pixel in bytes
-
-// All formats are 16BPP except for RGBA8 (32BPP) and BGR8 (24BPP)
-inline constexpr usize sizePerPixel(PICAColorFmt format) {
-	switch (format) {
-		case PICAColorFmt::BGR8: return 3;
-		case PICAColorFmt::RGBA8: return 4;
-		default: return 2;
+	// All formats are 16BPP except for RGBA8 (32BPP) and BGR8 (24BPP)
+	inline constexpr usize sizePerPixel(ColorFmt format) {
+		switch (format) {
+			case ColorFmt::BGR8: return 3;
+			case ColorFmt::RGBA8: return 4;
+			default: return 2;
+		}
 	}
-}
 
-inline constexpr usize sizePerPixel(PICADepthFmt format) {
-	switch (format) {
-		case PICADepthFmt::Depth16: return 2;
-		case PICADepthFmt::Depth24: return 3;
-		case PICADepthFmt::Depth24Stencil8: return 4;
-		default: return 1;  // Invalid format
+	inline constexpr usize sizePerPixel(DepthFmt format) {
+		switch (format) {
+			case DepthFmt::Depth16: return 2;
+			case DepthFmt::Depth24: return 3;
+			case DepthFmt::Depth24Stencil8: return 4;
+			default: return 1;  // Invalid format
+		}
 	}
-}
 
-enum class PICAPrimType : u32 {
-	TriangleList = 0,
-	TriangleStrip = 1,
-	TriangleFan = 2,
-	GeometryPrimitive = 3,
-};
+	enum class PrimType : u32 {
+		TriangleList = 0,
+		TriangleStrip = 1,
+		TriangleFan = 2,
+		GeometryPrimitive = 3,
+	};
+
+}  // namespace PICA

--- a/include/renderer_gl/renderer_gl.hpp
+++ b/include/renderer_gl/renderer_gl.hpp
@@ -47,11 +47,11 @@ class Renderer {
 	OpenGL::uvec2 fbSize;  // The size of the framebuffer (ie both the colour and depth buffer)'
 
 	u32 colourBufferLoc;                       // Location in 3DS VRAM for the colour buffer
-	PICAColorFmt colourBufferFormat;  // Format of the colours stored in the colour buffer
+	PICA::ColorFmt colourBufferFormat;  // Format of the colours stored in the colour buffer
 
 	// Same for the depth/stencil buffer
 	u32 depthBufferLoc;
-	PICADepthFmt depthBufferFormat;
+	PICA::DepthFmt depthBufferFormat;
 
 	// Dummy VAO/VBO for blitting the final output
 	OpenGL::VertexArray dummyVAO;
@@ -76,16 +76,16 @@ class Renderer {
 	void getGraphicsContext();                                                                      // Set up graphics context for rendering
 	void clearBuffer(u32 startAddress, u32 endAddress, u32 value, u32 control);                     // Clear a GPU buffer in VRAM
 	void displayTransfer(u32 inputAddr, u32 outputAddr, u32 inputSize, u32 outputSize, u32 flags);  // Perform display transfer
-	void drawVertices(PICAPrimType primType, std::span<const Vertex> vertices);               // Draw the given vertices
+	void drawVertices(PICA::PrimType primType, std::span<const Vertex> vertices);               // Draw the given vertices
 
 	void setFBSize(u32 width, u32 height) {
 		fbSize.x() = width;
 		fbSize.y() = height;
 	}
 
-	void setColourFormat(PICAColorFmt format) { colourBufferFormat = format; }
-	void setDepthFormat(PICADepthFmt format) {
-		if (format == PICADepthFmt::Unknown1) {
+	void setColourFormat(PICA::ColorFmt format) { colourBufferFormat = format; }
+	void setDepthFormat(PICA::DepthFmt format) {
+		if (format == PICA::DepthFmt::Unknown1) {
 			Helpers::panic("[PICA] Undocumented depth-stencil mode!");
 		}
 		depthBufferFormat = format;

--- a/include/renderer_gl/renderer_gl.hpp
+++ b/include/renderer_gl/renderer_gl.hpp
@@ -46,7 +46,7 @@ class Renderer {
 
 	OpenGL::uvec2 fbSize;  // The size of the framebuffer (ie both the colour and depth buffer)'
 
-	u32 colourBufferLoc;                       // Location in 3DS VRAM for the colour buffer
+	u32 colourBufferLoc;                 // Location in 3DS VRAM for the colour buffer
 	PICA::ColorFmt colourBufferFormat;  // Format of the colours stored in the colour buffer
 
 	// Same for the depth/stencil buffer

--- a/include/renderer_gl/renderer_gl.hpp
+++ b/include/renderer_gl/renderer_gl.hpp
@@ -7,6 +7,7 @@
 #include "opengl.hpp"
 #include "surface_cache.hpp"
 #include "textures.hpp"
+#include "PICA/regs.hpp"
 
 // More circular dependencies!
 class GPU;
@@ -46,11 +47,11 @@ class Renderer {
 	OpenGL::uvec2 fbSize;  // The size of the framebuffer (ie both the colour and depth buffer)'
 
 	u32 colourBufferLoc;                       // Location in 3DS VRAM for the colour buffer
-	ColourBuffer::Formats colourBufferFormat;  // Format of the colours stored in the colour buffer
+	PICAColorFmt colourBufferFormat;  // Format of the colours stored in the colour buffer
 
 	// Same for the depth/stencil buffer
 	u32 depthBufferLoc;
-	DepthBuffer::Formats depthBufferFormat;
+	PICADepthFmt depthBufferFormat;
 
 	// Dummy VAO/VBO for blitting the final output
 	OpenGL::VertexArray dummyVAO;
@@ -75,23 +76,19 @@ class Renderer {
 	void getGraphicsContext();                                                                      // Set up graphics context for rendering
 	void clearBuffer(u32 startAddress, u32 endAddress, u32 value, u32 control);                     // Clear a GPU buffer in VRAM
 	void displayTransfer(u32 inputAddr, u32 outputAddr, u32 inputSize, u32 outputSize, u32 flags);  // Perform display transfer
-	void drawVertices(OpenGL::Primitives primType, std::span<const Vertex> vertices);               // Draw the given vertices
+	void drawVertices(PICAPrimType primType, std::span<const Vertex> vertices);               // Draw the given vertices
 
 	void setFBSize(u32 width, u32 height) {
 		fbSize.x() = width;
 		fbSize.y() = height;
 	}
 
-	void setColourFormat(ColourBuffer::Formats format) { colourBufferFormat = format; }
-	void setColourFormat(u32 format) { colourBufferFormat = static_cast<ColourBuffer::Formats>(format); }
-
-	void setDepthFormat(DepthBuffer::Formats format) { depthBufferFormat = format; }
-	void setDepthFormat(u32 format) {
-		if (format == 1) {
+	void setColourFormat(PICAColorFmt format) { colourBufferFormat = format; }
+	void setDepthFormat(PICADepthFmt format) {
+		if (format == PICADepthFmt::Unknown1) {
 			Helpers::panic("[PICA] Undocumented depth-stencil mode!");
 		}
-
-		depthBufferFormat = static_cast<DepthBuffer::Formats>(format);
+		depthBufferFormat = format;
 	}
 
 	void setColourBufferLoc(u32 loc) { colourBufferLoc = loc; }

--- a/include/renderer_gl/surfaces.hpp
+++ b/include/renderer_gl/surfaces.hpp
@@ -95,10 +95,6 @@ struct DepthBuffer {
         range = Interval<u32>(loc, (u32)endLoc);
     }
 
-    bool hasStencil() {
-        return format == PICA::DepthFmt::Depth24Stencil8;
-    }
-
     void allocate() {
         // Create texture for the FBO, setting up filters and the like
         // Reading back the current texture is slow, but allocate calls should be few and far between.

--- a/include/renderer_gl/surfaces.hpp
+++ b/include/renderer_gl/surfaces.hpp
@@ -9,7 +9,7 @@ using Interval = boost::icl::right_open_interval<T>;
 
 struct ColourBuffer {
     u32 location;
-    PICAColorFmt format;
+    PICA::ColorFmt format;
     OpenGL::uvec2 size;
     bool valid;
 
@@ -21,7 +21,7 @@ struct ColourBuffer {
 
     ColourBuffer() : valid(false) {}
 
-    ColourBuffer(u32 loc, PICAColorFmt format, u32 x, u32 y, bool valid = true)
+    ColourBuffer(u32 loc, PICA::ColorFmt format, u32 x, u32 y, bool valid = true)
         : location(loc), format(format), size({x, y}), valid(valid) {
 
         u64 endLoc = (u64)loc + sizeInBytes();
@@ -70,13 +70,13 @@ struct ColourBuffer {
     }
 
     size_t sizeInBytes() {
-        return (size_t)size.x() * (size_t)size.y() * sizePerPixel(format);
+        return (size_t)size.x() * (size_t)size.y() * PICA::sizePerPixel(format);
     }
 };
 
 struct DepthBuffer {
     u32 location;
-    PICADepthFmt format;
+    PICA::DepthFmt format;
     OpenGL::uvec2 size; // Implicitly set to the size of the framebuffer
     bool valid;
 
@@ -87,7 +87,7 @@ struct DepthBuffer {
 
     DepthBuffer() : valid(false) {}
 
-    DepthBuffer(u32 loc, PICADepthFmt format, u32 x, u32 y, bool valid = true) :
+    DepthBuffer(u32 loc, PICA::DepthFmt format, u32 x, u32 y, bool valid = true) :
         location(loc), format(format), size({x, y}), valid(valid) {
 
         u64 endLoc = (u64)loc + sizeInBytes();
@@ -96,7 +96,7 @@ struct DepthBuffer {
     }
 
     bool hasStencil() {
-        return format == PICADepthFmt::Depth24Stencil8;
+        return format == PICA::DepthFmt::Depth24Stencil8;
     }
 
     void allocate() {
@@ -142,6 +142,6 @@ struct DepthBuffer {
     }
 
     size_t sizeInBytes() {
-        return (size_t)size.x() * (size_t)size.y() * sizePerPixel(format);
+        return (size_t)size.x() * (size_t)size.y() * PICA::sizePerPixel(format);
     }
 };

--- a/include/renderer_gl/textures.hpp
+++ b/include/renderer_gl/textures.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <array>
 #include <string>
+#include "PICA/regs.hpp"
 #include "boost/icl/interval.hpp"
 #include "helpers.hpp"
 #include "opengl.hpp"
@@ -9,28 +10,9 @@ template <typename T>
 using Interval = boost::icl::right_open_interval<T>;
 
 struct Texture {
-    enum class Formats : u32 {
-        RGBA8 = 0,
-        RGB8 = 1,
-        RGBA5551 = 2,
-        RGB565 = 3,
-        RGBA4 = 4,
-        IA8 = 5,
-        RG8 = 6,
-        I8 = 7,
-        A8 = 8,
-        IA4 = 9,
-        I4 = 10,
-        A4 = 11,
-        ETC1 = 12,
-        ETC1A4 = 13,
-
-        Trash1 = 14, Trash2 = 15 // TODO: What are these?
-    };
-
     u32 location;
     u32 config; // Magnification/minification filter, wrapping configs, etc
-    Formats format;
+    PICA::ColorFmt format;
     OpenGL::uvec2 size;
     bool valid;
 
@@ -41,7 +23,7 @@ struct Texture {
 
     Texture() : valid(false) {}
 
-    Texture(u32 loc, Formats format, u32 x, u32 y, u32 config, bool valid = true)
+    Texture(u32 loc, PICA::ColorFmt format, u32 x, u32 y, u32 config, bool valid = true)
         : location(loc), format(format), size({x, y}), config(config), valid(valid) {
 
         u64 endLoc = (u64)loc + sizeInBytes();
@@ -62,7 +44,7 @@ struct Texture {
     void free();
     u64 sizeInBytes();
 
-    u32 decodeTexel(u32 u, u32 v, Formats fmt, const void* data);
+    u32 decodeTexel(u32 u, u32 v, PICA::ColorFmt fmt, const void* data);
 
     // Get the morton interleave offset of a texel based on its U and V values
     static u32 mortonInterleave(u32 u, u32 v);
@@ -70,12 +52,9 @@ struct Texture {
     static u32 getSwizzledOffset(u32 u, u32 v, u32 width, u32 bytesPerPixel);
     static u32 getSwizzledOffset_4bpp(u32 u, u32 v, u32 width);
 
-    // Returns the string representation of a texture format
-    static std::string textureFormatToString(Formats fmt);
-
     // Returns the format of this texture as a string
     std::string formatToString() {
-        return textureFormatToString(format);
+        return PICA::textureFormatToString(format);
     }
 
     // Returns the texel at coordinates (u, v) of an ETC1(A4) texture

--- a/include/renderer_gl/textures.hpp
+++ b/include/renderer_gl/textures.hpp
@@ -12,7 +12,7 @@ using Interval = boost::icl::right_open_interval<T>;
 struct Texture {
     u32 location;
     u32 config; // Magnification/minification filter, wrapping configs, etc
-    PICA::ColorFmt format;
+    PICA::TextureFmt format;
     OpenGL::uvec2 size;
     bool valid;
 
@@ -23,7 +23,7 @@ struct Texture {
 
     Texture() : valid(false) {}
 
-    Texture(u32 loc, PICA::ColorFmt format, u32 x, u32 y, u32 config, bool valid = true)
+    Texture(u32 loc, PICA::TextureFmt format, u32 x, u32 y, u32 config, bool valid = true)
         : location(loc), format(format), size({x, y}), config(config), valid(valid) {
 
         u64 endLoc = (u64)loc + sizeInBytes();
@@ -44,7 +44,7 @@ struct Texture {
     void free();
     u64 sizeInBytes();
 
-    u32 decodeTexel(u32 u, u32 v, PICA::ColorFmt fmt, const void* data);
+    u32 decodeTexel(u32 u, u32 v, PICA::TextureFmt fmt, const void* data);
 
     // Get the morton interleave offset of a texel based on its U and V values
     static u32 mortonInterleave(u32 u, u32 v);

--- a/src/core/PICA/gpu.cpp
+++ b/src/core/PICA/gpu.cpp
@@ -50,45 +50,45 @@ template <bool indexed>
 void GPU::drawArrays() {
 	// Base address for vertex attributes
 	// The vertex base is always on a quadword boundary because the PICA does weird alignment shit any time possible
-	const u32 vertexBase = ((regs[PICAInternalRegs::VertexAttribLoc] >> 1) & 0xfffffff) * 16;
-	const u32 vertexCount = regs[PICAInternalRegs::VertexCountReg]; // Total # of vertices to transfer
+	const u32 vertexBase = ((regs[PICA::InternalRegs::VertexAttribLoc] >> 1) & 0xfffffff) * 16;
+	const u32 vertexCount = regs[PICA::InternalRegs::VertexCountReg]; // Total # of vertices to transfer
 
 	// Configures the type of primitive and the number of vertex shader outputs
-	const u32 primConfig = regs[PICAInternalRegs::PrimitiveConfig];
-	const PICAPrimType primType = static_cast<PICAPrimType>(Helpers::getBits<8, 2>(primConfig));
-	if (primType == PICAPrimType::TriangleFan) Helpers::panic("[PICA] Tried to draw unimplemented shape %d\n", primType);
+	const u32 primConfig = regs[PICA::InternalRegs::PrimitiveConfig];
+	const PICA::PrimType primType = static_cast<PICA::PrimType>(Helpers::getBits<8, 2>(primConfig));
+	if (primType == PICA::PrimType::TriangleFan) Helpers::panic("[PICA] Tried to draw unimplemented shape %d\n", primType);
 	if (vertexCount > Renderer::vertexBufferSize) Helpers::panic("[PICA] vertexCount > vertexBufferSize");
 
-	if ((primType == PICAPrimType::TriangleList && vertexCount % 3) ||
-		(primType == PICAPrimType::TriangleStrip && vertexCount < 3)) {
+	if ((primType == PICA::PrimType::TriangleList && vertexCount % 3) ||
+		(primType == PICA::PrimType::TriangleStrip && vertexCount < 3)) {
 		Helpers::panic("Invalid vertex count for primitive. Type: %d, vert count: %d\n", primType, vertexCount);
 	}
 
 	// Get the configuration for the index buffer, used only for indexed drawing
-	u32 indexBufferConfig = regs[PICAInternalRegs::IndexBufferConfig];
+	u32 indexBufferConfig = regs[PICA::InternalRegs::IndexBufferConfig];
 	u32 indexBufferPointer = vertexBase + (indexBufferConfig & 0xfffffff);
 	bool shortIndex = Helpers::getBit<31>(indexBufferConfig); // Indicates whether vert indices are 16-bit or 8-bit
 
 	// Stuff the global attribute config registers in one u64 to make attr parsing easier
 	// TODO: Cache this when the vertex attribute format registers are written to 
-	u64 vertexCfg = u64(regs[PICAInternalRegs::AttribFormatLow]) | (u64(regs[PICAInternalRegs::AttribFormatHigh]) << 32);
+	u64 vertexCfg = u64(regs[PICA::InternalRegs::AttribFormatLow]) | (u64(regs[PICA::InternalRegs::AttribFormatHigh]) << 32);
 
 	if constexpr (!indexed) {
-		u32 offset = regs[PICAInternalRegs::VertexOffsetReg];
+		u32 offset = regs[PICA::InternalRegs::VertexOffsetReg];
 		log("PICA::DrawArrays(vertex count = %d, vertexOffset = %d)\n", vertexCount, offset);
 	} else {
 		log("PICA::DrawElements(vertex count = %d, index buffer config = %08X)\n", vertexCount, indexBufferConfig);
 	}
 
 	// Total number of input attributes to shader. Differs between GS and VS. Currently stubbed to the VS one, as we don't have geometry shaders.
-	const u32 inputAttrCount = (regs[PICAInternalRegs::VertexShaderInputBufferCfg] & 0xf) + 1;
+	const u32 inputAttrCount = (regs[PICA::InternalRegs::VertexShaderInputBufferCfg] & 0xf) + 1;
 	const u64 inputAttrCfg = getVertexShaderInputConfig();
 		
 	for (u32 i = 0; i < vertexCount; i++) {
 		u32 vertexIndex; // Index of the vertex in the VBO
 
 		if constexpr (!indexed) {
-			vertexIndex = i + regs[PICAInternalRegs::VertexOffsetReg];
+			vertexIndex = i + regs[PICA::InternalRegs::VertexOffsetReg];
 		} else {
 			if (shortIndex) {
 				auto ptr = getPointerPhys<u16>(indexBufferPointer);
@@ -209,7 +209,7 @@ void GPU::drawArrays() {
 
 Vertex GPU::getImmediateModeVertex() {
 	Vertex v;
-	const int totalAttrCount = (regs[PICAInternalRegs::VertexShaderAttrNum] & 0xf) + 1;
+	const int totalAttrCount = (regs[PICA::InternalRegs::VertexShaderAttrNum] & 0xf) + 1;
 
 	// Copy immediate mode attributes to vertex shader unit
 	for (int i = 0; i < totalAttrCount; i++) {

--- a/src/core/PICA/regs.cpp
+++ b/src/core/PICA/regs.cpp
@@ -33,7 +33,7 @@ u32 GPU::readInternalReg(u32 index) {
 }
 
 void GPU::writeInternalReg(u32 index, u32 value, u32 mask) {
-	using namespace PICAInternalRegs;
+	using namespace PICA::InternalRegs;
 
 	if (index > regNum) {
 		Helpers::panic("Tried to write to invalid GPU register. Index: %X, value: %08X\n", index, value);
@@ -68,7 +68,7 @@ void GPU::writeInternalReg(u32 index, u32 value, u32 mask) {
 
 		case ColourBufferFormat: {
 			u32 format = getBits<16, 3>(value);
-			renderer.setColourFormat(static_cast<PICAColorFmt>(format));
+			renderer.setColourFormat(static_cast<PICA::ColorFmt>(format));
 			break;
 		}
 
@@ -80,7 +80,7 @@ void GPU::writeInternalReg(u32 index, u32 value, u32 mask) {
 
 		case DepthBufferFormat: {
 			u32 format = value & 0x3;
-			renderer.setDepthFormat(static_cast<PICADepthFmt>(format));
+			renderer.setDepthFormat(static_cast<PICA::DepthFmt>(format));
 			break;
 		}
 
@@ -137,7 +137,7 @@ void GPU::writeInternalReg(u32 index, u32 value, u32 mask) {
 				if (fixedAttribIndex < 12) [[likely]] {
 					shaderUnit.vs.fixedAttributes[fixedAttribIndex++] = attr;
 				} else if (fixedAttribIndex == 15) { // Otherwise if it's 15, we're submitting an immediate mode vertex
-					const uint totalAttrCount = (regs[PICAInternalRegs::VertexShaderAttrNum] & 0xf) + 1;
+					const uint totalAttrCount = (regs[PICA::InternalRegs::VertexShaderAttrNum] & 0xf) + 1;
 					if (totalAttrCount <= immediateModeAttrIndex) {
 						printf("Broken state in the immediate mode vertex submission pipeline. Failing silently\n");
 						immediateModeAttrIndex = 0;
@@ -151,13 +151,13 @@ void GPU::writeInternalReg(u32 index, u32 value, u32 mask) {
 						immediateModeVertices[immediateModeVertIndex++] = v;
 
 						// Get primitive type
-						const u32 primConfig = regs[PICAInternalRegs::PrimitiveConfig];
+						const u32 primConfig = regs[PICA::InternalRegs::PrimitiveConfig];
 						const u32 primType = getBits<8, 2>(primConfig);
 
 						// If we've reached 3 verts, issue a draw call
 						// Handle rendering depending on the primitive type
 						if (immediateModeVertIndex == 3) {
-							renderer.drawVertices(PICAPrimType::TriangleList, immediateModeVertices);
+							renderer.drawVertices(PICA::PrimType::TriangleList, immediateModeVertices);
 
 							switch (primType) {
 								// Triangle or geometry primitive. Draw a triangle and discard all vertices

--- a/src/core/PICA/regs.cpp
+++ b/src/core/PICA/regs.cpp
@@ -68,7 +68,7 @@ void GPU::writeInternalReg(u32 index, u32 value, u32 mask) {
 
 		case ColourBufferFormat: {
 			u32 format = getBits<16, 3>(value);
-			renderer.setColourFormat(format);
+			renderer.setColourFormat(static_cast<PICAColorFmt>(format));
 			break;
 		}
 
@@ -79,8 +79,8 @@ void GPU::writeInternalReg(u32 index, u32 value, u32 mask) {
 		}
 
 		case DepthBufferFormat: {
-			u32 fmt = value & 0x3;
-			renderer.setDepthFormat(fmt);
+			u32 format = value & 0x3;
+			renderer.setDepthFormat(static_cast<PICADepthFmt>(format));
 			break;
 		}
 
@@ -157,7 +157,7 @@ void GPU::writeInternalReg(u32 index, u32 value, u32 mask) {
 						// If we've reached 3 verts, issue a draw call
 						// Handle rendering depending on the primitive type
 						if (immediateModeVertIndex == 3) {
-							renderer.drawVertices(OpenGL::Triangle, immediateModeVertices);
+							renderer.drawVertices(PICAPrimType::TriangleList, immediateModeVertices);
 
 							switch (primType) {
 								// Triangle or geometry primitive. Draw a triangle and discard all vertices

--- a/src/core/renderer_gl/renderer_gl.cpp
+++ b/src/core/renderer_gl/renderer_gl.cpp
@@ -322,7 +322,7 @@ void Renderer::drawVertices(PICA::PrimType primType, std::span<const Vertex> ver
 		const u32 addr = (regs[0x85] & 0x0FFFFFFF) << 3;
 		const u32 format = regs[0x8E] & 0xF;
 
-		Texture targetTex(addr, static_cast<Texture::Formats>(format), width, height, config);
+		Texture targetTex(addr, static_cast<PICA::ColorFmt>(format), width, height, config);
 		OpenGL::Texture tex = getTexture(targetTex);
 		tex.bind();
 	}

--- a/src/core/renderer_gl/renderer_gl.cpp
+++ b/src/core/renderer_gl/renderer_gl.cpp
@@ -322,7 +322,7 @@ void Renderer::drawVertices(PICA::PrimType primType, std::span<const Vertex> ver
 		const u32 addr = (regs[0x85] & 0x0FFFFFFF) << 3;
 		const u32 format = regs[0x8E] & 0xF;
 
-		Texture targetTex(addr, static_cast<PICA::ColorFmt>(format), width, height, config);
+		Texture targetTex(addr, static_cast<PICA::TextureFmt>(format), width, height, config);
 		OpenGL::Texture tex = getTexture(targetTex);
 		tex.bind();
 	}

--- a/src/core/renderer_gl/textures.cpp
+++ b/src/core/renderer_gl/textures.cpp
@@ -43,34 +43,34 @@ u64 Texture::sizeInBytes() {
     u64 pixelCount = u64(size.x()) * u64(size.y());
 
     switch (format) {
-        case PICA::ColorFmt::RGBA8: // 4 bytes per pixel
+        case PICA::TextureFmt::RGBA8: // 4 bytes per pixel
             return pixelCount * 4;
 
-        case PICA::ColorFmt::RGB8: // 3 bytes per pixel
+        case PICA::TextureFmt::RGB8: // 3 bytes per pixel
             return pixelCount * 3;
 
-        case PICA::ColorFmt::RGBA5551: // 2 bytes per pixel
-        case PICA::ColorFmt::RGB565:
-        case PICA::ColorFmt::RGBA4:
-        case PICA::ColorFmt::RG8:
-        case PICA::ColorFmt::IA8:
+        case PICA::TextureFmt::RGBA5551: // 2 bytes per pixel
+        case PICA::TextureFmt::RGB565:
+        case PICA::TextureFmt::RGBA4:
+        case PICA::TextureFmt::RG8:
+        case PICA::TextureFmt::IA8:
             return pixelCount * 2;
 
-        case PICA::ColorFmt::A8: // 1 byte per pixel
-        case PICA::ColorFmt::I8:
-        case PICA::ColorFmt::IA4:
+        case PICA::TextureFmt::A8: // 1 byte per pixel
+        case PICA::TextureFmt::I8:
+        case PICA::TextureFmt::IA4:
             return pixelCount;
 
-        case PICA::ColorFmt::I4: // 4 bits per pixel
-        case PICA::ColorFmt::A4:
+        case PICA::TextureFmt::I4: // 4 bits per pixel
+        case PICA::TextureFmt::A4:
             return pixelCount / 2;
 
-        case PICA::ColorFmt::ETC1: // Compressed formats
-        case PICA::ColorFmt::ETC1A4: {
+        case PICA::TextureFmt::ETC1: // Compressed formats
+        case PICA::TextureFmt::ETC1A4: {
             // Number of 4x4 tiles
             const u64 tileCount = pixelCount / 16;
             // Tiles are 8 bytes each on ETC1 and 16 bytes each on ETC1A4
-            const u64 tileSize = format == PICA::ColorFmt::ETC1 ? 8 : 16;
+            const u64 tileSize = format == PICA::TextureFmt::ETC1 ? 8 : 16;
             return tileCount * tileSize;
         }
 
@@ -111,9 +111,9 @@ u32 Texture::getSwizzledOffset_4bpp(u32 u, u32 v, u32 width) {
 // Get the texel at position (u, v)
 // fmt: format of the texture
 // data: texture data of the texture
-u32 Texture::decodeTexel(u32 u, u32 v, PICA::ColorFmt fmt, const void* data) {
+u32 Texture::decodeTexel(u32 u, u32 v, PICA::TextureFmt fmt, const void* data) {
     switch (fmt) {
-        case PICA::ColorFmt::RGBA4: {
+        case PICA::TextureFmt::RGBA4: {
             u32 offset = getSwizzledOffset(u, v, size.u(), 2);
             auto ptr = static_cast<const u8*>(data);
             u16 texel = u16(ptr[offset]) | (u16(ptr[offset + 1]) << 8);
@@ -126,7 +126,7 @@ u32 Texture::decodeTexel(u32 u, u32 v, PICA::ColorFmt fmt, const void* data) {
             return (alpha << 24) | (b << 16) | (g << 8) | r;
         }
 
-        case PICA::ColorFmt::RGBA5551: {
+        case PICA::TextureFmt::RGBA5551: {
             u32 offset = getSwizzledOffset(u, v, size.u(), 2);
             auto ptr = static_cast<const u8*>(data);
             u16 texel = u16(ptr[offset]) | (u16(ptr[offset + 1]) << 8);
@@ -139,7 +139,7 @@ u32 Texture::decodeTexel(u32 u, u32 v, PICA::ColorFmt fmt, const void* data) {
             return (alpha << 24) | (b << 16) | (g << 8) | r;
         }
 
-        case PICA::ColorFmt::RGB565: {
+        case PICA::TextureFmt::RGB565: {
             u32 offset = getSwizzledOffset(u, v, size.u(), 2);
             auto ptr = static_cast<const u8*>(data);
             u16 texel = u16(ptr[offset]) | (u16(ptr[offset + 1]) << 8);
@@ -151,7 +151,7 @@ u32 Texture::decodeTexel(u32 u, u32 v, PICA::ColorFmt fmt, const void* data) {
             return (0xff << 24) | (b << 16) | (g << 8) | r;
         }
 
-        case PICA::ColorFmt::RG8: {
+        case PICA::TextureFmt::RG8: {
             u32 offset = getSwizzledOffset(u, v, size.u(), 2);
             auto ptr = static_cast<const u8*>(data);
 
@@ -162,7 +162,7 @@ u32 Texture::decodeTexel(u32 u, u32 v, PICA::ColorFmt fmt, const void* data) {
             return (0xff << 24) | (b << 16) | (g << 8) | r;
         }
 
-        case PICA::ColorFmt::RGB8: {
+        case PICA::TextureFmt::RGB8: {
             u32 offset = getSwizzledOffset(u, v, size.u(), 3);
             auto ptr = static_cast<const u8*>(data);
 
@@ -173,7 +173,7 @@ u32 Texture::decodeTexel(u32 u, u32 v, PICA::ColorFmt fmt, const void* data) {
             return (0xff << 24) | (b << 16) | (g << 8) | r;
         }
 
-        case PICA::ColorFmt::RGBA8: {
+        case PICA::TextureFmt::RGBA8: {
             u32 offset = getSwizzledOffset(u, v, size.u(), 4);
             auto ptr = static_cast<const u8*>(data);
 
@@ -185,7 +185,7 @@ u32 Texture::decodeTexel(u32 u, u32 v, PICA::ColorFmt fmt, const void* data) {
             return (alpha << 24) | (b << 16) | (g << 8) | r;
         }
 
-        case PICA::ColorFmt::IA4: {
+        case PICA::TextureFmt::IA4: {
             u32 offset = getSwizzledOffset(u, v, size.u(), 1);
             auto ptr = static_cast<const u8*>(data);
 
@@ -197,7 +197,7 @@ u32 Texture::decodeTexel(u32 u, u32 v, PICA::ColorFmt fmt, const void* data) {
             return (alpha << 24) | (intensity << 16) | (intensity << 8) | intensity;
         }
 
-        case PICA::ColorFmt::A4: {
+        case PICA::TextureFmt::A4: {
             u32 offset = getSwizzledOffset_4bpp(u, v, size.u());
             auto ptr = static_cast<const u8*>(data);
 
@@ -209,7 +209,7 @@ u32 Texture::decodeTexel(u32 u, u32 v, PICA::ColorFmt fmt, const void* data) {
             return (alpha << 24) | (0 << 16) | (0 << 8) | 0;
         }
 
-        case PICA::ColorFmt::A8: {
+        case PICA::TextureFmt::A8: {
             u32 offset = getSwizzledOffset(u, v, size.u(), 1);
             auto ptr = static_cast<const u8*>(data);
             const u8 alpha = ptr[offset];
@@ -218,7 +218,7 @@ u32 Texture::decodeTexel(u32 u, u32 v, PICA::ColorFmt fmt, const void* data) {
             return (alpha << 24) | (0 << 16) | (0 << 8) | 0;
         }
 
-        case PICA::ColorFmt::I4: {
+        case PICA::TextureFmt::I4: {
             u32 offset = getSwizzledOffset_4bpp(u, v, size.u());
             auto ptr = static_cast<const u8*>(data);
 
@@ -230,7 +230,7 @@ u32 Texture::decodeTexel(u32 u, u32 v, PICA::ColorFmt fmt, const void* data) {
             return (0xff << 24) | (intensity << 16) | (intensity << 8) | intensity;
         }
 
-        case PICA::ColorFmt::I8: {
+        case PICA::TextureFmt::I8: {
             u32 offset = getSwizzledOffset(u, v, size.u(), 1);
             auto ptr = static_cast<const u8*>(data);
             const u8 intensity = ptr[offset];
@@ -239,7 +239,7 @@ u32 Texture::decodeTexel(u32 u, u32 v, PICA::ColorFmt fmt, const void* data) {
             return (0xff << 24) | (intensity << 16) | (intensity << 8) | intensity;
         }
 
-        case PICA::ColorFmt::IA8: {
+        case PICA::TextureFmt::IA8: {
             u32 offset = getSwizzledOffset(u, v, size.u(), 2);
             auto ptr = static_cast<const u8*>(data);
 
@@ -249,8 +249,8 @@ u32 Texture::decodeTexel(u32 u, u32 v, PICA::ColorFmt fmt, const void* data) {
             return (alpha << 24) | (intensity << 16) | (intensity << 8) | intensity;
         }
 
-        case PICA::ColorFmt::ETC1: return getTexelETC(false, u, v, size.u(), data);
-        case PICA::ColorFmt::ETC1A4: return getTexelETC(true, u, v, size.u(), data);
+        case PICA::TextureFmt::ETC1: return getTexelETC(false, u, v, size.u(), data);
+        case PICA::TextureFmt::ETC1A4: return getTexelETC(true, u, v, size.u(), data);
 
         default:
             Helpers::panic("[Texture::DecodeTexel] Unimplemented format = %d", static_cast<int>(fmt));

--- a/src/core/renderer_gl/textures.cpp
+++ b/src/core/renderer_gl/textures.cpp
@@ -43,34 +43,34 @@ u64 Texture::sizeInBytes() {
     u64 pixelCount = u64(size.x()) * u64(size.y());
 
     switch (format) {
-        case Formats::RGBA8: // 4 bytes per pixel
+        case PICA::ColorFmt::RGBA8: // 4 bytes per pixel
             return pixelCount * 4;
 
-        case Formats::RGB8: // 3 bytes per pixel
+        case PICA::ColorFmt::RGB8: // 3 bytes per pixel
             return pixelCount * 3;
 
-        case Formats::RGBA5551: // 2 bytes per pixel
-        case Formats::RGB565:
-        case Formats::RGBA4:
-        case Formats::RG8:
-        case Formats::IA8:
+        case PICA::ColorFmt::RGBA5551: // 2 bytes per pixel
+        case PICA::ColorFmt::RGB565:
+        case PICA::ColorFmt::RGBA4:
+        case PICA::ColorFmt::RG8:
+        case PICA::ColorFmt::IA8:
             return pixelCount * 2;
 
-        case Formats::A8: // 1 byte per pixel
-        case Formats::I8:
-        case Formats::IA4:
+        case PICA::ColorFmt::A8: // 1 byte per pixel
+        case PICA::ColorFmt::I8:
+        case PICA::ColorFmt::IA4:
             return pixelCount;
 
-        case Formats::I4: // 4 bits per pixel
-        case Formats::A4:
+        case PICA::ColorFmt::I4: // 4 bits per pixel
+        case PICA::ColorFmt::A4:
             return pixelCount / 2;
 
-        case Formats::ETC1: // Compressed formats
-        case Formats::ETC1A4: {
+        case PICA::ColorFmt::ETC1: // Compressed formats
+        case PICA::ColorFmt::ETC1A4: {
             // Number of 4x4 tiles
             const u64 tileCount = pixelCount / 16;
             // Tiles are 8 bytes each on ETC1 and 16 bytes each on ETC1A4
-            const u64 tileSize = format == Formats::ETC1 ? 8 : 16;
+            const u64 tileSize = format == PICA::ColorFmt::ETC1 ? 8 : 16;
             return tileCount * tileSize;
         }
 
@@ -111,9 +111,9 @@ u32 Texture::getSwizzledOffset_4bpp(u32 u, u32 v, u32 width) {
 // Get the texel at position (u, v)
 // fmt: format of the texture
 // data: texture data of the texture
-u32 Texture::decodeTexel(u32 u, u32 v, Texture::Formats fmt, const void* data) {
+u32 Texture::decodeTexel(u32 u, u32 v, PICA::ColorFmt fmt, const void* data) {
     switch (fmt) {
-        case Formats::RGBA4: {
+        case PICA::ColorFmt::RGBA4: {
             u32 offset = getSwizzledOffset(u, v, size.u(), 2);
             auto ptr = static_cast<const u8*>(data);
             u16 texel = u16(ptr[offset]) | (u16(ptr[offset + 1]) << 8);
@@ -126,7 +126,7 @@ u32 Texture::decodeTexel(u32 u, u32 v, Texture::Formats fmt, const void* data) {
             return (alpha << 24) | (b << 16) | (g << 8) | r;
         }
 
-        case Formats::RGBA5551: {
+        case PICA::ColorFmt::RGBA5551: {
             u32 offset = getSwizzledOffset(u, v, size.u(), 2);
             auto ptr = static_cast<const u8*>(data);
             u16 texel = u16(ptr[offset]) | (u16(ptr[offset + 1]) << 8);
@@ -139,7 +139,7 @@ u32 Texture::decodeTexel(u32 u, u32 v, Texture::Formats fmt, const void* data) {
             return (alpha << 24) | (b << 16) | (g << 8) | r;
         }
 
-        case Formats::RGB565: {
+        case PICA::ColorFmt::RGB565: {
             u32 offset = getSwizzledOffset(u, v, size.u(), 2);
             auto ptr = static_cast<const u8*>(data);
             u16 texel = u16(ptr[offset]) | (u16(ptr[offset + 1]) << 8);
@@ -151,7 +151,7 @@ u32 Texture::decodeTexel(u32 u, u32 v, Texture::Formats fmt, const void* data) {
             return (0xff << 24) | (b << 16) | (g << 8) | r;
         }
 
-        case Formats::RG8: {
+        case PICA::ColorFmt::RG8: {
             u32 offset = getSwizzledOffset(u, v, size.u(), 2);
             auto ptr = static_cast<const u8*>(data);
 
@@ -162,7 +162,7 @@ u32 Texture::decodeTexel(u32 u, u32 v, Texture::Formats fmt, const void* data) {
             return (0xff << 24) | (b << 16) | (g << 8) | r;
         }
 
-        case Formats::RGB8: {
+        case PICA::ColorFmt::RGB8: {
             u32 offset = getSwizzledOffset(u, v, size.u(), 3);
             auto ptr = static_cast<const u8*>(data);
 
@@ -173,7 +173,7 @@ u32 Texture::decodeTexel(u32 u, u32 v, Texture::Formats fmt, const void* data) {
             return (0xff << 24) | (b << 16) | (g << 8) | r;
         }
 
-        case Formats::RGBA8: {
+        case PICA::ColorFmt::RGBA8: {
             u32 offset = getSwizzledOffset(u, v, size.u(), 4);
             auto ptr = static_cast<const u8*>(data);
 
@@ -185,7 +185,7 @@ u32 Texture::decodeTexel(u32 u, u32 v, Texture::Formats fmt, const void* data) {
             return (alpha << 24) | (b << 16) | (g << 8) | r;
         }
 
-        case Formats::IA4: {
+        case PICA::ColorFmt::IA4: {
             u32 offset = getSwizzledOffset(u, v, size.u(), 1);
             auto ptr = static_cast<const u8*>(data);
 
@@ -197,7 +197,7 @@ u32 Texture::decodeTexel(u32 u, u32 v, Texture::Formats fmt, const void* data) {
             return (alpha << 24) | (intensity << 16) | (intensity << 8) | intensity;
         }
 
-        case Formats::A4: {
+        case PICA::ColorFmt::A4: {
             u32 offset = getSwizzledOffset_4bpp(u, v, size.u());
             auto ptr = static_cast<const u8*>(data);
 
@@ -209,7 +209,7 @@ u32 Texture::decodeTexel(u32 u, u32 v, Texture::Formats fmt, const void* data) {
             return (alpha << 24) | (0 << 16) | (0 << 8) | 0;
         }
 
-        case Formats::A8: {
+        case PICA::ColorFmt::A8: {
             u32 offset = getSwizzledOffset(u, v, size.u(), 1);
             auto ptr = static_cast<const u8*>(data);
             const u8 alpha = ptr[offset];
@@ -218,7 +218,7 @@ u32 Texture::decodeTexel(u32 u, u32 v, Texture::Formats fmt, const void* data) {
             return (alpha << 24) | (0 << 16) | (0 << 8) | 0;
         }
 
-        case Formats::I4: {
+        case PICA::ColorFmt::I4: {
             u32 offset = getSwizzledOffset_4bpp(u, v, size.u());
             auto ptr = static_cast<const u8*>(data);
 
@@ -230,7 +230,7 @@ u32 Texture::decodeTexel(u32 u, u32 v, Texture::Formats fmt, const void* data) {
             return (0xff << 24) | (intensity << 16) | (intensity << 8) | intensity;
         }
 
-        case Formats::I8: {
+        case PICA::ColorFmt::I8: {
             u32 offset = getSwizzledOffset(u, v, size.u(), 1);
             auto ptr = static_cast<const u8*>(data);
             const u8 intensity = ptr[offset];
@@ -239,7 +239,7 @@ u32 Texture::decodeTexel(u32 u, u32 v, Texture::Formats fmt, const void* data) {
             return (0xff << 24) | (intensity << 16) | (intensity << 8) | intensity;
         }
 
-        case Formats::IA8: {
+        case PICA::ColorFmt::IA8: {
             u32 offset = getSwizzledOffset(u, v, size.u(), 2);
             auto ptr = static_cast<const u8*>(data);
 
@@ -249,8 +249,8 @@ u32 Texture::decodeTexel(u32 u, u32 v, Texture::Formats fmt, const void* data) {
             return (alpha << 24) | (intensity << 16) | (intensity << 8) | intensity;
         }
 
-        case Formats::ETC1: return getTexelETC(false, u, v, size.u(), data);
-        case Formats::ETC1A4: return getTexelETC(true, u, v, size.u(), data);
+        case PICA::ColorFmt::ETC1: return getTexelETC(false, u, v, size.u(), data);
+        case PICA::ColorFmt::ETC1A4: return getTexelETC(true, u, v, size.u(), data);
 
         default:
             Helpers::panic("[Texture::DecodeTexel] Unimplemented format = %d", static_cast<int>(fmt));
@@ -271,24 +271,4 @@ void Texture::decodeTexture(const void* data) {
 
     texture.bind();
     glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, size.u(), size.v(), GL_RGBA, GL_UNSIGNED_BYTE, decoded.data());
-}
-
-std::string Texture::textureFormatToString(Texture::Formats fmt) {
-    switch (fmt) {
-        case Formats::A4: return "A4";
-        case Formats::A8: return "A8";
-        case Formats::ETC1: return "ETC1";
-        case Formats::ETC1A4: return "ETC1A4";
-        case Formats::I4: return "I4";
-        case Formats::I8: return "I8";
-        case Formats::IA4: return "IA4";
-        case Formats::IA8: return "IA8";
-        case Formats::RG8: return "RG8";
-        case Formats::RGB565: return "RGB565";
-        case Formats::RGB8: return "RGB8";
-        case Formats::RGBA4: return "RGBA4";
-        case Formats::RGBA5551: return "RGBA5551";
-        case Formats::RGBA8: return "RGBA8";
-        default: return "Unknown";
-    }
 }


### PR DESCRIPTION
Slowly stepping the codebase towards having renderer-agnostic types and keeping the translation of PICA-types to OpenGL/VK/DX/Software/etc to the renderer-backend.