### PR TITLE
Add Discord RPC

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "third_party/glm"]
 	path = third_party/glm
 	url = https://github.com/g-truc/glm
+[submodule "third_party/discord-rpc"]
+	path = third_party/discord-rpc
+	url = https://github.com/discord/discord-rpc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
@@ -12,6 +12,10 @@ endif()
 
 project(Alber)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
+if(APPLE)
+    enable_language(OBJC)
+endif()
 
 if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-format-nonliteral -Wno-format-security")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ option(ENABLE_VULKAN "Enable Vulkan rendering backend" ON)
 option(ENABLE_LTO "Enable link-time optimization" OFF)
 option(ENABLE_USER_BUILD "Make a user-facing build. These builds have various assertions disabled, LTO, and more" OFF)
 option(ENABLE_HTTP_SERVER "Enable HTTP server. Used for Discord bot support" OFF)
+option(ENABLE_DISCORD_RPC "Compile with Discord RPC support (disabled by default)" ON)
 
 include_directories(${PROJECT_SOURCE_DIR}/include/)
 include_directories(${PROJECT_SOURCE_DIR}/include/kernel)
@@ -42,6 +43,11 @@ include_directories(third_party/stb)
 add_compile_definitions(NOMINMAX)             # Make windows.h not define min/max macros because third-party deps don't like it
 add_compile_definitions(WIN32_LEAN_AND_MEAN)  # Make windows.h not include literally everything
 add_compile_definitions(SDL_MAIN_HANDLED)
+
+if(ENABLE_DISCORD_RPC)
+    add_subdirectory(third_party/discord-rpc)
+    include_directories(third_party/discord-rpc/include)
+endif()
 
 set(SDL_STATIC ON CACHE BOOL "" FORCE)
 set(SDL_SHARED OFF CACHE BOOL "" FORCE)
@@ -255,6 +261,10 @@ if(ENABLE_LTO OR ENABLE_USER_BUILD)
 endif()
 
 target_link_libraries(Alber PRIVATE dynarmic SDL2-static cryptopp glad)
+
+if(ENABLE_DISCORD_RPC)
+    target_compile_definitions(Alber PUBLIC "PANDA3DS_ENABLE_DISCORD_RPC=1")
+endif()
 
 if(ENABLE_OPENGL)
     target_compile_definitions(Alber PUBLIC "PANDA3DS_ENABLE_OPENGL=1")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ set(SOURCE_FILES src/main.cpp src/emulator.cpp src/io_file.cpp src/config.cpp
 				 src/core/CPU/cpu_dynarmic.cpp src/core/CPU/dynarmic_cycles.cpp
 				 src/core/memory.cpp src/renderer.cpp src/core/renderer_null/renderer_null.cpp
 				 src/http_server.cpp src/stb_image_write.c src/core/cheats.cpp src/core/action_replay.cpp
+                 src/discord_rpc.cpp
 )
 set(CRYPTO_SOURCE_FILES src/core/crypto/aes_engine.cpp)
 set(KERNEL_SOURCE_FILES src/core/kernel/kernel.cpp src/core/kernel/resource_limits.cpp
@@ -163,7 +164,7 @@ set(HEADER_FILES include/emulator.hpp include/helpers.hpp include/termcolor.hpp
                  include/crypto/aes_engine.hpp include/metaprogramming.hpp include/PICA/pica_vertex.hpp
                  include/config.hpp include/services/ir_user.hpp include/http_server.hpp include/cheats.hpp
                  include/action_replay.hpp include/renderer_sw/renderer_sw.hpp include/compiler_builtins.hpp
-                 include/fs/romfs.hpp include/fs/ivfc.hpp
+                 include/fs/romfs.hpp include/fs/ivfc.hpp include/discord_rpc.hpp
 )
 
 set(THIRD_PARTY_SOURCE_FILES third_party/imgui/imgui.cpp
@@ -257,13 +258,14 @@ endif()
 add_executable(Alber ${ALL_SOURCES})
 
 if(ENABLE_LTO OR ENABLE_USER_BUILD)
-  set_target_properties(Alber PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
+    set_target_properties(Alber PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
 endif()
 
 target_link_libraries(Alber PRIVATE dynarmic SDL2-static cryptopp glad)
 
 if(ENABLE_DISCORD_RPC)
     target_compile_definitions(Alber PUBLIC "PANDA3DS_ENABLE_DISCORD_RPC=1")
+    target_link_libraries(Alber PRIVATE discord-rpc)
 endif()
 
 if(ENABLE_OPENGL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
-cmake_minimum_required(VERSION 3.16)
+# We need to be able to use enable_language(OBJC) on Mac, so we need CMake 3.16 vs the 3.10 we use otherwise. Blame Apple.
+if (APPLE)
+    cmake_minimum_required(VERSION 3.16)
+else()
+    cmake_minimum_required(VERSION 3.10)
+endif()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
@@ -7,7 +13,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION
 endif()
 
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
+    set(CMAKE_BUILD_TYPE Release)
 endif()
 
 project(Alber)

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -6,6 +6,7 @@
 // Remember to initialize every field here to its default value otherwise bad things will happen
 struct EmulatorConfig {
 	bool shaderJitEnabled = false;
+	bool discordRpcEnabled = false;
 	RendererType rendererType = RendererType::OpenGL;
 
 	EmulatorConfig(const std::filesystem::path& path);

--- a/include/discord_rpc.hpp
+++ b/include/discord_rpc.hpp
@@ -4,6 +4,7 @@
 #include <discord_rpc.h>
 
 #include <cstdint>
+#include <string>
 
 namespace Discord {
 	enum class RPCStatus { Idling, Playing };
@@ -14,7 +15,7 @@ namespace Discord {
 
 	  public:
 		void init();
-		void update(RPCStatus status);
+		void update(RPCStatus status, const std::string& title);
 		void stop();
 	};
 }  // namespace Discord

--- a/include/discord_rpc.hpp
+++ b/include/discord_rpc.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#ifdef PANDA3DS_ENABLE_DISCORD_RPC
+#include <discord_rpc.h>
+
+#include <cstdint>
+
+namespace Discord {
+	enum class RPCStatus { Idling, Playing };
+
+	class RPC {
+		std::uint64_t startTimestamp;
+		bool enabled = false;
+
+	  public:
+		void init();
+		void update(RPCStatus status);
+		void stop();
+	};
+}  // namespace Discord
+
+#endif

--- a/include/emulator.hpp
+++ b/include/emulator.hpp
@@ -67,8 +67,8 @@ class Emulator {
 
 #ifdef PANDA3DS_ENABLE_DISCORD_RPC
 	Discord::RPC discordRpc;
-	void updateDiscord();
 #endif
+	void updateDiscord();
 
 	// Keep the handle for the ROM here to reload when necessary and to prevent deleting it
 	// This is currently only used for ELFs, NCSDs use the IOFile API instead

--- a/include/emulator.hpp
+++ b/include/emulator.hpp
@@ -11,6 +11,7 @@
 #include "config.hpp"
 #include "cpu.hpp"
 #include "crypto/aes_engine.hpp"
+#include "discord_rpc.hpp"
 #include "io_file.hpp"
 #include "memory.hpp"
 
@@ -62,6 +63,11 @@ class Emulator {
 #ifdef PANDA3DS_ENABLE_HTTP_SERVER
 	HttpServer httpServer;
 	friend struct HttpServer;
+#endif
+
+#ifdef PANDA3DS_ENABLE_DISCORD_RPC
+	Discord::RPC discordRpc;
+	void updateDiscord();
 #endif
 
 	// Keep the handle for the ROM here to reload when necessary and to prevent deleting it

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -29,6 +29,15 @@ void EmulatorConfig::load(const std::filesystem::path& path) {
 		return;
 	}
 
+	if (data.contains("General")) {
+		auto generalResult = toml::expect<toml::value>(data.at("General"));
+		if (generalResult.is_ok()) {
+			auto general = generalResult.unwrap();
+
+			discordRpcEnabled = toml::find_or<toml::boolean>(general, "EnableDiscordRPC", false);
+		}
+	}
+
 	if (data.contains("GPU")) {
 		auto gpuResult = toml::expect<toml::value>(data.at("GPU"));
 		if (gpuResult.is_ok()) {
@@ -68,6 +77,7 @@ void EmulatorConfig::save(const std::filesystem::path& path) {
 		printf("Saving new configuration file %s\n", path.string().c_str());
 	}
 
+	data["General"]["EnableDiscordRPC"] = discordRpcEnabled;
 	data["GPU"]["EnableShaderJIT"] = shaderJitEnabled;
 	data["GPU"]["Renderer"] = std::string(Renderer::typeToString(rendererType));
 

--- a/src/discord_rpc.cpp
+++ b/src/discord_rpc.cpp
@@ -1,0 +1,37 @@
+#ifdef PANDA3DS_ENABLE_DISCORD_RPC
+
+#include "discord_rpc.hpp"
+
+#include <cstring>
+#include <ctime>
+
+void Discord::RPC::init() {
+	DiscordEventHandlers handlers{};
+	Discord_Initialize("1138176975865909360", &handlers, 1, nullptr);
+
+	startTimestamp = time(nullptr);
+	enabled = true;
+}
+
+void Discord::RPC::update(Discord::RPCStatus status) {
+	DiscordRichPresence rpc{};
+
+	rpc.details = "Panda";
+	rpc.state = "Petting a panda";
+
+	rpc.largeImageKey = "pand";
+	rpc.largeImageText = "Panda3DS is a 3DS emulator for Windows, MacOS and Linux";
+	rpc.startTimestamp = startTimestamp;
+
+	Discord_UpdatePresence(&rpc);
+}
+
+void Discord::RPC::stop() {
+	if (enabled) {
+		enabled = false;
+		Discord_ClearPresence();
+		Discord_Shutdown();
+	}
+}
+
+#endif

--- a/src/discord_rpc.cpp
+++ b/src/discord_rpc.cpp
@@ -13,11 +13,15 @@ void Discord::RPC::init() {
 	enabled = true;
 }
 
-void Discord::RPC::update(Discord::RPCStatus status) {
+void Discord::RPC::update(Discord::RPCStatus status, const std::string& game) {
 	DiscordRichPresence rpc{};
 
-	rpc.details = "Panda";
-	rpc.state = "Petting a panda";
+	if (status == Discord::RPCStatus::Playing) {
+		rpc.details = "Playing a game";
+		rpc.state = game.c_str();
+	} else {
+		rpc.details = "Idle";
+	}
 
 	rpc.largeImageKey = "pand";
 	rpc.largeImageText = "Panda3DS is a 3DS emulator for Windows, MacOS and Linux";


### PR DESCRIPTION
To address any potential privacy concerns
- Discord RPC is an opt-in feature that is off by default. You must turn it on yourself in the config file (or in the future GUI)
- If that is not enough, there is a CMake option for enabling/disabling whether RPC support should be compiled in at all

This is how the RPC looks in Discord
![image](https://github.com/wheremyfoodat/Panda3DS/assets/44909372/3a11b00e-e7e3-422c-8f88-0041755e8002)
