### PR TITLE
SW renderer infrastructure

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "third_party/cmrc"]
 	path = third_party/cmrc
 	url = https://github.com/vector-of-bool/cmrc
+[submodule "third_party/glm"]
+	path = third_party/glm
+	url = https://github.com/g-truc/glm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ target_include_directories(boost SYSTEM INTERFACE ${Boost_INCLUDE_DIR})
 
 set(CRYPTOPP_BUILD_TESTING OFF)
 add_subdirectory(third_party/cryptopp)
+add_subdirectory(third_party/glad)
 
 # Check for x64
 if (CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "x86-64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
@@ -178,8 +179,6 @@ source_group("Source Files\\Third Party" FILES ${THIRD_PARTY_SOURCE_FILES})
 set(RENDERER_GL_SOURCE_FILES "") # Empty by default unless we are compiling with the GL renderer
 
 if(ENABLE_OPENGL)
-	add_subdirectory(third_party/glad)
-
 	set(RENDERER_GL_INCLUDE_FILES include/renderer_gl/opengl.hpp
 		include/renderer_gl/renderer_gl.hpp include/renderer_gl/textures.hpp
 		include/renderer_gl/surfaces.hpp include/renderer_gl/surface_cache.hpp
@@ -222,11 +221,11 @@ if(ENABLE_LTO OR ENABLE_USER_BUILD)
   set_target_properties(Alber PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
 endif()
 
-target_link_libraries(Alber PRIVATE dynarmic SDL2-static cryptopp)
+target_link_libraries(Alber PRIVATE dynarmic SDL2-static cryptopp glad)
 
 if(ENABLE_OPENGL)
     target_compile_definitions(Alber PUBLIC "PANDA3DS_ENABLE_OPENGL=1")
-    target_link_libraries(Alber PRIVATE glad resources_renderer_gl)
+    target_link_libraries(Alber PRIVATE resources_renderer_gl)
 endif()
 
 if(GPU_DEBUG_INFO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,8 @@ set(FS_SOURCE_FILES src/core/fs/archive_self_ncch.cpp src/core/fs/archive_save_d
                     src/core/fs/archive_ext_save_data.cpp src/core/fs/archive_ncch.cpp
 )
 
+set(RENDERER_SW_SOURCE_FILES src/core/renderer_sw/renderer_sw.cpp)
+
 set(HEADER_FILES include/emulator.hpp include/helpers.hpp include/termcolor.hpp
                  include/cpu.hpp include/cpu_dynarmic.hpp include/memory.hpp include/renderer.hpp include/kernel/kernel.hpp
                  include/dynarmic_cp15.hpp include/kernel/resource_limits.hpp include/kernel/kernel_types.hpp
@@ -150,7 +152,7 @@ set(HEADER_FILES include/emulator.hpp include/helpers.hpp include/termcolor.hpp
                  include/result/result_gsp.hpp include/result/result_kernel.hpp include/result/result_os.hpp
                  include/crypto/aes_engine.hpp include/metaprogramming.hpp include/PICA/pica_vertex.hpp
                  include/config.hpp include/services/ir_user.hpp include/httpserver.hpp include/cheats.hpp
-                 include/action_replay.hpp
+                 include/action_replay.hpp include/renderer_sw/renderer_sw.hpp
 )
 
 set(THIRD_PARTY_SOURCE_FILES third_party/imgui/imgui.cpp
@@ -169,6 +171,7 @@ source_group("Source Files\\Core\\Kernel" FILES ${KERNEL_SOURCE_FILES})
 source_group("Source Files\\Core\\Loader" FILES ${LOADER_SOURCE_FILES})
 source_group("Source Files\\Core\\Services" FILES ${SERVICE_SOURCE_FILES})
 source_group("Source Files\\Core\\PICA" FILES ${PICA_SOURCE_FILES})
+source_group("Source Files\\Core\\Software Renderer" FILES ${RENDERER_SW_SOURCE_FILES})
 source_group("Source Files\\Third Party" FILES ${THIRD_PARTY_SOURCE_FILES})
 
 set(RENDERER_GL_SOURCE_FILES "") # Empty by default unless we are compiling with the GL renderer
@@ -205,7 +208,7 @@ endif()
 
 source_group("Header Files\\Core" FILES ${HEADER_FILES})
 set(ALL_SOURCES ${SOURCE_FILES} ${FS_SOURCE_FILES} ${CRYPTO_SOURCE_FILES} ${KERNEL_SOURCE_FILES} ${LOADER_SOURCE_FILES} ${SERVICE_SOURCE_FILES}
-	${PICA_SOURCE_FILES} ${THIRD_PARTY_SOURCE_FILES} ${HEADER_FILES})
+	${RENDERER_SW_SOURCE_FILES} ${PICA_SOURCE_FILES} ${THIRD_PARTY_SOURCE_FILES} ${HEADER_FILES})
 
 if(ENABLE_OPENGL)
     # Add the OpenGL source files to ALL_SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ add_subdirectory(third_party/SDL2)
 add_subdirectory(third_party/toml11)
 include_directories(${SDL2_INCLUDE_DIR})
 include_directories(third_party/toml11)
+include_directories(third_party/glm)
 
 add_subdirectory(third_party/cmrc)
 

--- a/include/renderer.hpp
+++ b/include/renderer.hpp
@@ -12,6 +12,7 @@ enum class RendererType : s8 {
 	Null = 0,
 	OpenGL = 1,
 	Vulkan = 2,
+	Software = 3,
 };
 
 class GPU;

--- a/include/renderer_sw/renderer_sw.hpp
+++ b/include/renderer_sw/renderer_sw.hpp
@@ -1,0 +1,17 @@
+#include "renderer.hpp"
+
+class GPU;
+
+class RendererSw final : public Renderer {
+  public:
+	RendererSw(GPU& gpu, const std::array<u32, regNum>& internalRegs);
+	~RendererSw() override;
+
+	void reset() override;
+	void display() override;
+	void initGraphicsContext() override;
+	void clearBuffer(u32 startAddress, u32 endAddress, u32 value, u32 control) override;
+	void displayTransfer(u32 inputAddr, u32 outputAddr, u32 inputSize, u32 outputSize, u32 flags) override;
+	void drawVertices(PICA::PrimType primType, std::span<const PICA::Vertex> vertices) override;
+	void screenshot(const std::string& name) override;
+};

--- a/src/core/PICA/gpu.cpp
+++ b/src/core/PICA/gpu.cpp
@@ -8,6 +8,7 @@
 #include "PICA/float_types.hpp"
 #include "PICA/regs.hpp"
 #include "renderer_null/renderer_null.hpp"
+#include "renderer_sw/renderer_sw.hpp"
 #ifdef PANDA3DS_ENABLE_OPENGL
 #include "renderer_gl/renderer_gl.hpp"
 #endif
@@ -25,6 +26,12 @@ GPU::GPU(Memory& mem, EmulatorConfig& config) : mem(mem), config(config) {
 			renderer.reset(new RendererNull(*this, regs));
 			break;
 		}
+
+		case RendererType::Software: {
+			renderer.reset(new RendererSw(*this, regs));
+			break;
+		}
+
 #ifdef PANDA3DS_ENABLE_OPENGL
 		case RendererType::OpenGL: {
 			renderer.reset(new RendererGL(*this, regs));

--- a/src/core/renderer_sw/renderer_sw.cpp
+++ b/src/core/renderer_sw/renderer_sw.cpp
@@ -1,0 +1,20 @@
+#include "renderer_sw/renderer_sw.hpp"
+
+RendererSw::RendererSw(GPU& gpu, const std::array<u32, regNum>& internalRegs) : Renderer(gpu, internalRegs) {}
+RendererSw::~RendererSw() {}
+
+void RendererSw::reset() { printf("RendererSW: Unimplemented reset call\n"); }
+void RendererSw::display() { printf("RendererSW: Unimplemented display call\n"); }
+
+void RendererSw::initGraphicsContext() { printf("RendererSW: Unimplemented initGraphicsContext call\n"); }
+void RendererSw::clearBuffer(u32 startAddress, u32 endAddress, u32 value, u32 control) { printf("RendererSW: Unimplemented clearBuffer call\n"); }
+
+void RendererSw::displayTransfer(u32 inputAddr, u32 outputAddr, u32 inputSize, u32 outputSize, u32 flags) {
+	printf("RendererSW: Unimplemented displayTransfer call\n");
+}
+
+void RendererSw::drawVertices(PICA::PrimType primType, std::span<const PICA::Vertex> vertices) {
+	printf("RendererSW: Unimplemented drawVertices call\n");
+}
+
+void RendererSw::screenshot(const std::string& name) { printf("RendererSW: Unimplemented screenshot call\n"); }

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -13,9 +13,11 @@ std::optional<RendererType> Renderer::typeFromString(std::string inString) {
 	// Huge table of possible names and misspellings
 	// Please stop misspelling Vulkan as Vulcan
 	static const std::unordered_map<std::string, RendererType> map = {
-		{"null", RendererType::Null}, {"nil", RendererType::Null},      {"none", RendererType::Null},
-		{"gl", RendererType::OpenGL}, {"ogl", RendererType::OpenGL},    {"opengl", RendererType::OpenGL},
-		{"vk", RendererType::Vulkan}, {"vulkan", RendererType::Vulkan}, {"vulcan", RendererType::Vulkan},
+		{"null", RendererType::Null},         {"nil", RendererType::Null},      {"none", RendererType::Null},
+		{"gl", RendererType::OpenGL},         {"ogl", RendererType::OpenGL},    {"opengl", RendererType::OpenGL},
+		{"vk", RendererType::Vulkan},         {"vulkan", RendererType::Vulkan}, {"vulcan", RendererType::Vulkan},
+		{"sw", RendererType::Software},       {"soft", RendererType::Software}, {"software", RendererType::Software},
+		{"softrast", RendererType::Software},
 	};
 
 	if (auto search = map.find(inString); search != map.end()) {
@@ -30,6 +32,7 @@ const char* Renderer::typeToString(RendererType rendererType) {
 		case RendererType::Null: return "null";
 		case RendererType::OpenGL: return "opengl";
 		case RendererType::Vulkan: return "vulkan";
+		case RendererType::Software: return "software";
 		default: return "Invalid";
 	}
 }


### PR DESCRIPTION
Adds an empty sw renderer backend properly hooked to the frontend and config file + a glm submodule for vector and quaternion math