### PR TITLE
Move `stb_image_write` into its own translation unit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ endif()
 
 set(SOURCE_FILES src/main.cpp src/emulator.cpp src/io_file.cpp src/gl_state.cpp src/config.cpp
                  src/core/CPU/cpu_dynarmic.cpp src/core/CPU/dynarmic_cycles.cpp src/core/memory.cpp
-                 src/httpserver.cpp
+                 src/httpserver.cpp src/stb_image_write.c
 )
 set(CRYPTO_SOURCE_FILES src/core/crypto/aes_engine.cpp)
 set(KERNEL_SOURCE_FILES src/core/kernel/kernel.cpp src/core/kernel/resource_limits.cpp

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -1,5 +1,5 @@
 #include "emulator.hpp"
-#define STB_IMAGE_WRITE_IMPLEMENTATION
+
 #include <stb_image_write.h>
 
 #ifdef _WIN32

--- a/src/stb_image_write.c
+++ b/src/stb_image_write.c
@@ -1,0 +1,2 @@
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include <stb_image_write.h>


### PR DESCRIPTION
Rather than having the entire implementation within `emulator.cpp`, causing incremental builds to be much slower, give it its own translation unit `stb_image_write.c`.