### PR TITLE
Add more HLE Y2R functions

### DIFF
--- a/include/services/y2r.hpp
+++ b/include/services/y2r.hpp
@@ -87,6 +87,7 @@ class Y2RService {
 
 	void setAlpha(u32 messagePointer);
 	void setBlockAlignment(u32 messagePointer);
+	void setCoefficientParams(u32 messagePointer);
 	void setInputFormat(u32 messagePointer);
 	void setInputLineWidth(u32 messagePointer);
 	void setInputLines(u32 messagePointer);

--- a/include/services/y2r.hpp
+++ b/include/services/y2r.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <array>
 #include <optional>
 #include "helpers.hpp"
 #include "kernel_types.hpp"
@@ -50,6 +51,15 @@ class Y2RService {
 		Block8x8 = 1, // Output buffer's pixels are morton swizzled. Used when outputting to a GPU texture.
 	};
 
+	// https://github.com/citra-emu/citra/blob/ac9d72a95ca9a60de8d39484a14aecf489d6d016/src/core/hle/service/cam/y2r_u.cpp#L33
+	using CoefficientSet = std::array<s16, 8>;
+	static constexpr std::array<CoefficientSet, 4> standardCoefficients{{
+		{{0x100, 0x166, 0xB6, 0x58, 0x1C5, -0x166F, 0x10EE, -0x1C5B}},  // ITU_Rec601
+		{{0x100, 0x193, 0x77, 0x2F, 0x1DB, -0x1933, 0xA7C, -0x1D51}},   // ITU_Rec709
+		{{0x12A, 0x198, 0xD0, 0x64, 0x204, -0x1BDE, 0x10F2, -0x229B}},  // ITU_Rec601_Scaling
+		{{0x12A, 0x1CA, 0x88, 0x36, 0x21C, -0x1F04, 0x99C, -0x2421}},   // ITU_Rec709_Scaling
+	}};
+
 	InputFormat inputFmt;
 	OutputFormat outputFmt;
 	Rotation rotation;
@@ -88,6 +98,7 @@ class Y2RService {
 	void setSpacialDithering(u32 messagePointer);
 	void setStandardCoeff(u32 messagePointer);
 	void setTemporalDithering(u32 messagePointer);
+	void getStandardCoefficientParams(u32 messagePointer);
 
 	void startConversion(u32 messagePointer);
 	void stopConversion(u32 messagePointer);

--- a/include/services/y2r.hpp
+++ b/include/services/y2r.hpp
@@ -60,6 +60,8 @@ class Y2RService {
 		{{0x12A, 0x1CA, 0x88, 0x36, 0x21C, -0x1F04, 0x99C, -0x2421}},   // ITU_Rec709_Scaling
 	}};
 
+	CoefficientSet conversionCoefficients; // Current conversion coefficients
+
 	InputFormat inputFmt;
 	OutputFormat outputFmt;
 	Rotation rotation;
@@ -98,6 +100,7 @@ class Y2RService {
 	void setSpacialDithering(u32 messagePointer);
 	void setStandardCoeff(u32 messagePointer);
 	void setTemporalDithering(u32 messagePointer);
+	void getCoefficientParams(u32 messagePointer);
 	void getStandardCoefficientParams(u32 messagePointer);
 
 	void startConversion(u32 messagePointer);

--- a/src/core/services/y2r.cpp
+++ b/src/core/services/y2r.cpp
@@ -23,6 +23,7 @@ namespace Y2RCommands {
 		GetInputLineWidth = 0x001B0000,
 		SetInputLines = 0x001C0040,
 		GetInputLines = 0x001D0000,
+		SetCoefficientParams = 0x001E0100,
 		GetCoefficientParams = 0x001F0000,
 		SetStandardCoeff = 0x00200040,
 		GetStandardCoefficientParams = 0x00210040,
@@ -89,6 +90,7 @@ void Y2RService::handleSyncRequest(u32 messagePointer) {
 		case Y2RCommands::StopConversion: stopConversion(messagePointer); break;
 
 		// Intentionally break ordering a bit for less-used Y2R functions
+		case Y2RCommands::SetCoefficientParams: setCoefficientParams(messagePointer); break;
 		case Y2RCommands::GetCoefficientParams: getCoefficientParams(messagePointer); break;
 		default: Helpers::panic("Y2R service requested. Command: %08X\n", command);
 	}
@@ -345,6 +347,19 @@ void Y2RService::getStandardCoefficientParams(u32 messagePointer) {
 	}
 }
 
+void Y2RService::setCoefficientParams(u32 messagePointer) {
+	log("Y2R::SetCoefficientParams\n");
+	mem.write32(messagePointer, IPC::responseHeader(0x1E, 1, 0));
+	mem.write32(messagePointer + 4, Result::Success);
+	auto& coeff = conversionCoefficients;
+
+	// Write coefficient parameters to output buffer
+	for (int i = 0; i < 8; i++) {
+		const u32 pointer = messagePointer + 8 + i * sizeof(u16);  // Pointer to write parameter to
+		coeff[i] = mem.read16(pointer);
+	}
+}
+
 void Y2RService::getCoefficientParams(u32 messagePointer) {
 	log("Y2R::GetCoefficientParams\n");
 	mem.write32(messagePointer, IPC::responseHeader(0x1F, 5, 0));
@@ -357,7 +372,6 @@ void Y2RService::getCoefficientParams(u32 messagePointer) {
 		mem.write16(pointer, coeff[i]);
 	}
 }
-
 
 void Y2RService::setSendingY(u32 messagePointer) {
 	log("Y2R::SetSendingY\n");

--- a/src/core/services/y2r.cpp
+++ b/src/core/services/y2r.cpp
@@ -288,6 +288,7 @@ void Y2RService::getInputLineWidth(u32 messagePointer) {
 	mem.write32(messagePointer + 4, Result::Success);
 	mem.write32(messagePointer + 8, inputLineWidth);
 }
+
 void Y2RService::setInputLines(u32 messagePointer) {
 	const u16 lines = mem.read16(messagePointer + 4);
 	log("Y2R::SetInputLines (lines = %d)\n", lines);
@@ -349,15 +350,16 @@ void Y2RService::getStandardCoefficientParams(u32 messagePointer) {
 
 void Y2RService::setCoefficientParams(u32 messagePointer) {
 	log("Y2R::SetCoefficientParams\n");
-	mem.write32(messagePointer, IPC::responseHeader(0x1E, 1, 0));
-	mem.write32(messagePointer + 4, Result::Success);
 	auto& coeff = conversionCoefficients;
 
 	// Write coefficient parameters to output buffer
 	for (int i = 0; i < 8; i++) {
-		const u32 pointer = messagePointer + 8 + i * sizeof(u16);  // Pointer to write parameter to
+		const u32 pointer = messagePointer + 4 + i * sizeof(u16);  // Pointer to write parameter to
 		coeff[i] = mem.read16(pointer);
 	}
+
+	mem.write32(messagePointer, IPC::responseHeader(0x1E, 1, 0));
+	mem.write32(messagePointer + 4, Result::Success);
 }
 
 void Y2RService::getCoefficientParams(u32 messagePointer) {


### PR DESCRIPTION
Used by Street Fighter IV and more.
Sadly Street Fighter IV needs some more KTimer fixes to fully go in-game, since it uses timers to time the opening FMV which doesn't work with the current timer stub.