### PR TITLE
Add resource limit for threads to getResourceLimitLimitValues

### DIFF
--- a/src/core/kernel/resource_limits.cpp
+++ b/src/core/kernel/resource_limits.cpp
@@ -89,6 +89,7 @@ s32 Kernel::getCurrentResourceValue(const KernelObject* limit, u32 resourceName)
 u32 Kernel::getMaxForResource(const KernelObject* limit, u32 resourceName) {
 	switch (resourceName) {
 		case ResourceType::Commit: return appResourceLimits.maxCommit;
+		case ResourceType::Thread: return appResourceLimits.maxThreads;
 		default: Helpers::panic("Attempted to get the max of unknown kernel resource: %d\n", resourceName);
 	}
 }


### PR DESCRIPTION
Fixes farm simulator 18 (never make me play this game again)
![image](https://github.com/wheremyfoodat/Panda3DS/assets/44909372/64cecadd-c5c6-4c77-b2b6-da795f4db08d)
