### PR TITLE
Better KTimer implementation 

### DIFF
--- a/include/kernel/kernel.hpp
+++ b/include/kernel/kernel.hpp
@@ -36,6 +36,7 @@ class Kernel {
 	std::vector<KernelObject> objects;
 	std::vector<Handle> portHandles;
 	std::vector<Handle> mutexHandles;
+	std::vector<Handle> timerHandles;
 
 	// Thread indices, sorted by priority
 	std::vector<int> threadIndices;

--- a/src/core/kernel/kernel.cpp
+++ b/src/core/kernel/kernel.cpp
@@ -148,6 +148,7 @@ void Kernel::reset() {
 	}
 	objects.clear();
 	mutexHandles.clear();
+	timerHandles.clear();
 	portHandles.clear();
 	threadIndices.clear();
 	serviceManager.reset();

--- a/src/core/kernel/timers.cpp
+++ b/src/core/kernel/timers.cpp
@@ -9,7 +9,7 @@ Handle Kernel::makeTimer(ResetType type) {
 		Helpers::panic("Created pulse timer");
 	}
 
-	// timerHandles.push_back(ret);
+	timerHandles.push_back(ret);
 	return ret;
 }
 

--- a/src/core/kernel/timers.cpp
+++ b/src/core/kernel/timers.cpp
@@ -74,8 +74,8 @@ void Kernel::svcCreateTimer() {
 void Kernel::svcSetTimer() {
 	Handle handle = regs[0];
 	// TODO: Is this actually s64 or u64? 3DBrew says s64, but u64 makes more sense
-	const s64 initial = s64(u64(regs[1]) | (u64(regs[3]) << 32));
-	const s64 interval = s64(u64(regs[2]) | (u64(regs[4]) << 32));
+	const s64 initial = s64(u64(regs[2]) | (u64(regs[3]) << 32));
+	const s64 interval = s64(u64(regs[1]) | (u64(regs[4]) << 32));
 	logSVC("SetTimer (handle = %X, initial delay = %llX, interval delay = %llX)\n", handle, initial, interval);
 
 	KernelObject* object = getObject(handle, KernelObjectType::Timer);

--- a/src/core/kernel/timers.cpp
+++ b/src/core/kernel/timers.cpp
@@ -51,6 +51,10 @@ void Kernel::signalTimer(Handle timerHandle, Timer* timer) {
 			case ResetType::Pulse: Helpers::panic("Signalled pulsing timer"); break;
 		}
 	}
+
+	if (timer->interval == 0) {
+		cancelTimer(timer);
+	}
 }
 
 void Kernel::svcCreateTimer() {
@@ -70,8 +74,8 @@ void Kernel::svcCreateTimer() {
 void Kernel::svcSetTimer() {
 	Handle handle = regs[0];
 	// TODO: Is this actually s64 or u64? 3DBrew says s64, but u64 makes more sense
-	const s64 initial = s64(u64(regs[1]) | (u64(regs[2]) << 32));
-	const s64 interval = s64(u64(regs[3]) | (u64(regs[4]) << 32));
+	const s64 initial = s64(u64(regs[1]) | (u64(regs[3]) << 32));
+	const s64 interval = s64(u64(regs[2]) | (u64(regs[4]) << 32));
 	logSVC("SetTimer (handle = %X, initial delay = %llX, interval delay = %llX)\n", handle, initial, interval);
 
 	KernelObject* object = getObject(handle, KernelObjectType::Timer);


### PR DESCRIPTION
Required for various games like Pokemon Dream Radar, Kid Icarus, FIFA et al
Fixes some of them on my local with a small timer scheduling stub, which I won't push so upstream will have to wait for a proper scheduler to be implemented