### PR TITLE
Change shared memory remap panic to warning

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -394,7 +394,8 @@ MemoryInfo Memory::queryMemory(u32 vaddr) {
 u8* Memory::mapSharedMemory(Handle handle, u32 vaddr, u32 myPerms, u32 otherPerms) {
 	for (auto& e : sharedMemBlocks) {
 		if (e.handle == handle) {
-			if (e.mapped) Helpers::panic("Allocated shared memory block twice. Is this allowed?");
+			// Virtual Console titles trigger this. TODO: Investigate how it should work
+			if (e.mapped) Helpers::warn("Allocated shared memory block twice. Is this allowed?");
 
 			const u32 paddr = e.paddr;
 			const u32 size = e.size;


### PR DESCRIPTION
Gets Virtual Console titles to do things (Pokemon Crystal VC below)
![image](https://github.com/wheremyfoodat/Panda3DS/assets/44909372/27162a00-cbc6-48dc-aefa-921ca8038165)
