### PR TITLE
Result: Initialize m_value to 0 in default HorizonResult constructor

### DIFF
--- a/include/result/result_common.hpp
+++ b/include/result/result_common.hpp
@@ -157,7 +157,7 @@ namespace Result {
 		}
 
 	public:
-		constexpr HorizonResult() {}
+		constexpr HorizonResult() : m_value(0) {}
 		constexpr HorizonResult(uint32_t value) : m_value(value) {}
 		constexpr HorizonResult(uint32_t description, HorizonResultModule module, HorizonResultSummary summary, HorizonResultLevel level) : m_value(makeValue(description, static_cast<uint32_t>(module), static_cast<uint32_t>(summary), static_cast<uint32_t>(level))) {}
 		constexpr operator uint32_t() const { return m_value; }


### PR DESCRIPTION
Fixes arm gcc getting mad due to the default constructor not actually producing a constexpr result