### PR TITLE
Fix Kernel WaitSynchronization1 HLE, properly report CirclePadPro as not connected

### DIFF
--- a/src/core/kernel/events.cpp
+++ b/src/core/kernel/events.cpp
@@ -96,7 +96,7 @@ void Kernel::svcSignalEvent() {
 // Result WaitSynchronization1(Handle handle, s64 timeout_nanoseconds)
 void Kernel::waitSynchronization1() {
 	const Handle handle = regs[0];
-	const s64 ns = s64(u64(regs[1]) | (u64(regs[2]) << 32));
+	const s64 ns = s64(u64(regs[2]) | (u64(regs[3]) << 32));
 	logSVC("WaitSynchronization1(handle = %X, ns = %lld)\n", handle, ns);
 
 	const auto object = getObject(handle);

--- a/src/core/services/ir_user.cpp
+++ b/src/core/services/ir_user.cpp
@@ -120,9 +120,14 @@ void IRUserService::requireConnection(u32 messagePointer) {
 		u32 sharedMemAddress = sharedMemory.value().addr;
 
 		if (deviceID == u8(DeviceID::CirclePadPro)) {
-			mem.write8(sharedMemAddress + offsetof(SharedMemoryStatus, connectionStatus), 2); // Citra uses 2 here but only 1 works??
-			mem.write8(sharedMemAddress + offsetof(SharedMemoryStatus, connectionRole), 2);
-			mem.write8(sharedMemAddress + offsetof(SharedMemoryStatus, isConnected), 1);
+			// Note: We temporarily pretend we don't have a CirclePad Pro. This code must change when we emulate it or N3DS C-stick
+			constexpr u8 status = 1; // Not connected. Any value other than 2 is considered not connected.
+			constexpr u8 role = 0;
+			constexpr u8 connected = 0;
+
+			mem.write8(sharedMemAddress + offsetof(SharedMemoryStatus, connectionStatus), status);
+			mem.write8(sharedMemAddress + offsetof(SharedMemoryStatus, connectionRole), role);
+			mem.write8(sharedMemAddress + offsetof(SharedMemoryStatus, isConnected), connected);
 
 			connectedDevice = true;
 			if (connectionStatusEvent.has_value()) {


### PR DESCRIPTION
Fixes games stuck polling IR (eg Majora's Mask 3D) and other games that may have been broken due to WaitSync timeouts not working