### PR TITLE
Render to texture fixes

### DIFF
--- a/include/renderer_gl/renderer_gl.hpp
+++ b/include/renderer_gl/renderer_gl.hpp
@@ -45,7 +45,7 @@ class RendererGL final : public Renderer {
 	bool oldDepthmapEnable = false;
 
 	SurfaceCache<DepthBuffer, 16, true> depthBufferCache;
-	SurfaceCache<ColourBuffer, 16, true> colourBufferCache;
+	SurfaceCache<ColourBuffer, 32, true> colourBufferCache;
 	SurfaceCache<Texture, 256, true> textureCache;
 
 	// Dummy VAO/VBO for blitting the final output

--- a/src/core/renderer_gl/renderer_gl.cpp
+++ b/src/core/renderer_gl/renderer_gl.cpp
@@ -321,6 +321,12 @@ void RendererGL::bindTexturesToSlots() {
 		u32 format = regs[ioBase + (i == 0 ? 13 : 5)] & 0xF;
 
 		glActiveTexture(GL_TEXTURE0 + i);
+		auto fb = getColourBuffer(addr, static_cast<PICA::ColorFmt>(format), width, height, false);
+		if (fb.has_value()) {
+			fb->texture.bind();
+			continue;
+		}
+
 		Texture targetTex(addr, static_cast<PICA::TextureFmt>(format), width, height, config);
 		OpenGL::Texture tex = getTexture(targetTex);
 		tex.bind();

--- a/src/core/renderer_gl/textures.cpp
+++ b/src/core/renderer_gl/textures.cpp
@@ -254,7 +254,7 @@ void Texture::decodeTexture(std::span<const u8> data) {
     // Decode texels line by line
     for (u32 v = 0; v < size.v(); v++) {
         for (u32 u = 0; u < size.u(); u++) {
-            u32 colour = decodeTexel(u, v, format, data);
+            u32 colour = decodeTexel(u, size.v() - v - 1, format, data);
             decoded.push_back(colour);
         }
     }

--- a/src/host_shaders/opengl_vertex_shader.vert
+++ b/src/host_shaders/opengl_vertex_shader.vert
@@ -67,9 +67,9 @@ void main() {
 	v_colour = a_vertexColour;
 
 	// Flip y axis of UVs because OpenGL uses an inverted y for texture sampling compared to the PICA
-	v_texcoord0 = vec3(a_texcoord0.x, 1.0 - a_texcoord0.y, a_texcoord0_w);
-	v_texcoord1 = vec2(a_texcoord1.x, 1.0 - a_texcoord1.y);
-	v_texcoord2 = vec2(a_texcoord2.x, 1.0 - a_texcoord2.y);
+        v_texcoord0 = vec3(a_texcoord0.x, a_texcoord0.y, a_texcoord0_w);
+        v_texcoord1 = vec2(a_texcoord1.x, a_texcoord1.y);
+        v_texcoord2 = vec2(a_texcoord2.x, a_texcoord2.y);
 	v_view = a_view;
 
 	v_normal = normalize(rotateVec3ByQuaternion(vec3(0.0, 0.0, 1.0), a_quaternion));


### PR DESCRIPTION
This addresses a couple of current issues when games perform render to texture tricks.

* When binding texture units we now check the colour buffer cache first, in case the game is trying to use a framebuffer
  as texture source. This is not an ideal solution; the proper way would be to merge the texture and colour buffer caches but
  that requires a more thought out invalidation scheme and this approach works for the majority of cases.

* At the moment textures are loaded normally and the texture coordinates are flipped in the vertex shader to account for the difference between opengl and pica texture coordinate origin. However this presents problems as the afformentioned framebuffers are not in pica origin, producing incorrect results. To address this textures are loaded flipped instead of flipping coordinates. With this Samus Returns render to texture effect is correct, position wise and the top screen is now blue
![samus](https://github.com/wheremyfoodat/Panda3DS/assets/47210458/e1c4645f-f974-4fcd-8879-325462f21f58)

* Bumps colour buffer cache size to 32 as certain games already exceed the current limit, resulting in flashes. Iterating over an std::array is very fast so I don't expect this to result in any performance loss. Combined with above fix FE:A renders properly

![awake](https://github.com/wheremyfoodat/Panda3DS/assets/47210458/38ed6769-99c6-4126-a0d6-37a4fcc4abc2)