### PR TITLE
[Qt] Full scripting integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -43,3 +43,6 @@
 [submodule "third_party/hydra_core"]
 	path = third_party/hydra_core
 	url = https://github.com/hydra-emu/core
+[submodule "third_party/zep"]
+	path = third_party/zep
+	url = https://github.com/Panda3DS-emu/zep

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,12 +186,20 @@ set(RENDERER_SW_SOURCE_FILES src/core/renderer_sw/renderer_sw.cpp)
 # Frontend source files
 if(NOT ANDROID)
     if(ENABLE_QT_GUI)
-        set(FRONTEND_SOURCE_FILES src/panda_qt/main.cpp src/panda_qt/screen.cpp src/panda_qt/main_window.cpp src/panda_qt/about_window.cpp src/panda_qt/config_window.cpp)
-        set(FRONTEND_HEADER_FILES include/panda_qt/screen.hpp include/panda_qt/main_window.hpp include/panda_qt/about_window.hpp include/panda_qt/config_window.hpp)
+        set(FRONTEND_SOURCE_FILES src/panda_qt/main.cpp src/panda_qt/screen.cpp src/panda_qt/main_window.cpp src/panda_qt/about_window.cpp
+            src/panda_qt/config_window.cpp src/panda_qt/zep.cpp src/panda_qt/text_editor.cpp
+        )   
+        set(FRONTEND_HEADER_FILES include/panda_qt/screen.hpp include/panda_qt/main_window.hpp include/panda_qt/about_window.hpp
+            include/panda_qt/config_window.hpp include/panda_qt/text_editor.hpp
+        )
 
         source_group("Source Files\\Qt" FILES ${FRONTEND_SOURCE_FILES})
         source_group("Header Files\\Qt" FILES ${FRONTEND_HEADER_FILES})
         include_directories(${Qt6Gui_PRIVATE_INCLUDE_DIRS})
+
+        include_directories(third_party/zep/include) # Include zep for text editor usage
+        configure_file(third_party/zep/cmake/config_app.h.cmake ${CMAKE_BINARY_DIR}/zep_config/config_app.h)
+        include_directories(${CMAKE_BINARY_DIR}/zep_config)
     else()
         set(FRONTEND_SOURCE_FILES src/panda_sdl/main.cpp src/panda_sdl/frontend_sdl.cpp)
         set(FRONTEND_HEADER_FILES "")
@@ -428,6 +436,9 @@ endif()
 
 if(ENABLE_QT_GUI)
     target_compile_definitions(Alber PUBLIC "PANDA3DS_FRONTEND_QT=1")
+    target_compile_definitions(Alber PUBLIC "ZEP_QT=1")
+    target_compile_definitions(Alber PUBLIC "ZEP_FEATURE_CPP_FILE_SYSTEM=1")
+
     target_link_libraries(Alber PRIVATE Qt6::Widgets)
 
     if(LINUX OR FREEBSD)

--- a/include/emulator.hpp
+++ b/include/emulator.hpp
@@ -119,6 +119,8 @@ class Emulator {
 	EmulatorConfig& getConfig() { return config; }
 	Cheats& getCheats() { return cheats; }
 	ServiceManager& getServiceManager() { return kernel.getServiceManager(); }
+	LuaManager& getLua() { return lua; }
+
 	RendererType getRendererType() const { return config.rendererType; }
 	Renderer* getRenderer() { return gpu.getRenderer(); }
 	u64 getTicks() { return cpu.getTicks(); }

--- a/include/lua_manager.hpp
+++ b/include/lua_manager.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <string>
+
 #include "helpers.hpp"
 #include "memory.hpp"
 
@@ -36,6 +38,8 @@ class LuaManager {
 	void initialize();
 	void initializeThunks();
 	void loadFile(const char* path);
+	void loadString(const std::string& code);
+
 	void reset();
 	void signalEvent(LuaEvent e) {
 		if (haveScript) [[unlikely]] {
@@ -52,6 +56,7 @@ class LuaManager {
 	void close() {}
 	void initialize() {}
 	void loadFile(const char* path) {}
+	void loadString(const std::string& code) {}
 	void reset() {}
 	void signalEvent(LuaEvent e) {}
 };

--- a/include/panda_qt/main_window.hpp
+++ b/include/panda_qt/main_window.hpp
@@ -13,6 +13,7 @@
 #include "panda_qt/about_window.hpp"
 #include "panda_qt/config_window.hpp"
 #include "panda_qt/screen.hpp"
+#include "panda_qt/text_editor.hpp"
 #include "services/hid.hpp"
 
 class MainWindow : public QMainWindow {
@@ -20,9 +21,7 @@ class MainWindow : public QMainWindow {
 
   private:
 	// Types of messages we might send from the GUI thread to the emulator thread
-	enum class MessageType {
-		LoadROM, Reset, Pause, Resume, TogglePause, DumpRomFS, PressKey, ReleaseKey
-	};
+	enum class MessageType { LoadROM, Reset, Pause, Resume, TogglePause, DumpRomFS, PressKey, ReleaseKey };
 
 	// Tagged union representing our message queue messages
 	struct EmulatorMessage {
@@ -43,7 +42,7 @@ class MainWindow : public QMainWindow {
 	Emulator* emu = nullptr;
 	std::thread emuThread;
 
-	std::atomic<bool> appRunning = true; // Is the application itself running?
+	std::atomic<bool> appRunning = true;  // Is the application itself running?
 	// Used for synchronizing messages between the emulator and UI
 	std::mutex messageQueueMutex;
 	std::vector<EmulatorMessage> messageQueue;
@@ -51,12 +50,14 @@ class MainWindow : public QMainWindow {
 	ScreenWidget screen;
 	AboutWindow* aboutWindow;
 	ConfigWindow* configWindow;
+	TextEditorWindow* luaEditor;
 	QMenuBar* menuBar = nullptr;
 
 	void swapEmuBuffer();
 	void emuThreadMainLoop();
 	void selectROM();
 	void dumpRomFS();
+	void openLuaEditor();
 	void showAboutMenu();
 	void sendMessage(const EmulatorMessage& message);
 	void dispatchMessage(const EmulatorMessage& message);

--- a/include/panda_qt/main_window.hpp
+++ b/include/panda_qt/main_window.hpp
@@ -21,7 +21,7 @@ class MainWindow : public QMainWindow {
 
   private:
 	// Types of messages we might send from the GUI thread to the emulator thread
-	enum class MessageType { LoadROM, Reset, Pause, Resume, TogglePause, DumpRomFS, PressKey, ReleaseKey };
+	enum class MessageType { LoadROM, Reset, Pause, Resume, TogglePause, DumpRomFS, PressKey, ReleaseKey, LoadLuaScript };
 
 	// Tagged union representing our message queue messages
 	struct EmulatorMessage {
@@ -35,6 +35,10 @@ class MainWindow : public QMainWindow {
 			struct {
 				u32 key;
 			} key;
+
+			struct {
+				std::string* str;
+			} string;
 		};
 	};
 
@@ -72,4 +76,5 @@ class MainWindow : public QMainWindow {
 
 	void keyPressEvent(QKeyEvent* event) override;
 	void keyReleaseEvent(QKeyEvent* event) override;
+	void loadLuaScript(const std::string& code);
 };

--- a/include/panda_qt/main_window.hpp
+++ b/include/panda_qt/main_window.hpp
@@ -59,6 +59,7 @@ class MainWindow : public QMainWindow {
 
 	void swapEmuBuffer();
 	void emuThreadMainLoop();
+	void selectLuaFile();
 	void selectROM();
 	void dumpRomFS();
 	void openLuaEditor();

--- a/include/panda_qt/text_editor.hpp
+++ b/include/panda_qt/text_editor.hpp
@@ -19,4 +19,5 @@ class TextEditorWindow : public QDialog {
 
   public:
 	TextEditorWindow(QWidget* parent, const std::string& filename, const std::string& initialText);
+	void setText(const std::string& text) { zepWidget.GetEditor().GetMRUBuffer()->SetText(text); }
 };

--- a/include/panda_qt/text_editor.hpp
+++ b/include/panda_qt/text_editor.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <QApplication>
+#include <QDialog>
+#include <QWidget>
+#include <string>
+
+#include "zep.h"
+#include "zep/mode_repl.h"
+#include "zep/regress.h"
+
+class TextEditorWindow : public QDialog {
+	Q_OBJECT
+
+  private:
+	Zep::ZepWidget_Qt zepWidget;
+	Zep::IZepReplProvider replProvider;
+	static constexpr float fontSize = 14.0f;
+
+  public:
+	TextEditorWindow(QWidget* parent, const std::string& filename, const std::string& initialText);
+};

--- a/src/lua.cpp
+++ b/src/lua.cpp
@@ -51,6 +51,31 @@ void LuaManager::loadFile(const char* path) {
 	}
 }
 
+void LuaManager::loadString(const std::string& code) {
+	// Initialize Lua if it has not been initialized
+	if (!initialized) {
+		initialize();
+	}
+
+	// If init failed, don't execute
+	if (!initialized) {
+		printf("Lua initialization failed, file won't run\n");
+		haveScript = false;
+
+		return;
+	}
+
+	int status = luaL_loadstring(L, code.c_str());  // load Lua script
+	int ret = lua_pcall(L, 0, 0, 0);                // tell Lua to run the script
+
+	if (ret != 0) {
+		haveScript = false;
+		fprintf(stderr, "%s\n", lua_tostring(L, -1));  // tell us what mistake we made
+	} else {
+		haveScript = true;
+	}
+}
+
 void LuaManager::signalEventInternal(LuaEvent e) {
 	lua_getglobal(L, "eventHandler"); // We want to call the event handler
 	lua_pushnumber(L, static_cast<int>(e)); // Push event type

--- a/src/panda_qt/main_window.cpp
+++ b/src/panda_qt/main_window.cpp
@@ -195,6 +195,11 @@ void MainWindow::dispatchMessage(const EmulatorMessage& message) {
 			delete message.path.p;
 			break;
 
+		case MessageType::LoadLuaScript:
+			emu->getLua().loadString(*message.string.str);
+			delete message.string.str;
+			break;
+
 		case MessageType::Pause: emu->pause(); break;
 		case MessageType::Resume: emu->resume(); break;
 		case MessageType::TogglePause: emu->togglePause(); break;
@@ -258,4 +263,12 @@ void MainWindow::keyReleaseEvent(QKeyEvent* event) {
 		case Qt::Key_Return: releaseKey(HID::Keys::Start); break;
 		case Qt::Key_Backspace: releaseKey(HID::Keys::Select); break;
 	}
+}
+
+void MainWindow::loadLuaScript(const std::string& code) {
+	EmulatorMessage message{.type = MessageType::LoadLuaScript};
+
+	// Make a copy of the code on the heap to send via the message queue
+	message.string.str = new std::string(code);
+	sendMessage(message);
 }

--- a/src/panda_qt/main_window.cpp
+++ b/src/panda_qt/main_window.cpp
@@ -36,7 +36,9 @@ MainWindow::MainWindow(QApplication* app, QWidget* parent) : QMainWindow(parent)
 	connect(configureAction, &QAction::triggered, this, [this]() { configWindow->show(); });
 
 	auto dumpRomFSAction = toolsMenu->addAction(tr("Dump RomFS"));
+	auto luaEditorAction = toolsMenu->addAction(tr("Open Lua Editor"));
 	connect(dumpRomFSAction, &QAction::triggered, this, &MainWindow::dumpRomFS);
+	connect(luaEditorAction, &QAction::triggered, this, &MainWindow::openLuaEditor);
 
 	auto aboutAction = aboutMenu->addAction(tr("About Panda3DS"));
 	connect(aboutAction, &QAction::triggered, this, &MainWindow::showAboutMenu);
@@ -44,6 +46,7 @@ MainWindow::MainWindow(QApplication* app, QWidget* parent) : QMainWindow(parent)
 	// Set up misc objects
 	aboutWindow = new AboutWindow(nullptr);
 	configWindow = new ConfigWindow(this);
+	luaEditor = new TextEditorWindow(this, "script.lua", "");
 
 	emu = new Emulator();
 	emu->setOutputSize(screen.surfaceWidth, screen.surfaceHeight);
@@ -133,6 +136,7 @@ MainWindow::~MainWindow() {
 	delete menuBar;
 	delete aboutWindow;
 	delete configWindow;
+	delete luaEditor;
 }
 
 // Send a message to the emulator thread. Lock the mutex and just push back to the vector.
@@ -180,6 +184,8 @@ void MainWindow::showAboutMenu() {
 	AboutWindow about(this);
 	about.exec();
 }
+
+void MainWindow::openLuaEditor() { luaEditor->show(); }
 
 void MainWindow::dispatchMessage(const EmulatorMessage& message) {
 	switch (message.type) {

--- a/src/panda_qt/text_editor.cpp
+++ b/src/panda_qt/text_editor.cpp
@@ -1,0 +1,20 @@
+#include "panda_qt/text_editor.hpp"
+#include <QVBoxLayout>
+
+using namespace Zep;
+
+TextEditorWindow::TextEditorWindow(QWidget* parent, const std::string& filename, const std::string& initialText)
+	: QDialog(parent), zepWidget(this, qApp->applicationDirPath().toStdString(), fontSize) {
+	resize(600, 600);
+
+	// Register our extensions
+	ZepRegressExCommand::Register(zepWidget.GetEditor());
+	ZepReplExCommand::Register(zepWidget.GetEditor(), &replProvider);
+
+	zepWidget.GetEditor().SetGlobalMode(Zep::ZepMode_Standard::StaticName());
+	zepWidget.GetEditor().InitWithText(filename, initialText);
+	
+	QVBoxLayout* mainLayout = new QVBoxLayout();
+	setLayout(mainLayout);
+	mainLayout->addWidget(&zepWidget);
+}

--- a/src/panda_qt/text_editor.cpp
+++ b/src/panda_qt/text_editor.cpp
@@ -15,15 +15,18 @@ TextEditorWindow::TextEditorWindow(QWidget* parent, const std::string& filename,
 	ZepRegressExCommand::Register(zepWidget.GetEditor());
 	ZepReplExCommand::Register(zepWidget.GetEditor(), &replProvider);
 
+	// Default to standard mode instead of vim mode, initialize text box
 	zepWidget.GetEditor().SetGlobalMode(Zep::ZepMode_Standard::StaticName());
 	zepWidget.GetEditor().InitWithText(filename, initialText);
 
+	// Layout for widgets
 	QVBoxLayout* mainLayout = new QVBoxLayout();
 	setLayout(mainLayout);
 
 	QPushButton* button = new QPushButton(tr("Load script"), this);
 	button->setFixedSize(100, 20);
 
+	// When the Load Script button is pressed, send the current text to the MainWindow, which will upload it to the emulator's lua object
 	connect(button, &QPushButton::pressed, this, [this]() {
 		if (parentWidget()) {
 			auto buffer = zepWidget.GetEditor().GetMRUBuffer();

--- a/src/panda_qt/text_editor.cpp
+++ b/src/panda_qt/text_editor.cpp
@@ -1,5 +1,9 @@
 #include "panda_qt/text_editor.hpp"
+
+#include <QPushButton>
 #include <QVBoxLayout>
+
+#include "panda_qt/main_window.hpp"
 
 using namespace Zep;
 
@@ -13,8 +17,25 @@ TextEditorWindow::TextEditorWindow(QWidget* parent, const std::string& filename,
 
 	zepWidget.GetEditor().SetGlobalMode(Zep::ZepMode_Standard::StaticName());
 	zepWidget.GetEditor().InitWithText(filename, initialText);
-	
+
 	QVBoxLayout* mainLayout = new QVBoxLayout();
 	setLayout(mainLayout);
+
+	QPushButton* button = new QPushButton(tr("Load script"), this);
+	button->setFixedSize(100, 20);
+
+	connect(button, &QPushButton::pressed, this, [this]() {
+		if (parentWidget()) {
+			auto buffer = zepWidget.GetEditor().GetMRUBuffer();
+			const std::string text = buffer->GetBufferText(buffer->Begin(), buffer->End());
+
+			static_cast<MainWindow*>(parentWidget())->loadLuaScript(text);
+		} else {
+			// This should be unreachable, only here for safety purposes
+			printf("Text editor does not have any parent widget, click doesn't work :(\n");
+		}
+	});
+
+	mainLayout->addWidget(button);
 	mainLayout->addWidget(&zepWidget);
 }

--- a/src/panda_qt/zep.cpp
+++ b/src/panda_qt/zep.cpp
@@ -1,0 +1,2 @@
+#define ZEP_SINGLE_HEADER_BUILD
+#include "zep.h"


### PR DESCRIPTION
This PR adjusts panda-sdl's scripting engine for panda-qt
This includes
- Built-in text editor for Lua files
- Syntax highlighting
- Ability to load `.lua` and `.txt` files from the filesystem, similar to panda-sdl. Loaded Lua files are also mirrored in the built-in text editor so you can load a .lua file and edit it inside the emulator..

![image](https://github.com/wheremyfoodat/Panda3DS/assets/44909372/e93410c0-5b21-4daf-9fd1-5dec53695fd9)
