### PR TITLE
Address `C4267`/`C4244` warnings

### DIFF
--- a/include/PICA/gpu.hpp
+++ b/include/PICA/gpu.hpp
@@ -26,7 +26,7 @@ class GPU {
 	MAKE_LOG_FUNCTION(log, gpuLogger)
 
 	static constexpr u32 maxAttribCount = 12; // Up to 12 vertex attributes
-	static constexpr u32 vramSize = 6_MB;
+	static constexpr u32 vramSize = u32(6_MB);
 	Registers regs; // GPU internal registers
 	std::array<vec4f, 16> currentAttributes; // Vertex attributes before being passed to the shader
 

--- a/include/helpers.hpp
+++ b/include/helpers.hpp
@@ -113,9 +113,16 @@ namespace Helpers {
 	}
 
 	/// Extract bits from an integer-type
-	template <usize offset, usize bits, typename T>
-	static constexpr T getBits(T value) {
-		return (value >> offset) & ones<T, bits>();
+	template <usize offset, usize bits, typename ReturnT, typename ValueT>
+	static constexpr ReturnT getBits(ValueT value) {
+		static_assert((offset + bits) <= (CHAR_BIT * sizeof(ValueT)), "Invalid bit range");
+		static_assert(bits > 0, "Invalid bit size");
+		return ReturnT(ValueT(value >> offset) & ones<ValueT, bits>());
+	}
+
+	template <usize offset, usize bits, typename ValueT>
+	static constexpr ValueT getBits(ValueT value) {
+		return getBits<offset, bits, ValueT, ValueT>(value);
 	}
 
 #ifdef HELPERS_APPLE_CLANG

--- a/include/memory.hpp
+++ b/include/memory.hpp
@@ -110,7 +110,7 @@ class Memory {
 	std::vector<KernelMemoryTypes::MemoryInfo> memoryInfo;
 
 	std::array<SharedMemoryBlock, 3> sharedMemBlocks = {
-		SharedMemoryBlock(0, _shared_font_len, KernelHandles::FontSharedMemHandle), // Shared memory for the system font
+		SharedMemoryBlock(0, u32(_shared_font_len), KernelHandles::FontSharedMemHandle), // Shared memory for the system font
 		SharedMemoryBlock(0, 0x1000, KernelHandles::GSPSharedMemHandle), // GSP shared memory
 		SharedMemoryBlock(0, 0x1000, KernelHandles::HIDSharedMemHandle)  // HID shared memory
  	};
@@ -121,14 +121,14 @@ public:
 	static constexpr u32 pageMask = pageSize - 1;
 	static constexpr u32 totalPageCount = 1 << (32 - pageShift);
 	
-	static constexpr u32 FCRAM_SIZE = 128_MB;
-	static constexpr u32 FCRAM_APPLICATION_SIZE = 64_MB;
+	static constexpr u32 FCRAM_SIZE = u32(128_MB);
+	static constexpr u32 FCRAM_APPLICATION_SIZE = u32(64_MB);
 	static constexpr u32 FCRAM_PAGE_COUNT = FCRAM_SIZE / pageSize;
 	static constexpr u32 FCRAM_APPLICATION_PAGE_COUNT = FCRAM_APPLICATION_SIZE / pageSize;
 
-	static constexpr u32 DSP_RAM_SIZE = 512_KB;
-	static constexpr u32 DSP_CODE_MEMORY_OFFSET = 0_KB;
-	static constexpr u32 DSP_DATA_MEMORY_OFFSET = 256_KB;
+	static constexpr u32 DSP_RAM_SIZE = u32(512_KB);
+	static constexpr u32 DSP_CODE_MEMORY_OFFSET = u32(0_KB);
+	static constexpr u32 DSP_DATA_MEMORY_OFFSET = u32(256_KB);
 
 private:
 	std::bitset<FCRAM_PAGE_COUNT> usedFCRAMPages;
@@ -141,8 +141,8 @@ private:
 
 public:
 	u16 kernelVersion = 0;
-	u32 usedUserMemory = 0_MB; // How much of the APPLICATION FCRAM range is used (allocated to the appcore)
-	u32 usedSystemMemory = 0_MB; // Similar for the SYSTEM range (reserved for the syscore)
+	u32 usedUserMemory = u32(0_MB); // How much of the APPLICATION FCRAM range is used (allocated to the appcore)
+	u32 usedSystemMemory = u32(0_MB); // Similar for the SYSTEM range (reserved for the syscore)
 
 	Memory(u64& cpuTicks);
 	void reset();

--- a/src/core/fs/archive_ncch.cpp
+++ b/src/core/fs/archive_ncch.cpp
@@ -138,8 +138,8 @@ std::optional<u32> NCCHArchive::readFile(FileSession* file, u64 offset, u32 size
 	// Seek to file offset depending on if we're reading from RomFS, ExeFS, etc
 	switch (type) {
 		case PathType::RomFS: {
-			const u32 romFSSize = cxi->romFS.size;
-			const u32 romFSOffset = cxi->romFS.offset;
+			const u64 romFSSize = cxi->romFS.size;
+			const u64 romFSOffset = cxi->romFS.offset;
 			if ((offset >> 32) || (offset >= romFSSize) || (offset + size >= romFSSize)) {
 				Helpers::panic("Tried to read from NCCH with too big of an offset");
 			}
@@ -161,8 +161,8 @@ std::optional<u32> NCCHArchive::readFile(FileSession* file, u64 offset, u32 size
 	}
 
 	for (u64 i = 0; i < bytesRead; i++) {
-		mem.write8(dataPointer + i, data[i]);
+		mem.write8(u32(dataPointer + i), data[i]);
 	}
 
-	return bytesRead;
+	return u32(bytesRead);
 }

--- a/src/core/fs/archive_self_ncch.cpp
+++ b/src/core/fs/archive_self_ncch.cpp
@@ -76,8 +76,8 @@ std::optional<u32> SelfNCCHArchive::readFile(FileSession* file, u64 offset, u32 
 	// Seek to file offset depending on if we're reading from RomFS, ExeFS, etc
 	switch (type) {
 		case PathType::RomFS: {
-			const u32 romFSSize = cxi->romFS.size;
-			const u32 romFSOffset = cxi->romFS.offset;
+			const u64 romFSSize = cxi->romFS.size;
+			const u64 romFSOffset = cxi->romFS.offset;
 			if ((offset >> 32) || (offset >= romFSSize) || (offset + size >= romFSSize)) {
 				Helpers::panic("Tried to read from SelfNCCH with too big of an offset");
 			}
@@ -88,8 +88,8 @@ std::optional<u32> SelfNCCHArchive::readFile(FileSession* file, u64 offset, u32 
 		}
 
 		case PathType::ExeFS: {
-			const u32 exeFSSize = cxi->exeFS.size;
-			const u32 exeFSOffset = cxi->exeFS.offset;
+			const u64 exeFSSize = cxi->exeFS.size;
+			const u64 exeFSOffset = cxi->exeFS.offset;
 			if ((offset >> 32) || (offset >= exeFSSize) || (offset + size >= exeFSSize)) {
 				Helpers::panic("Tried to read from SelfNCCH with too big of an offset");
 			}
@@ -110,8 +110,8 @@ std::optional<u32> SelfNCCHArchive::readFile(FileSession* file, u64 offset, u32 
 	}
 
 	for (u64 i = 0; i < bytesRead; i++) {
-		mem.write8(dataPointer + i, data[i]);
+		mem.write8(u32(dataPointer + i), data[i]);
 	}
 
-	return bytesRead;
+	return u32(bytesRead);
 }

--- a/src/core/kernel/file_operations.cpp
+++ b/src/core/kernel/file_operations.cpp
@@ -97,11 +97,11 @@ void Kernel::readFile(u32 messagePointer, Handle fileHandle) {
 		}
 		else {
 			for (size_t i = 0; i < bytesRead; i++) {
-				mem.write8(dataPointer + i, data[i]);
+				mem.write8(u32(dataPointer + i), data[i]);
 			}
 
 			mem.write32(messagePointer + 4, Result::Success);
-			mem.write32(messagePointer + 8, bytesRead);
+			mem.write32(messagePointer + 8, u32(bytesRead));
 		}
 
 		return;
@@ -142,7 +142,7 @@ void Kernel::writeFile(u32 messagePointer, Handle fileHandle) {
 
 	std::unique_ptr<u8[]> data(new u8[size]);
 	for (size_t i = 0; i < size; i++) {
-		data[i] = mem.read8(dataPointer + i);
+		data[i] = mem.read8(u32(dataPointer + i));
 	}
 
 	IOFile f(file->fd);
@@ -153,7 +153,7 @@ void Kernel::writeFile(u32 messagePointer, Handle fileHandle) {
 		Helpers::panic("Kernel::WriteFile failed");
 	} else {
 		mem.write32(messagePointer + 4, Result::Success);
-		mem.write32(messagePointer + 8, bytesWritten);
+		mem.write32(messagePointer + 8, u32(bytesWritten));
 	}
 }
 

--- a/src/core/kernel/threads.cpp
+++ b/src/core/kernel/threads.cpp
@@ -286,7 +286,7 @@ int Kernel::wakeupOneThread(u64 waitlist, Handle handle) {
 			// Get the index of the event in the object's waitlist, write it to r1
 			for (size_t i = 0; i < t.waitList.size(); i++) {
 				if (t.waitList[i] == handle) {
-					t.gprs[1] = i;
+					t.gprs[1] = u32(i);
 					break;
 				}
 			}
@@ -321,7 +321,7 @@ void Kernel::wakeupAllThreads(u64 waitlist, Handle handle) {
 			// Get the index of the event in the object's waitlist, write it to r1
 			for (size_t i = 0; i < t.waitList.size(); i++) {
 				if (t.waitList[i] == handle) {
-					t.gprs[1] = i;
+					t.gprs[1] = u32(i);
 					break;
 				}
 			}

--- a/src/core/loader/lz77.cpp
+++ b/src/core/loader/lz77.cpp
@@ -12,7 +12,7 @@ u32 CartLZ77::decompressedSize(const u8* buffer, u32 compressedSize) {
 }
 
 bool CartLZ77::decompress(std::vector<u8>& output, const std::vector<u8>& input) {
-    u32 sizeCompressed = input.size() * sizeof(u8);
+    u32 sizeCompressed = u32(input.size() * sizeof(u8));
     u32 sizeDecompressed = decompressedSize(input);
     output.resize(sizeDecompressed);
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -223,7 +223,10 @@ std::string Memory::readString(u32 address, u32 maxSize) {
 
 	for (std::size_t i = 0; i < maxSize; ++i) {
 		char c = read8(address++);
-		if (c == '\0') break;
+		if (c == '\0') {
+			break;
+		}
+
 		string.push_back(c);
 	}
 	string.shrink_to_fit();
@@ -256,7 +259,9 @@ std::optional<u32> Memory::allocateMemory(u32 vaddr, u32 paddr, u32 size, bool l
 	// Non-linear allocation needs special handling
 	if (paddr == 0 && adjustAddrs) {
 		std::optional<u32> newPaddr = findPaddr(size);
-		if (!newPaddr.has_value()) Helpers::panic("Failed to find paddr");
+		if (!newPaddr.has_value()) {
+			Helpers::panic("Failed to find paddr");
+		}
 
 		paddr = newPaddr.value();
 		assert(paddr + size <= FCRAM_APPLICATION_SIZE || isMap);
@@ -277,7 +282,9 @@ std::optional<u32> Memory::allocateMemory(u32 vaddr, u32 paddr, u32 size, bool l
 		}
 	}
 
-	if (!isMap) usedUserMemory += size;
+	if (!isMap) {
+		usedUserMemory += size;
+	}
 
 	// Do linear mapping
 	u32 virtualPage = vaddr >> pageShift;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -1,9 +1,11 @@
 #include "memory.hpp"
+
+#include <cassert>
+#include <chrono>  // For time since epoch
+#include <ctime>
+
 #include "config_mem.hpp"
 #include "resource_limits.hpp"
-#include <cassert>
-#include <chrono> // For time since epoch
-#include <ctime>
 
 using namespace KernelMemoryTypes;
 
@@ -13,15 +15,15 @@ Memory::Memory(u64& cpuTicks) : cpuTicks(cpuTicks) {
 
 	readTable.resize(totalPageCount, 0);
 	writeTable.resize(totalPageCount, 0);
-	memoryInfo.reserve(32); // Pre-allocate some room for memory allocation info to avoid dynamic allocs
+	memoryInfo.reserve(32);  // Pre-allocate some room for memory allocation info to avoid dynamic allocs
 }
 
 void Memory::reset() {
 	// Unallocate all memory
 	memoryInfo.clear();
 	usedFCRAMPages.reset();
-	usedUserMemory = 0_MB;
-	usedSystemMemory = 0_MB;
+	usedUserMemory = u32(0_MB);
+	usedSystemMemory = u32(0_MB);
 
 	for (u32 i = 0; i < totalPageCount; i++) {
 		readTable[i] = 0;
@@ -35,7 +37,7 @@ void Memory::reset() {
 	}
 
 	u32 basePaddrForTLS = tlsBaseOpt.value();
-	for (int i = 0; i < appResourceLimits.maxThreads; i++) {
+	for (u32 i = 0; i < appResourceLimits.maxThreads; i++) {
 		u32 vaddr = VirtualAddrs::TLSBase + i * VirtualAddrs::TLSSize;
 		allocateMemory(vaddr, basePaddrForTLS, VirtualAddrs::TLSSize, true);
 		basePaddrForTLS += VirtualAddrs::TLSSize;
@@ -48,8 +50,8 @@ void Memory::reset() {
 	}
 
 	// Map DSP RAM as R/W at [0x1FF00000, 0x1FF7FFFF]
-	constexpr u32 dspRamPages = DSP_RAM_SIZE / pageSize; // Number of DSP RAM pages
-	constexpr u32 initialPage = VirtualAddrs::DSPMemStart / pageSize; // First page of DSP RAM in the virtual address space
+	constexpr u32 dspRamPages = DSP_RAM_SIZE / pageSize;               // Number of DSP RAM pages
+	constexpr u32 initialPage = VirtualAddrs::DSPMemStart / pageSize;  // First page of DSP RAM in the virtual address space
 
 	for (u32 i = 0; i < dspRamPages; i++) {
 		auto pointer = uintptr_t(&dspRam[i * pageSize]);
@@ -67,7 +69,7 @@ bool Memory::allocateMainThreadStack(u32 size) {
 	}
 
 	const u32 stackBottom = VirtualAddrs::StackTop - size;
-	std::optional<u32> result = allocateMemory(stackBottom, basePaddr.value(), size, true); // Should never be nullopt
+	std::optional<u32> result = allocateMemory(stackBottom, basePaddr.value(), size, true);  // Should never be nullopt
 	return result.has_value();
 }
 
@@ -78,18 +80,17 @@ u8 Memory::read8(u32 vaddr) {
 	uintptr_t pointer = readTable[page];
 	if (pointer != 0) [[likely]] {
 		return *(u8*)(pointer + offset);
-	}
-	else {
+	} else {
 		switch (vaddr) {
 			case ConfigMem::BatteryState: return getBatteryState(true, true, BatteryLevel::FourBars);
 			case ConfigMem::EnvInfo: return envInfo;
 			case ConfigMem::HardwareType: return ConfigMem::HardwareCodes::Product;
 			case ConfigMem::KernelVersionMinor: return u8(kernelVersion & 0xff);
 			case ConfigMem::KernelVersionMajor: return u8(kernelVersion >> 8);
-			case ConfigMem::LedState3D: return 1; // Report the 3D LED as always off (non-zero) for now
-			case ConfigMem::NetworkState: return 2; // Report that we've got an internet connection
+			case ConfigMem::LedState3D: return 1;    // Report the 3D LED as always off (non-zero) for now
+			case ConfigMem::NetworkState: return 2;  // Report that we've got an internet connection
 			case ConfigMem::HeadphonesConnectedMaybe: return 0;
-			case ConfigMem::Unknown1086: return 1; // It's unknown what this is but some games want it to be 1
+			case ConfigMem::Unknown1086: return 1;  // It's unknown what this is but some games want it to be 1
 			default: Helpers::panic("Unimplemented 8-bit read, addr: %08X", vaddr);
 		}
 	}
@@ -102,8 +103,7 @@ u16 Memory::read16(u32 vaddr) {
 	uintptr_t pointer = readTable[page];
 	if (pointer != 0) [[likely]] {
 		return *(u16*)(pointer + offset);
-	}
-	else {
+	} else {
 		Helpers::panic("Unimplemented 16-bit read, addr: %08X", vaddr);
 	}
 }
@@ -117,18 +117,20 @@ u32 Memory::read32(u32 vaddr) {
 		return *(u32*)(pointer + offset);
 	} else {
 		switch (vaddr) {
-			case ConfigMem::Datetime0: return u32(timeSince3DSEpoch()); // ms elapsed since Jan 1 1900, bottom 32 bits
-			case ConfigMem::Datetime0 + 4: return u32(timeSince3DSEpoch() >> 32); // top 32 bits
+			case ConfigMem::Datetime0: return u32(timeSince3DSEpoch());  // ms elapsed since Jan 1 1900, bottom 32 bits
+			case ConfigMem::Datetime0 + 4:
+				return u32(timeSince3DSEpoch() >> 32);  // top 32 bits
 			// Ticks since time was last updated. For now we return the current tick count
 			case ConfigMem::Datetime0 + 8: return u32(cpuTicks);
 			case ConfigMem::Datetime0 + 12: return u32(cpuTicks >> 32);
-			case ConfigMem::Datetime0 + 16: return 0xFFB0FF0; // Unknown, set by PTM
-			case ConfigMem::Datetime0 + 20: case ConfigMem::Datetime0 + 24: case ConfigMem::Datetime0 + 28:
-				return 0; // Set to 0 by PTM
+			case ConfigMem::Datetime0 + 16: return 0xFFB0FF0;  // Unknown, set by PTM
+			case ConfigMem::Datetime0 + 20:
+			case ConfigMem::Datetime0 + 24:
+			case ConfigMem::Datetime0 + 28: return 0;  // Set to 0 by PTM
 
 			case ConfigMem::AppMemAlloc: return appResourceLimits.maxCommit;
 			case ConfigMem::SyscoreVer: return 2;
-			case 0x1FF81000: return 0; // TODO: Figure out what this config mem address does
+			case 0x1FF81000: return 0;  // TODO: Figure out what this config mem address does
 			default:
 				if (vaddr >= VirtualAddrs::VramStart && vaddr < VirtualAddrs::VramStart + VirtualAddrs::VramSize) {
 					Helpers::warn("VRAM read!\n");
@@ -154,13 +156,12 @@ void Memory::write8(u32 vaddr, u8 value) {
 	uintptr_t pointer = writeTable[page];
 	if (pointer != 0) [[likely]] {
 		*(u8*)(pointer + offset) = value;
-	}
-	else {
+	} else {
 		// VRAM write
 		if (vaddr >= VirtualAddrs::VramStart && vaddr < VirtualAddrs::VramStart + VirtualAddrs::VramSize) {
 			// TODO: Invalidate renderer caches here
 			vram[vaddr - VirtualAddrs::VramStart] = value;
-		} 
+		}
 
 		else {
 			Helpers::panic("Unimplemented 8-bit write, addr: %08X, val: %02X", vaddr, value);
@@ -219,11 +220,10 @@ void* Memory::getWritePointer(u32 address) {
 std::string Memory::readString(u32 address, u32 maxSize) {
 	std::string string;
 	string.reserve(maxSize);
-	
+
 	for (std::size_t i = 0; i < maxSize; ++i) {
 		char c = read8(address++);
-		if (c == '\0')
-			break;
+		if (c == '\0') break;
 		string.push_back(c);
 	}
 	string.shrink_to_fit();
@@ -233,12 +233,9 @@ std::string Memory::readString(u32 address, u32 maxSize) {
 
 // Return a pointer to the linear heap vaddr based on the kernel ver, because it needed to be moved
 // thanks to the New 3DS having more FCRAM
-u32 Memory::getLinearHeapVaddr() {
-	return (kernelVersion < 0x22C) ? VirtualAddrs::LinearHeapStartOld : VirtualAddrs::LinearHeapStartNew;
-}
+u32 Memory::getLinearHeapVaddr() { return (kernelVersion < 0x22C) ? VirtualAddrs::LinearHeapStartOld : VirtualAddrs::LinearHeapStartNew; }
 
-std::optional<u32> Memory::allocateMemory(u32 vaddr, u32 paddr, u32 size, bool linear, bool r, bool w, bool x,
-	bool adjustAddrs, bool isMap) {
+std::optional<u32> Memory::allocateMemory(u32 vaddr, u32 paddr, u32 size, bool linear, bool r, bool w, bool x, bool adjustAddrs, bool isMap) {
 	// Kernel-allocated memory & size must always be aligned to a page boundary
 	// Additionally assert we don't OoM and that we don't try to allocate physical FCRAM past what's available to userland
 	// If we're mapping there's no fear of OoM, because we're not really allocating memory, just binding vaddrs to specific paddrs
@@ -259,8 +256,7 @@ std::optional<u32> Memory::allocateMemory(u32 vaddr, u32 paddr, u32 size, bool l
 	// Non-linear allocation needs special handling
 	if (paddr == 0 && adjustAddrs) {
 		std::optional<u32> newPaddr = findPaddr(size);
-		if (!newPaddr.has_value())
-			Helpers::panic("Failed to find paddr");
+		if (!newPaddr.has_value()) Helpers::panic("Failed to find paddr");
 
 		paddr = newPaddr.value();
 		assert(paddr + size <= FCRAM_APPLICATION_SIZE || isMap);
@@ -281,12 +277,11 @@ std::optional<u32> Memory::allocateMemory(u32 vaddr, u32 paddr, u32 size, bool l
 		}
 	}
 
-	if (!isMap)
-		usedUserMemory += size;
+	if (!isMap) usedUserMemory += size;
 
 	// Do linear mapping
 	u32 virtualPage = vaddr >> pageShift;
-	u32 physPage = paddr >> pageShift; // TODO: Special handle when non-linear mapping is necessary
+	u32 physPage = paddr >> pageShift;  // TODO: Special handle when non-linear mapping is necessary
 	for (u32 i = 0; i < neededPageCount; i++) {
 		if (r) {
 			readTable[virtualPage] = uintptr_t(&fcram[physPage * pageSize]);
@@ -320,11 +315,10 @@ std::optional<u32> Memory::findPaddr(u32 size) {
 	u32 counter = 0;
 
 	for (u32 i = 0; i < FCRAM_APPLICATION_PAGE_COUNT; i++) {
-		if (usedFCRAMPages[i]) { // Page is occupied already, go to new candidate
+		if (usedFCRAMPages[i]) {  // Page is occupied already, go to new candidate
 			candidatePage = i + 1;
 			counter = 0;
-		}
-		else { // The paddr we're testing has 1 more free page
+		} else {  // The paddr we're testing has 1 more free page
 			counter++;
 			// Check if there's enough free memory to use this page
 			// We use == instead of >= because some software does 0-byte allocations
@@ -351,12 +345,12 @@ u32 Memory::allocateSysMemory(u32 size) {
 		Helpers::panic("Memory::allocateSysMemory: Overflowed OS FCRAM");
 	}
 
-	const u32 pageCount = size / pageSize; // Number of pages that will be used up
-	const u32 startIndex = sysFCRAMIndex() + usedSystemMemory; // Starting FCRAM index
+	const u32 pageCount = size / pageSize;                      // Number of pages that will be used up
+	const u32 startIndex = sysFCRAMIndex() + usedSystemMemory;  // Starting FCRAM index
 	const u32 startingPage = startIndex / pageSize;
 
 	for (u32 i = 0; i < pageCount; i++) {
-		if (usedFCRAMPages[startingPage + i]) // Also a theoretically unreachable panic for safety
+		if (usedFCRAMPages[startingPage + i])  // Also a theoretically unreachable panic for safety
 			Helpers::panic("Memory::reserveMemory: Trying to reserve already reserved memory");
 		usedFCRAMPages[startingPage + i] = true;
 	}
@@ -419,7 +413,7 @@ void Memory::mirrorMapping(u32 destAddress, u32 sourceAddress, u32 size) {
 	// Should theoretically be unreachable, only here for safety purposes
 	assert(isAligned(destAddress) && isAligned(sourceAddress) && isAligned(size));
 
-	const u32 pageCount = size / pageSize; // How many pages we need to mirror
+	const u32 pageCount = size / pageSize;  // How many pages we need to mirror
 	for (u32 i = 0; i < pageCount; i++) {
 		// Redo the shift here to "properly" handle wrapping around the address space instead of reading OoB
 		const u32 sourcePage = sourceAddress / pageSize;
@@ -437,16 +431,16 @@ void Memory::mirrorMapping(u32 destAddress, u32 sourceAddress, u32 size) {
 u64 Memory::timeSince3DSEpoch() {
 	using namespace std::chrono;
 
-	std::time_t rawTime = std::time(nullptr); // Get current UTC time
-	auto localTime = std::localtime(&rawTime); // Convert to local time
+	std::time_t rawTime = std::time(nullptr);   // Get current UTC time
+	auto localTime = std::localtime(&rawTime);  // Convert to local time
 
-	bool daylightSavings = localTime->tm_isdst > 0; // Get if time includes DST
+	bool daylightSavings = localTime->tm_isdst > 0;  // Get if time includes DST
 	localTime = std::gmtime(&rawTime);
 
 	// Use gmtime + mktime to calculate difference between local time and UTC
 	auto timezoneDifference = rawTime - std::mktime(localTime);
 	if (daylightSavings) {
-		timezoneDifference += 60ull * 60ull; // Add 1 hour (60 seconds * 60 minutes)
+		timezoneDifference += 60ull * 60ull;  // Add 1 hour (60 seconds * 60 minutes)
 	}
 
 	// seconds between Jan 1 1900 and Jan 1 1970

--- a/src/core/renderer_gl/etc1.cpp
+++ b/src/core/renderer_gl/etc1.cpp
@@ -60,14 +60,14 @@ u32 Texture::decodeETC(u32 alpha, u32 u, u32 v, u64 colourData) {
     };
 
     // Parse colour data for 4x4 block
-    const u32 subindices = getBits<0, 16>(colourData);
-    const u32 negationFlags = getBits<16, 16>(colourData);
+    const u32 subindices = getBits<0, 16, u32>(colourData);
+    const u32 negationFlags = getBits<16, 16, u32>(colourData);
     const bool flip = getBit<32>(colourData);
     const bool diffMode = getBit<33>(colourData);
 
     // Note: index1 is indeed stored on the higher bits, with index2 in the lower bits
-    const u32 tableIndex1 = getBits<37, 3>(colourData);
-    const u32 tableIndex2 = getBits<34, 3>(colourData);
+    const u32 tableIndex1 = getBits<37, 3, u32>(colourData);
+    const u32 tableIndex2 = getBits<34, 3, u32>(colourData);
     const u32 texelIndex = u * 4 + v; // Index of the texel in the block
 
     if (flip)
@@ -75,14 +75,14 @@ u32 Texture::decodeETC(u32 alpha, u32 u, u32 v, u64 colourData) {
 
     s32 r, g, b;
     if (diffMode) {
-        r = getBits<59, 5>(colourData);
-        g = getBits<51, 5>(colourData);
-        b = getBits<43, 5>(colourData);
+        r = getBits<59, 5, s32>(colourData);
+        g = getBits<51, 5, s32>(colourData);
+        b = getBits<43, 5, s32>(colourData);
 
         if (u >= 2) {
-            r += signExtend3To32(getBits<56, 3>(colourData));
-            g += signExtend3To32(getBits<48, 3>(colourData));
-            b += signExtend3To32(getBits<40, 3>(colourData));
+            r += signExtend3To32(getBits<56, 3, u32>(colourData));
+            g += signExtend3To32(getBits<48, 3, u32>(colourData));
+            b += signExtend3To32(getBits<40, 3, u32>(colourData));
         }
 
         // Expand from 5 to 8 bits per channel
@@ -91,13 +91,13 @@ u32 Texture::decodeETC(u32 alpha, u32 u, u32 v, u64 colourData) {
         b = Colour::convert5To8Bit(b);
     } else {
         if (u < 2) {
-            r = getBits<60, 4>(colourData);
-            g = getBits<52, 4>(colourData);
-            b = getBits<44, 4>(colourData);
+            r = getBits<60, 4, s32>(colourData);
+            g = getBits<52, 4, s32>(colourData);
+            b = getBits<44, 4, s32>(colourData);
         } else {
-            r = getBits<56, 4>(colourData);
-            g = getBits<48, 4>(colourData);
-            b = getBits<40, 4>(colourData);
+            r = getBits<56, 4, s32>(colourData);
+            g = getBits<48, 4, s32>(colourData);
+            b = getBits<40, 4, s32>(colourData);
         }
 
         // Expand from 4 to 8 bits per channel

--- a/src/core/renderer_gl/renderer_gl.cpp
+++ b/src/core/renderer_gl/renderer_gl.cpp
@@ -911,7 +911,7 @@ void Renderer::drawVertices(PICA::PrimType primType, std::span<const Vertex> ver
 	}
 
 	vbo.bufferVertsSub(vertices);
-	OpenGL::draw(primitiveTopology, vertices.size());
+	OpenGL::draw(primitiveTopology, GLsizei(vertices.size()));
 }
 
 constexpr u32 topScreenBuffer = 0x1f000000;

--- a/src/core/renderer_gl/renderer_gl.cpp
+++ b/src/core/renderer_gl/renderer_gl.cpp
@@ -888,8 +888,8 @@ void Renderer::drawVertices(PICA::PrimType primType, std::span<const Vertex> ver
 	}
 
 	// TODO: Actually use this
-	float viewportWidth = f24::fromRaw(regs[PICA::InternalRegs::ViewportWidth] & 0xffffff).toFloat32() * 2.0;
-	float viewportHeight = f24::fromRaw(regs[PICA::InternalRegs::ViewportHeight] & 0xffffff).toFloat32() * 2.0;
+	GLsizei viewportWidth = GLsizei(f24::fromRaw(regs[PICA::InternalRegs::ViewportWidth] & 0xffffff).toFloat32() * 2.0f);
+	GLsizei viewportHeight = GLsizei(f24::fromRaw(regs[PICA::InternalRegs::ViewportHeight] & 0xffffff).toFloat32() * 2.0f);
 	OpenGL::setViewport(viewportWidth, viewportHeight);
 
 	// Note: The code below must execute after we've bound the colour buffer & its framebuffer
@@ -929,10 +929,10 @@ void Renderer::clearBuffer(u32 startAddress, u32 endAddress, u32 value, u32 cont
 	return;
 	log("GPU: Clear buffer\nStart: %08X End: %08X\nValue: %08X Control: %08X\n", startAddress, endAddress, value, control);
 
-	const float r = float(getBits<24, 8>(value)) / 255.0;
-	const float g = float(getBits<16, 8>(value)) / 255.0;
-	const float b = float(getBits<8, 8>(value)) / 255.0;
-	const float a = float(value & 0xff) / 255.0;
+	const float r = float(getBits<24, 8>(value)) / 255.0f;
+	const float g = float(getBits<16, 8>(value)) / 255.0f;
+	const float b = float(getBits<8, 8>(value)) / 255.0f;
+	const float a = float(value & 0xff) / 255.0f;
 
 	if (startAddress == topScreenBuffer) {
 		log("GPU: Cleared top screen\n");

--- a/src/core/renderer_gl/textures.cpp
+++ b/src/core/renderer_gl/textures.cpp
@@ -119,10 +119,10 @@ u32 Texture::decodeTexel(u32 u, u32 v, PICA::TextureFmt fmt, const void* data) {
             auto ptr = static_cast<const u8*>(data);
             u16 texel = u16(ptr[offset]) | (u16(ptr[offset + 1]) << 8);
 
-            u8 alpha = Colour::convert4To8Bit(getBits<0, 4>(texel));
-            u8 b = Colour::convert4To8Bit(getBits<4, 4>(texel));
-            u8 g = Colour::convert4To8Bit(getBits<8, 4>(texel));
-            u8 r = Colour::convert4To8Bit(getBits<12, 4>(texel));
+            u8 alpha = Colour::convert4To8Bit(getBits<0, 4, u8>(texel));
+            u8 b = Colour::convert4To8Bit(getBits<4, 4, u8>(texel));
+            u8 g = Colour::convert4To8Bit(getBits<8, 4, u8>(texel));
+            u8 r = Colour::convert4To8Bit(getBits<12, 4, u8>(texel));
 
             return (alpha << 24) | (b << 16) | (g << 8) | r;
         }
@@ -133,9 +133,9 @@ u32 Texture::decodeTexel(u32 u, u32 v, PICA::TextureFmt fmt, const void* data) {
             u16 texel = u16(ptr[offset]) | (u16(ptr[offset + 1]) << 8);
 
             u8 alpha = getBit<0>(texel) ? 0xff : 0;
-            u8 b = Colour::convert5To8Bit(getBits<1, 5>(texel));
-            u8 g = Colour::convert5To8Bit(getBits<6, 5>(texel));
-            u8 r = Colour::convert5To8Bit(getBits<11, 5>(texel));
+            u8 b = Colour::convert5To8Bit(getBits<1, 5, u8>(texel));
+            u8 g = Colour::convert5To8Bit(getBits<6, 5, u8>(texel));
+            u8 r = Colour::convert5To8Bit(getBits<11, 5, u8>(texel));
 
             return (alpha << 24) | (b << 16) | (g << 8) | r;
         }
@@ -145,9 +145,9 @@ u32 Texture::decodeTexel(u32 u, u32 v, PICA::TextureFmt fmt, const void* data) {
             auto ptr = static_cast<const u8*>(data);
             u16 texel = u16(ptr[offset]) | (u16(ptr[offset + 1]) << 8);
 
-            u8 b = Colour::convert5To8Bit(getBits<0, 5>(texel));
-            u8 g = Colour::convert6To8Bit(getBits<5, 6>(texel));
-            u8 r = Colour::convert5To8Bit(getBits<11, 5>(texel));
+            u8 b = Colour::convert5To8Bit(getBits<0, 5, u8>(texel));
+            u8 g = Colour::convert6To8Bit(getBits<5, 6, u8>(texel));
+            u8 r = Colour::convert5To8Bit(getBits<11, 5, u8>(texel));
 
             return (0xff << 24) | (b << 16) | (g << 8) | r;
         }

--- a/src/core/services/dsp.cpp
+++ b/src/core/services/dsp.cpp
@@ -143,7 +143,7 @@ std::vector<u8> DSPService::readPipe(u32 pipe, u32 size) {
 	}
 
 	std::vector<u8>& data = pipeData[pipe];
-	size = std::min<u32>(size, data.size()); // Clamp size to the maximum available data size
+	size = std::min<u32>(size, u32(data.size())); // Clamp size to the maximum available data size
 
 	if (size == 0)
 		return {};
@@ -168,7 +168,7 @@ void DSPService::readPipeIfPossible(u32 messagePointer) {
 	}
 
 	mem.write32(messagePointer + 4, Result::Success);
-	mem.write16(messagePointer + 8, data.size()); // Number of bytes read
+	mem.write16(messagePointer + 8, u16(data.size())); // Number of bytes read
 }
 
 void DSPService::recvData(u32 messagePointer) {

--- a/src/core/services/fs.cpp
+++ b/src/core/services/fs.cpp
@@ -219,7 +219,7 @@ void FSService::openArchive(u32 messagePointer) {
 }
 
 void FSService::openFile(u32 messagePointer) {
-	const Handle archiveHandle = mem.read64(messagePointer + 8);
+	const Handle archiveHandle = Handle(mem.read64(messagePointer + 8));
 	const u32 filePathType = mem.read32(messagePointer + 16);
 	const u32 filePathSize = mem.read32(messagePointer + 20);
 	const u32 openFlags = mem.read32(messagePointer + 24);
@@ -342,7 +342,7 @@ void FSService::openFileDirectly(u32 messagePointer) {
 }
 
 void FSService::createFile(u32 messagePointer) {
-	const Handle archiveHandle = mem.read64(messagePointer + 8);
+	const Handle archiveHandle = Handle(mem.read64(messagePointer + 8));
 	const u32 filePathType = mem.read32(messagePointer + 16);
 	const u32 filePathSize = mem.read32(messagePointer + 20);
 	const u32 attributes = mem.read32(messagePointer + 24);
@@ -367,7 +367,7 @@ void FSService::createFile(u32 messagePointer) {
 }
 
 void FSService::deleteFile(u32 messagePointer) {
-	const Handle archiveHandle = mem.read64(messagePointer + 8);
+	const Handle archiveHandle = Handle(mem.read64(messagePointer + 8));
 	const u32 filePathType = mem.read32(messagePointer + 16);
 	const u32 filePathSize = mem.read32(messagePointer + 20);
 	const u32 filePathPointer = mem.read32(messagePointer + 28);
@@ -478,7 +478,7 @@ void FSService::formatThisUserSaveData(u32 messagePointer) {
 }
 
 void FSService::controlArchive(u32 messagePointer) {
-	const Handle archiveHandle = mem.read64(messagePointer + 4);
+	const Handle archiveHandle = Handle(mem.read64(messagePointer + 4));
 	const u32 action = mem.read32(messagePointer + 12);
 	const u32 inputSize = mem.read32(messagePointer + 16);
 	const u32 outputSize = mem.read32(messagePointer + 20);


### PR DESCRIPTION
Just some janitorial stuff involving implicit casting from int/float types into smaller-types(lossy casting).

Particularly all of the [C4267](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4267?view=msvc-170) and [C4244](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244?view=msvc-170) warnings.