### PR TITLE
Add OpenGL object-naming and scoping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ endif()
 project(Alber)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
+option(GPU_DEBUG_INFO "Enable additional GPU debugging info" OFF)
+
 include_directories(${PROJECT_SOURCE_DIR}/include/)
 include_directories(${PROJECT_SOURCE_DIR}/include/kernel)
 include_directories (${FMT_INCLUDE_DIR})
@@ -139,3 +141,8 @@ source_group("Source Files\\Third Party" FILES ${THIRD_PARTY_SOURCE_FILES})
 add_executable(Alber ${SOURCE_FILES} ${FS_SOURCE_FILES} ${KERNEL_SOURCE_FILES} ${LOADER_SOURCE_FILES} ${SERVICE_SOURCE_FILES}
 ${PICA_SOURCE_FILES} ${RENDERER_GL_SOURCE_FILES} ${THIRD_PARTY_SOURCE_FILES} ${HEADER_FILES})
 target_link_libraries(Alber PRIVATE dynarmic SDL2-static glad)
+
+
+if(GPU_DEBUG_INFO)
+  target_compile_definitions(Alber PRIVATE GPU_DEBUG_INFO=1)
+endif()

--- a/include/opengl.hpp
+++ b/include/opengl.hpp
@@ -73,6 +73,26 @@ namespace OpenGL {
 		glObjectLabel(identifier, name, length, label);
 	}
 
+    class DebugScope {
+		inline static GLuint scopeDepth = 0;
+		const GLuint m_scope_depth;
+
+	  public:
+		OPENGL_PRINTF_FORMAT_ATTR(2, 3)
+		DebugScope(OPENGL_PRINTF_FORMAT const char* format, ...) : m_scope_depth(scopeDepth++) {
+			GLchar message[256] = {};
+			va_list args;
+			va_start(args, format);
+			const GLsizei length = vsnprintf(message, std::size(message), format, args);
+			va_end(args);
+			glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, m_scope_depth, length, message);
+		}
+		~DebugScope() {
+			glPopDebugGroup();
+			scopeDepth--;
+		}
+	};
+
     struct VertexArray {
         GLuint m_handle = 0;
 

--- a/include/opengl.hpp
+++ b/include/opengl.hpp
@@ -20,6 +20,7 @@
 #pragma once
 #include <array>
 #include <cassert>
+#include <cstdarg>
 #include <functional>
 #include <initializer_list>
 #include <iostream>
@@ -43,6 +44,15 @@
 #include <span>
 #endif
 
+#ifdef _MSC_VER
+#include <sal.h> 
+#define OPENGL_PRINTF_FORMAT _Printf_format_string_
+#define OPENGL_PRINTF_FORMAT_ATTR(format_arg_index, dots_arg_index)
+#else
+#define OPENGL_PRINTF_FORMAT
+#define OPENGL_PRINTF_FORMAT_ATTR(format_arg_index, dots_arg_index) __attribute__((__format__(__printf__, format_arg_index, dots_arg_index)))
+#endif
+
 // Uncomment the following define if you want GL objects to automatically free themselves when their lifetime ends
 // #define OPENGL_DESTRUCTORS
 
@@ -52,6 +62,16 @@ namespace OpenGL {
     // https://stackoverflow.com/questions/53945490/how-to-assert-that-a-constexpr-if-else-clause-never-happen
     template <class...>
     constexpr std::false_type AlwaysFalse{};
+
+    OPENGL_PRINTF_FORMAT_ATTR(3, 4)
+	static void setObjectLabel(GLenum identifier, GLuint name, OPENGL_PRINTF_FORMAT const char* format, ...) {
+		GLchar label[256] = {};
+		va_list args;
+		va_start(args, format);
+		const GLsizei length = vsnprintf(label, std::size(label), format, args);
+		va_end(args);
+		glObjectLabel(identifier, name, length, label);
+	}
 
     struct VertexArray {
         GLuint m_handle = 0;

--- a/include/opengl.hpp
+++ b/include/opengl.hpp
@@ -44,6 +44,10 @@
 #include <span>
 #endif
 
+#if defined(GPU_DEBUG_INFO)
+#define OPENGL_DEBUG_INFO
+#endif
+
 #ifdef _MSC_VER
 #include <sal.h> 
 #define OPENGL_PRINTF_FORMAT _Printf_format_string_
@@ -63,23 +67,29 @@ namespace OpenGL {
     template <class...>
     constexpr std::false_type AlwaysFalse{};
 
-    OPENGL_PRINTF_FORMAT_ATTR(3, 4)
+	OPENGL_PRINTF_FORMAT_ATTR(3, 4)
 	static void setObjectLabel(GLenum identifier, GLuint name, OPENGL_PRINTF_FORMAT const char* format, ...) {
+#if defined(OPENGL_DEBUG_INFO)
 		GLchar label[256] = {};
 		va_list args;
 		va_start(args, format);
 		const GLsizei length = vsnprintf(label, std::size(label), format, args);
 		va_end(args);
 		glObjectLabel(identifier, name, length, label);
+#endif
 	}
 
-    class DebugScope {
+	class DebugScope {
+#if defined(OPENGL_DEBUG_INFO)
 		inline static GLuint scopeDepth = 0;
 		const GLuint m_scope_depth;
+#endif
 
 	  public:
 		OPENGL_PRINTF_FORMAT_ATTR(2, 3)
-		DebugScope(OPENGL_PRINTF_FORMAT const char* format, ...) : m_scope_depth(scopeDepth++) {
+		DebugScope(OPENGL_PRINTF_FORMAT const char* format, ...)
+#if defined(OPENGL_DEBUG_INFO)
+			: m_scope_depth(scopeDepth++) {
 			GLchar message[256] = {};
 			va_list args;
 			va_start(args, format);
@@ -87,13 +97,20 @@ namespace OpenGL {
 			va_end(args);
 			glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, m_scope_depth, length, message);
 		}
+#else
+		{
+		}
+#endif
+
 		~DebugScope() {
+#if defined(OPENGL_DEBUG_INFO)
 			glPopDebugGroup();
 			scopeDepth--;
+#endif
 		}
 	};
 
-    struct VertexArray {
+	struct VertexArray {
         GLuint m_handle = 0;
 
         void create() {


### PR DESCRIPTION
Adds `OpenGL::setObjectLabel` and `OpenGL::DebugScope` for naming OpenGL-objects and grouping scopes of commands to help with debugging and captures.

Both support printf-style formatting and use the appropriate function-attributes and will emit warnings if the specifiers and type do not match up. `OpenGL::DebugScope` is a raii-based wrapper around `gl{Push,Pop}DebugGroup` allowing one to simple create a `OpenGL::DebugScope` object with the formatted name and it will automatically Push/Pop the scope.

![qrenderdoc_01pq6Nw2Rq](https://github.com/wheremyfoodat/Panda3DS/assets/644247/afc6dfb4-eb5a-4033-9b93-69e974691c62)

This is just the utility functions, I'll let the actual naming/scoping come later.
