### PR TITLE
Implement SVC 0x3B (GetThreadContext)

### DIFF
--- a/include/kernel/kernel.hpp
+++ b/include/kernel/kernel.hpp
@@ -146,6 +146,7 @@ public:
 	void getResourceLimitCurrentValues();
 	void getSystemInfo();
 	void getSystemTick();
+	void getThreadContext();
 	void getThreadID();
 	void getThreadIdealProcessor();
 	void getThreadPriority();

--- a/src/core/kernel/kernel.cpp
+++ b/src/core/kernel/kernel.cpp
@@ -66,6 +66,7 @@ void Kernel::serviceSVC(u32 svc) {
 		case 0x38: getResourceLimit(); break;
 		case 0x39: getResourceLimitLimitValues(); break;
 		case 0x3A: getResourceLimitCurrentValues(); break;
+		case 0x3B: getThreadContext(); break;
 		case 0x3D: outputDebugString(); break;
 		default: Helpers::panic("Unimplemented svc: %X @ %08X", svc, regs[15]); break;
 	}

--- a/src/core/kernel/threads.cpp
+++ b/src/core/kernel/threads.cpp
@@ -462,6 +462,13 @@ void Kernel::getThreadIdealProcessor() {
 	regs[1] = static_cast<u32>(ProcessorID::AppCore);
 }
 
+void Kernel::getThreadContext() {
+	Helpers::warn("Stubbed Kernel::GetThreadContext");
+
+	// TODO: Decompile this from Kernel11. 3DBrew says function is stubbed.
+	regs[0] = Result::Success;
+}
+
 void Kernel::setThreadPriority() {
 	const Handle handle = regs[0];
 	const u32 priority = regs[1];


### PR DESCRIPTION
![image](https://github.com/wheremyfoodat/Panda3DS/assets/44909372/18fadafa-74b6-42bf-91c9-dba6284a1e69)

K11 decomp seems to indicate that svcGetThreadContext is not a stub in the actual retail kernel, but this seems to work fine enough for now. Added a warning in case it needs to be revisited, still