### PR TITLE
Add slash to CLion build folders' .gitignore line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 
 #Clion Files
 .idea/
-cmake-build-*
+cmake-build-*/
 
 Debug/
 Release/


### PR DESCRIPTION
Makes it extra :sparkles: reliable :sparkles: