### PR TITLE
Implement reading texture from NULL

### DIFF
--- a/include/renderer_gl/renderer_gl.hpp
+++ b/include/renderer_gl/renderer_gl.hpp
@@ -55,6 +55,7 @@ class RendererGL final : public Renderer {
 	OpenGL::Texture screenTexture;
 	GLuint lightLUTTextureArray;
 	OpenGL::Framebuffer screenFramebuffer;
+	OpenGL::Texture blankTexture;
 
 	OpenGL::Framebuffer getColourFBO();
 	OpenGL::Texture getTexture(Texture& tex);


### PR DESCRIPTION
The behaviour emulated isn't 1:1 with original hardware since the original hardware behavior is impossible to emulate with OpenGL (or Vulkan, or any other graphics API). However returning blank should be fine (Citra does similarly)

Fixes Cars 2, gets Tomodachi Life to the creating save data screen, is one of the things needed to get Pokemon XY working