### PR TITLE
Disable compilation of SDL tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ add_compile_definitions(SDL_MAIN_HANDLED)
 
 set(SDL_STATIC ON CACHE BOOL "" FORCE)
 set(SDL_SHARED OFF CACHE BOOL "" FORCE)
+set(SDL_TEST OFF CACHE BOOL "" FORCE)
 add_subdirectory(third_party/SDL2)
 add_subdirectory(third_party/glad)
 add_subdirectory(third_party/toml11)


### PR DESCRIPTION
Speed up our compilation by about 20 files by removing the need to compile all of SDL's test suite.