### PR TITLE
config: Use `error_code` prototype of `filesystem::exists`

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -11,7 +11,8 @@
 
 void EmulatorConfig::load(const std::filesystem::path& path) {
 	// If the configuration file does not exist, create it and return
-	if (!std::filesystem::exists(path)) {
+	std::error_code error;
+	if (!std::filesystem::exists(path, error)) {
 		save(path);
 		return;
 	}
@@ -38,13 +39,19 @@ void EmulatorConfig::load(const std::filesystem::path& path) {
 void EmulatorConfig::save(const std::filesystem::path& path) {
 	toml::basic_value<toml::preserve_comments> data;
 
-	if (std::filesystem::exists(path)) {
+	std::error_code error;
+	if (std::filesystem::exists(path, error)) {
 		try {
 			data = toml::parse<toml::preserve_comments>(path);
 		} catch (std::exception& ex) {
-			Helpers::warn("Got exception trying to save config file. Exception: %s\n", ex.what());
+			Helpers::warn("Exception trying to parse config file. Exception: %s\n", ex.what());
 			return;
 		}
+	} else {
+		if (error) {
+			Helpers::warn("FileSystem error accessing %s %s\n", path.string().c_str(), error.message().c_str());
+		}
+		Helpers::warn("Saving new configuration file %s \n", path.string().c_str());
 	}
 
 	data["GPU"]["EnableShaderJIT"] = shaderJitEnabled;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -49,9 +49,9 @@ void EmulatorConfig::save(const std::filesystem::path& path) {
 		}
 	} else {
 		if (error) {
-			Helpers::warn("FileSystem error accessing %s %s\n", path.string().c_str(), error.message().c_str());
+			Helpers::warn("Filesystem error accessing %s (error: %s)\n", path.string().c_str(), error.message().c_str());
 		}
-		Helpers::warn("Saving new configuration file %s \n", path.string().c_str());
+		printf("Saving new configuration file %s\n", path.string().c_str());
 	}
 
 	data["GPU"]["EnableShaderJIT"] = shaderJitEnabled;


### PR DESCRIPTION
The non-error-code version of these functions are susceptible to throwing an exception in the case of system errors like permission issues or underlying device errors.