### PR TITLE
Fix ambiguity between enum and type

### DIFF
--- a/src/core/kernel/threads.cpp
+++ b/src/core/kernel/threads.cpp
@@ -641,9 +641,8 @@ void Kernel::svcReleaseSemaphore() {
 // can simply compile to a fast sub+cmp+set despite looking slow
 bool Kernel::isWaitable(const KernelObject* object) {
 	auto type = object->type;
-	using enum KernelObjectType;
-
-	return type == Event || type == Mutex || type == Port || type == Semaphore || type == Timer || type == Thread;
+	return type == KernelObjectType::Event || type == KernelObjectType::Mutex || type == KernelObjectType::Port ||
+		   type == KernelObjectType::Semaphore || type == KernelObjectType::Timer || type == KernelObjectType::Thread;
 }
 
 // Returns whether we should wait on a sync object or not


### PR DESCRIPTION
For whatever reason when compiling on MacOS x86_64 (probably on an old compiler, it's a VM) I would get this error
![image](https://github.com/wheremyfoodat/Panda3DS/assets/21157395/45c80613-c383-46dc-836b-fd885a67eb24)

This commit fixes this, compiles fine for me now.