### PR TITLE
Make SendSyncRequest warn instead of panic on invalid handles

### DIFF
--- a/src/core/kernel/ports.cpp
+++ b/src/core/kernel/ports.cpp
@@ -109,7 +109,7 @@ void Kernel::sendSyncRequest() {
 	// If we're actually communicating with a port
 	const auto session = getObject(handle, KernelObjectType::Session);
 	if (session == nullptr) [[unlikely]] {
-		Helpers::panic("SendSyncRequest: Invalid handle");
+		Helpers::warn("SendSyncRequest: Invalid handle");
 		regs[0] = Result::Kernel::InvalidHandle;
 		return;
 	}


### PR DESCRIPTION
Some games like Arc Baseball use invalid handles...