### PR TITLE
Remove logging overhead in user builds & update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,12 @@ fb.bat
 *.idb
 
 # 3DS files
+*.3ds
 *.3dsx
+*.app
+*.cci
+*.cxi
 *.elf
 *.smdh
+
+config.toml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ set(HEADER_FILES include/emulator.hpp include/helpers.hpp include/termcolor.hpp
                  include/result/result_gsp.hpp include/result/result_kernel.hpp include/result/result_os.hpp
                  include/crypto/aes_engine.hpp include/metaprogramming.hpp include/PICA/pica_vertex.hpp
                  include/config.hpp include/services/ir_user.hpp include/httpserver.hpp include/cheats.hpp
-                 include/action_replay.hpp include/renderer_sw/renderer_sw.hpp
+                 include/action_replay.hpp include/renderer_sw/renderer_sw.hpp include/compiler_builtins.hpp
 )
 
 set(THIRD_PARTY_SOURCE_FILES third_party/imgui/imgui.cpp

--- a/include/compiler_builtins.hpp
+++ b/include/compiler_builtins.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#ifdef _MSC_VER
+#define ALWAYS_INLINE __forceinline
+#else
+#define ALWAYS_INLINE __attribute__((always_inline))
+#endif

--- a/include/helpers.hpp
+++ b/include/helpers.hpp
@@ -155,4 +155,3 @@ namespace Helpers {
 constexpr size_t operator""_KB(unsigned long long int x) { return 1024ULL * x; }
 constexpr size_t operator""_MB(unsigned long long int x) { return 1024_KB * x; }
 constexpr size_t operator""_GB(unsigned long long int x) { return 1024_MB * x; }
-

--- a/include/kernel/kernel.hpp
+++ b/include/kernel/kernel.hpp
@@ -107,9 +107,9 @@ private:
 	MAKE_LOG_FUNCTION(log, kernelLogger)
 	MAKE_LOG_FUNCTION(logSVC, svcLogger)
 	MAKE_LOG_FUNCTION(logThread, threadLogger)
-	MAKE_LOG_FUNCTION(logDebugString, debugStringLogger)
 	MAKE_LOG_FUNCTION(logError, errorLogger)
 	MAKE_LOG_FUNCTION(logFileIO, fileIOLogger)
+	MAKE_LOG_FUNCTION_USER(logDebugString, debugStringLogger)
 
 	// SVC implementations
 	void arbitrateAddress();

--- a/include/logger.hpp
+++ b/include/logger.hpp
@@ -2,61 +2,78 @@
 #include <cstdarg>
 #include <fstream>
 
+#include "compiler_builtins.hpp"
+
 namespace Log {
-    // Our logger class
-    template <bool enabled>
-    class Logger {
-    public:
-        void log(const char* fmt, ...) {
-            if constexpr (!enabled) return;
-            
-            std::va_list args;
-            va_start(args, fmt);
-            std::vprintf(fmt, args);
-            va_end(args);
-        }
-    };
+	// Our logger class
+	template <bool enabled>
+	class Logger {
+	  public:
+		ALWAYS_INLINE void log(const char* fmt, ...) {
+			if constexpr (!enabled) return;
 
-    // Our loggers here. Enable/disable by toggling the template param
-    static Logger<false> kernelLogger;
-    static Logger<true> debugStringLogger; // Enables output for the outputDebugString SVC
-    static Logger<false> errorLogger;
-    static Logger<false> fileIOLogger;
-    static Logger<false> svcLogger;
-    static Logger<false> threadLogger;
-    static Logger<false> gpuLogger;
-    static Logger<false> rendererLogger;
-    static Logger<false> shaderJITLogger;
+			std::va_list args;
+			va_start(args, fmt);
+			std::vprintf(fmt, args);
+			va_end(args);
+		}
+	};
 
-    // Service loggers
-    static Logger<false> acLogger;
-    static Logger<false> actLogger;
-    static Logger<false> amLogger;
-    static Logger<false> aptLogger;
-    static Logger<false> bossLogger;
-    static Logger<false> camLogger;
-    static Logger<false> cecdLogger;
-    static Logger<false> cfgLogger;
-    static Logger<false> dspServiceLogger;
-    static Logger<false> dlpSrvrLogger;
-    static Logger<false> frdLogger;
-    static Logger<false> fsLogger;
-    static Logger<false> hidLogger;
+	// Our loggers here. Enable/disable by toggling the template param
+	static Logger<false> kernelLogger;
+	// Enables output for the outputDebugString SVC
+	static Logger<true> debugStringLogger;
+	static Logger<false> errorLogger;
+	static Logger<false> fileIOLogger;
+	static Logger<false> svcLogger;
+	static Logger<false> threadLogger;
+	static Logger<false> gpuLogger;
+	static Logger<false> rendererLogger;
+	static Logger<false> shaderJITLogger;
+
+	// Service loggers
+	static Logger<false> acLogger;
+	static Logger<false> actLogger;
+	static Logger<false> amLogger;
+	static Logger<false> aptLogger;
+	static Logger<false> bossLogger;
+	static Logger<false> camLogger;
+	static Logger<false> cecdLogger;
+	static Logger<false> cfgLogger;
+	static Logger<false> dspServiceLogger;
+	static Logger<false> dlpSrvrLogger;
+	static Logger<false> frdLogger;
+	static Logger<false> fsLogger;
+	static Logger<false> hidLogger;
 	static Logger<false> irUserLogger;
-    static Logger<false> gspGPULogger;
-    static Logger<false> gspLCDLogger;
-    static Logger<false> ldrLogger;
-    static Logger<false> micLogger;
-    static Logger<false> nfcLogger;
-    static Logger<false> nimLogger;
-    static Logger<false> ndmLogger;
-    static Logger<false> ptmLogger;
-    static Logger<false> y2rLogger;
-    static Logger<false> srvLogger;
+	static Logger<false> gspGPULogger;
+	static Logger<false> gspLCDLogger;
+	static Logger<false> ldrLogger;
+	static Logger<false> micLogger;
+	static Logger<false> nfcLogger;
+	static Logger<false> nimLogger;
+	static Logger<false> ndmLogger;
+	static Logger<false> ptmLogger;
+	static Logger<false> y2rLogger;
+	static Logger<false> srvLogger;
 
-    #define MAKE_LOG_FUNCTION(functionName, logger)      \
-    template <typename... Args>                          \
-    void functionName(const char* fmt, Args... args) {   \
-        Log::logger.log(fmt, args...);                   \
-    }
+	// We have 2 ways to create a log function
+	// MAKE_LOG_FUNCTION: Creates a log function which is toggleable but always killed for user-facing builds
+	// MAKE_LOG_FUNCTION_USER: Creates a log function which is toggleable, may be on for user builds as well
+	// We need this because sadly due to the loggers taking variadic arguments, compilers will not properly
+	// Kill them fully even when they're disabled. The only way they will is if the function with varargs is totally empty
+
+#define MAKE_LOG_FUNCTION_USER(functionName, logger)                   \
+	template <typename... Args>                                        \
+	ALWAYS_INLINE void functionName(const char* fmt, Args&&... args) { \
+		Log::logger.log(fmt, args...);                                 \
+	}
+
+#ifdef PANDA3DS_USER_BUILD
+#define MAKE_LOG_FUNCTION(functionName, logger) \
+	template <typename... Args>                 \
+	ALWAYS_INLINE void functionName(const char* fmt, Args&&... args) {}
+#else
+#define MAKE_LOG_FUNCTION(functionName, logger) MAKE_LOG_FUNCTION_USER(functionName, logger)
+#endif
 }


### PR DESCRIPTION
There used to be an "issue" with user builds where even if a logger is disabled at compile time, the compiler can't fully understand that due to being unable to inline non-trivial functions with variadic arguments. Thus, even for a disabled log call, the compiler would emit a call to a thunk function, which would then call the actual log function, which would then simply return.

This is fixed in this PR (in a way that I am not a huge fan of, but whatever) by making the log functions trivial and inlineable when compiling a user-facing build unless they are generated with `MAKE_LOG_FUNCTION_USER`.

This should remove this overhead from user-facing builds (it persists with dev builds, but it doesn't matter, really).
All of this research was performed on MSVC but I suspect similar things happen with the GNUC compilers.

Also updated the gitignore for Paris