### PR TITLE
Refactor http server

### DIFF
--- a/include/emulator.hpp
+++ b/include/emulator.hpp
@@ -63,6 +63,7 @@ class Emulator {
 
 #ifdef PANDA3DS_ENABLE_HTTP_SERVER
 	HttpServer httpServer;
+	friend class HttpServer;
 #endif
 
 	// Keep the handle for the ROM here to reload when necessary and to prevent deleting it
@@ -93,8 +94,4 @@ class Emulator {
 	bool loadELF(const std::filesystem::path& path);
 	bool loadELF(std::ifstream& file);
 	void initGraphicsContext();
-
-#ifdef PANDA3DS_ENABLE_HTTP_SERVER
-	void pollHttpServer();
-#endif
 };

--- a/include/httpserver.hpp
+++ b/include/httpserver.hpp
@@ -18,7 +18,7 @@ class Emulator;
 namespace httplib {
 	class Server;
 	class Response;
-}  // namespace httplib
+}
 
 // Wrapper for httplib::Response that allows the HTTP server to wait for the response to be ready
 struct DeferredResponseWrapper {
@@ -32,6 +32,8 @@ struct DeferredResponseWrapper {
 
 // Actions derive from this class and are used to communicate with the HTTP server
 class HttpAction {
+	HttpActionType type;
+
   public:
 	HttpAction(HttpActionType type) : type(type) {}
 	virtual ~HttpAction() = default;
@@ -40,22 +42,17 @@ class HttpAction {
 
 	static std::unique_ptr<HttpAction> createScreenshotAction(DeferredResponseWrapper& response);
 	static std::unique_ptr<HttpAction> createKeyAction(uint32_t key, bool state);
-
-  private:
-	HttpActionType type;
 };
 
 struct HttpServer {
 	HttpServer(Emulator* emulator);
 	~HttpServer();
-
 	void processActions();
 
   private:
 	static constexpr const char* httpServerScreenshotPath = "screenshot.png";
 
 	Emulator* emulator;
-
 	std::unique_ptr<httplib::Server> server;
 
 	std::thread httpServerThread;

--- a/include/services/hid.hpp
+++ b/include/services/hid.hpp
@@ -90,11 +90,10 @@ class HIDService {
 
 	void pressKey(u32 mask) { newButtons |= mask; }
 	void releaseKey(u32 mask) { newButtons &= ~mask; }
-	bool isPressed(u32 mask) { return (oldButtons & mask) != 0; }
 
-	u32 getOldButtons() { return oldButtons; }
-	s16 getCirclepadX() { return circlePadX; }
-	s16 getCirclepadY() { return circlePadY; }
+	u32 getOldButtons() const { return oldButtons; }
+	s16 getCirclepadX() const { return circlePadX; }
+	s16 getCirclepadY() const { return circlePadY; }
 
 	void setCirclepadX(s16 x) {
 		circlePadX = x;

--- a/include/services/hid.hpp
+++ b/include/services/hid.hpp
@@ -90,6 +90,7 @@ class HIDService {
 
 	void pressKey(u32 mask) { newButtons |= mask; }
 	void releaseKey(u32 mask) { newButtons &= ~mask; }
+	bool isPressed(u32 mask) { return (oldButtons & mask) != 0; }
 
 	u32 getOldButtons() { return oldButtons; }
 	s16 getCirclepadX() { return circlePadX; }

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -2,131 +2,186 @@
 #include "httpserver.hpp"
 
 #include <fstream>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <vector>
-#include <sstream>
 
+#include "emulator.hpp"
 #include "httplib.h"
-#include "services/hid.hpp"
 
-HttpServer::HttpServer() : keyMap(
-	{
-		{"A", { HID::Keys::A, false } },
-		{"B", { HID::Keys::B, false } },
-		{"Select", { HID::Keys::Select, false } },
-		{"Start", { HID::Keys::Start, false } },
-		{"Right", { HID::Keys::Right, false } },
-		{"Left", { HID::Keys::Left, false } },
-		{"Up", { HID::Keys::Up, false } },
-		{"Down", { HID::Keys::Down, false } },
-		{"R", { HID::Keys::R, false } },
-		{"L", { HID::Keys::L, false } },
-		{"X", { HID::Keys::X, false } },
-		{"Y", { HID::Keys::Y, false } },
+class HttpActionScreenshot : public HttpAction {
+  public:
+	HttpActionScreenshot(DeferredResponseWrapper& response) : HttpAction(HttpActionType::Screenshot), response(response) {}
+
+	DeferredResponseWrapper& getResponse() { return response; }
+
+  private:
+	DeferredResponseWrapper& response;
+};
+
+class HttpActionKey : public HttpAction {
+  public:
+	HttpActionKey(uint32_t key, bool state) : HttpAction(HttpActionType::Key), key(key), state(state) {}
+
+	uint32_t getKey() const { return key; }
+	bool getState() const { return state; }
+
+  private:
+	uint32_t key;
+	bool state;
+};
+
+std::unique_ptr<HttpAction> HttpAction::createScreenshotAction(DeferredResponseWrapper& response) {
+	return std::make_unique<HttpActionScreenshot>(response);
+}
+
+std::unique_ptr<HttpAction> HttpAction::createKeyAction(uint32_t key, bool state) { return std::make_unique<HttpActionKey>(key, state); }
+
+HttpServer::HttpServer(Emulator* emulator)
+	: emulator(emulator), server(std::make_unique<httplib::Server>()), keyMap({
+																		   {"A", {HID::Keys::A}},
+																		   {"B", {HID::Keys::B}},
+																		   {"Select", {HID::Keys::Select}},
+																		   {"Start", {HID::Keys::Start}},
+																		   {"Right", {HID::Keys::Right}},
+																		   {"Left", {HID::Keys::Left}},
+																		   {"Up", {HID::Keys::Up}},
+																		   {"Down", {HID::Keys::Down}},
+																		   {"R", {HID::Keys::R}},
+																		   {"L", {HID::Keys::L}},
+																		   {"X", {HID::Keys::X}},
+																		   {"Y", {HID::Keys::Y}},
+																	   }) {
+	httpServerThread = std::thread(&HttpServer::startHttpServer, this);
+}
+
+HttpServer::~HttpServer() {
+	printf("Stopping http server...\n");
+	server->stop();
+	if (httpServerThread.joinable()) {
+		httpServerThread.join();
 	}
-) {}
+}
+
+void HttpServer::pushAction(std::unique_ptr<HttpAction> action) {
+	std::scoped_lock lock(actionQueueMutex);
+	actionQueue.push(std::move(action));
+}
 
 void HttpServer::startHttpServer() {
-	std::thread http_thread([this]() {
-		httplib::Server server;
+	server->Get("/ping", [](const httplib::Request&, httplib::Response& response) { response.set_content("pong", "text/plain"); });
 
-		server.Get("/ping", [](const httplib::Request&, httplib::Response& response) { response.set_content("pong", "text/plain"); });
-
-		server.Get("/screen", [this](const httplib::Request&, httplib::Response& response) {
-			{
-				std::scoped_lock lock(actionMutex);
-				pendingAction = true;
-				action = HttpAction::Screenshot;
-			}
-			// wait until the screenshot is ready
-			pendingAction.wait(true);
-			std::ifstream image(httpServerScreenshotPath, std::ios::binary);
-			std::vector<char> buffer(std::istreambuf_iterator<char>(image), {});
-			response.set_content(buffer.data(), buffer.size(), "image/png");
-		});
-
-		server.Get("/input", [this](const httplib::Request& request, httplib::Response& response) {
-			bool ok = false;
-			for (auto& [keyStr, value] : request.params) {
-				auto key = stringToKey(keyStr);
-				printf("Param: %s\n", keyStr.c_str());
-
-				if (key != 0) {
-					std::scoped_lock lock(actionMutex);
-					pendingAction = true;
-					pendingKey = key;
-					ok = true;
-					if (value == "1") {
-						action = HttpAction::PressKey;
-						setKeyState(keyStr, true);
-					} else if (value == "0") {
-						action = HttpAction::ReleaseKey;
-						setKeyState(keyStr, false);
-					} else {
-						// Should not happen but just in case
-						pendingAction = false;
-						ok = false;
-					}
-					// Not supporting multiple keys at once for now (ever?)
-					break;
-				}
-			}
-
-			if (ok) {
-				response.set_content("ok", "text/plain");
-			}
-		});
-
-		server.Get("/step", [this](const httplib::Request&, httplib::Response& response) {
-			// TODO: implement /step
-			response.set_content("ok", "text/plain");
-		});
-
-		server.Get("/status", [this](const httplib::Request&, httplib::Response& response) {
-			response.set_content(status(), "text/plain");
-		});
-
-		// TODO: ability to specify host and port
-		printf("Starting HTTP server on port 1234\n");
-		server.listen("localhost", 1234);
+	server->Get("/screen", [this](const httplib::Request&, httplib::Response& response) {
+		DeferredResponseWrapper wrapper(response);
+		// Lock the mutex before pushing the action to ensure that the condition variable is not notified before we wait on it
+		std::unique_lock lock(wrapper.mutex);
+		pushAction(HttpAction::createScreenshotAction(wrapper));
+		wrapper.cv.wait(lock, [&wrapper] { return wrapper.ready; });
 	});
 
-	http_thread.detach();
+	server->Get("/input", [this](const httplib::Request& request, httplib::Response& response) {
+		bool ok = false;
+		for (auto& [keyStr, value] : request.params) {
+			u32 key = stringToKey(keyStr);
+
+			if (key != 0) {
+				bool state = value == "1";
+
+				if (!state && value != "0") {
+					// Invalid state
+					ok = false;
+					break;
+				}
+
+				pushAction(HttpAction::createKeyAction(key, state));
+				ok = true;
+			} else {
+				// Invalid key
+				ok = false;
+				break;
+			}
+		}
+
+		if (ok) {
+			response.set_content("ok", "text/plain");
+		} else {
+			response.set_content("error", "text/plain");
+		}
+	});
+
+	server->Get("/step", [this](const httplib::Request&, httplib::Response& response) {
+		// TODO: implement /step
+		response.set_content("ok", "text/plain");
+	});
+
+	server->Get("/status", [this](const httplib::Request&, httplib::Response& response) { response.set_content(status(), "text/plain"); });
+
+	// TODO: ability to specify host and port
+	printf("Starting HTTP server on port 1234\n");
+	server->listen("localhost", 1234);
 }
 
 std::string HttpServer::status() {
+	HIDService& hid = emulator->kernel.getServiceManager().getHID();
+
 	std::stringstream stringStream;
 
 	stringStream << "Panda3DS\n";
 	stringStream << "Status: " << (paused ? "Paused" : "Running") << "\n";
+
 	for (auto& [keyStr, value] : keyMap) {
-		stringStream << keyStr << ": " << value.second << "\n";
+		stringStream << keyStr << ": " << hid.isPressed(value) << "\n";
 	}
 
 	return stringStream.str();
 }
 
+void HttpServer::processActions() {
+	std::scoped_lock lock(actionQueueMutex);
+
+	HIDService& hid = emulator->kernel.getServiceManager().getHID();
+
+	while (!actionQueue.empty()) {
+		std::unique_ptr<HttpAction> action = std::move(actionQueue.front());
+		actionQueue.pop();
+
+		switch (action->getType()) {
+			case HttpActionType::Screenshot: {
+				HttpActionScreenshot* screenshotAction = static_cast<HttpActionScreenshot*>(action.get());
+				emulator->gpu.screenshot(httpServerScreenshotPath);
+				std::ifstream file(httpServerScreenshotPath, std::ios::binary);
+				std::vector<char> buffer(std::istreambuf_iterator<char>(file), {});
+
+				DeferredResponseWrapper& response = screenshotAction->getResponse();
+				response.inner_response.set_content(buffer.data(), buffer.size(), "image/png");
+				std::unique_lock<std::mutex> lock(response.mutex);
+				response.ready = true;
+				response.cv.notify_one();
+				break;
+			}
+			case HttpActionType::Key: {
+				HttpActionKey* keyAction = static_cast<HttpActionKey*>(action.get());
+				if (keyAction->getState()) {
+					hid.pressKey(keyAction->getKey());
+				} else {
+					hid.releaseKey(keyAction->getKey());
+				}
+				break;
+			}
+			default: {
+				break;
+			}
+		}
+	}
+}
+
 u32 HttpServer::stringToKey(const std::string& key_name) {
 	if (keyMap.find(key_name) != keyMap.end()) {
-		return keyMap[key_name].first;
+		return keyMap[key_name];
 	}
 
 	return 0;
-}
-
-bool HttpServer::getKeyState(const std::string& key_name) {
-	if (keyMap.find(key_name) != keyMap.end()) {
-		return keyMap[key_name].second;
-	}
-
-	return false;
-}
-
-void HttpServer::setKeyState(const std::string& key_name, bool state) {
-	if (keyMap.find(key_name) != keyMap.end()) {
-		keyMap[key_name].second = state;
-	}
 }
 
 #endif  // PANDA3DS_ENABLE_HTTP_SERVER


### PR DESCRIPTION
Improvements:

- Remove Emulator::pollHttpServer function as it did not belong inside Emulator, instead give HttpServer a pointer to emulator
- Create an HttpAction class which each type of action (more to be added) derives
- Instead of a single request, can now queue many requests in a (hopefully) thread safe queue and execute them whenever polled
- Use RAII for starting and stopping the server
- Cleaner HttpServer class overall
- Added function that checks if a button is pressed in hid.hpp