### PR TITLE
Add basic event scheduler functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,7 +244,7 @@ set(HEADER_FILES include/emulator.hpp include/helpers.hpp include/termcolor.hpp
                  include/services/news_u.hpp include/applets/software_keyboard.hpp include/applets/applet_manager.hpp include/fs/archive_user_save_data.hpp
                  include/services/amiibo_device.hpp include/services/nfc_types.hpp include/swap.hpp include/services/csnd.hpp include/services/nwm_uds.hpp
                  include/fs/archive_system_save_data.hpp include/lua_manager.hpp include/memory_mapped_file.hpp include/hydra_icon.hpp
-                 include/PICA/dynapica/shader_rec_emitter_arm64.hpp
+                 include/PICA/dynapica/shader_rec_emitter_arm64.hpp include/scheduler.hpp
 )
 
 cmrc_add_resource_library(

--- a/include/cpu_dynarmic.hpp
+++ b/include/cpu_dynarmic.hpp
@@ -9,6 +9,7 @@
 #include "helpers.hpp"
 #include "kernel.hpp"
 #include "memory.hpp"
+#include "scheduler.hpp"
 
 class CPU;
 
@@ -112,15 +113,16 @@ public:
 };
 
 class CPU {
-    std::unique_ptr<Dynarmic::A32::Jit> jit;
-    std::shared_ptr<CP15> cp15;
+	std::unique_ptr<Dynarmic::A32::Jit> jit;
+	std::shared_ptr<CP15> cp15;
 
-    // Make exclusive monitor with only 1 CPU core
-    Dynarmic::ExclusiveMonitor exclusiveMonitor{1};
-    MyEnvironment env;
-    Memory& mem;
+	// Make exclusive monitor with only 1 CPU core
+	Dynarmic::ExclusiveMonitor exclusiveMonitor{1};
+	MyEnvironment env;
+	Memory& mem;
+	Scheduler scheduler;
 
-public:
+  public:
     static constexpr u64 ticksPerSec = 268111856;
 
     CPU(Memory& mem, Kernel& kernel);

--- a/include/cpu_dynarmic.hpp
+++ b/include/cpu_dynarmic.hpp
@@ -126,7 +126,7 @@ class CPU {
 	Emulator& emu;
 
   public:
-    static constexpr u64 ticksPerSec = 268111856;
+    static constexpr u64 ticksPerSec = Scheduler::arm11Clock;
 
     CPU(Memory& mem, Kernel& kernel, Emulator& emu);
     void reset();
@@ -174,6 +174,10 @@ class CPU {
     u64& getTicksRef() {
         return scheduler.currentTimestamp;
     }
+
+	Scheduler& getScheduler() {
+		return scheduler;
+	}
 
     void clearCache() { jit->ClearCache(); }
     void runFrame();

--- a/include/emulator.hpp
+++ b/include/emulator.hpp
@@ -15,6 +15,7 @@
 #include "io_file.hpp"
 #include "lua_manager.hpp"
 #include "memory.hpp"
+#include "scheduler.hpp"
 
 #ifdef PANDA3DS_ENABLE_HTTP_SERVER
 #include "http_server.hpp"
@@ -42,6 +43,7 @@ class Emulator {
 	Kernel kernel;
 	Crypto::AESEngine aesEngine;
 	Cheats cheats;
+	Scheduler scheduler;
 
 	// Variables to keep track of whether the user is controlling the 3DS analog stick with their keyboard
 	// This is done so when a gamepad is connected, we won't automatically override the 3DS analog stick settings with the gamepad's state
@@ -85,6 +87,8 @@ class Emulator {
 	// change ROMs. If Reload is selected, the emulator will reload its selected ROM. This is useful for eg a "reset" button that keeps the current
 	// ROM and just resets the emu
 	enum class ReloadOption { NoReload, Reload };
+	// Used in CPU::runFrame
+	bool frameDone = false;
 
 	Emulator();
 	~Emulator();
@@ -94,6 +98,8 @@ class Emulator {
 	void reset(ReloadOption reload);
 	void run(void* frontend = nullptr);
 	void runFrame();
+	// Poll the scheduler for events
+	void pollScheduler();
 
 	void resume();  // Resume the emulator
 	void pause();   // Pause the emulator
@@ -121,6 +127,7 @@ class Emulator {
 	Cheats& getCheats() { return cheats; }
 	ServiceManager& getServiceManager() { return kernel.getServiceManager(); }
 	LuaManager& getLua() { return lua; }
+	Scheduler& getScheduler() { return scheduler; }
 
 	RendererType getRendererType() const { return config.rendererType; }
 	Renderer* getRenderer() { return gpu.getRenderer(); }

--- a/include/kernel/kernel.hpp
+++ b/include/kernel/kernel.hpp
@@ -70,6 +70,7 @@ public:
 	Handle makeMutex(bool locked = false); // Needs to be public to be accessible to the APT/DSP services
 	Handle makeSemaphore(u32 initialCount, u32 maximumCount); // Needs to be public to be accessible to the service manager port
 	Handle makeTimer(ResetType resetType);
+	void pollTimers();
 
 	// Signals an event, returns true on success or false if the event does not exist
 	bool signalEvent(Handle e);
@@ -94,7 +95,6 @@ public:
 	void releaseMutex(Mutex* moo);
 	void cancelTimer(Timer* timer);
 	void signalTimer(Handle timerHandle, Timer* timer);
-	void updateTimer(Handle timerHandle, Timer* timer);
 
 	// Wake up the thread with the highest priority out of all threads in the waitlist
 	// Returns the index of the woken up thread

--- a/include/kernel/kernel_types.hpp
+++ b/include/kernel/kernel_types.hpp
@@ -177,13 +177,12 @@ struct Timer {
 	u64 waitlist;  // Refer to the getWaitlist function below for documentation
 	ResetType resetType = ResetType::OneShot;
 
-	u64 startTick;     // CPU tick the timer started
-	u64 currentDelay;  // Number of ns until the timer fires next time
+	u64 fireTick;      // CPU tick the timer will be fired
 	u64 interval;      // Number of ns until the timer fires for the second and future times
 	bool fired;        // Has this timer been signalled?
 	bool running;      // Is this timer running or stopped?
 
-	Timer(ResetType type) : resetType(type), startTick(0), currentDelay(0), interval(0), waitlist(0), fired(false), running(false) {}
+	Timer(ResetType type) : resetType(type), fireTick(0), interval(0), waitlist(0), fired(false), running(false) {}
 };
 
 struct MemoryBlock {

--- a/include/scheduler.hpp
+++ b/include/scheduler.hpp
@@ -18,12 +18,10 @@ struct Scheduler {
 	using EventMap = boost::container::flat_multimap<Key, Val, std::less<Key>, boost::container::static_vector<std::pair<Key, Val>, size>>;
 
 	EventMap<u64, EventType, totalNumberOfEvents> events;
-	u64 currentTimestamp = 0;
 	u64 nextTimestamp = 0;
 
 	// Set nextTimestamp to the timestamp of the next event
 	void updateNextTimestamp() { nextTimestamp = events.cbegin()->first; }
-	void addCycles(u64 cycles) { currentTimestamp += cycles; }
 
 	void addEvent(EventType type, u64 timestamp) {
 		events.emplace(timestamp, type);
@@ -40,8 +38,6 @@ struct Scheduler {
 	};
 
 	void reset() {
-		currentTimestamp = 0;
-
 		// Clear any pending events
 		events.clear();
 		// Add a dummy event to always keep the scheduler non-empty

--- a/include/scheduler.hpp
+++ b/include/scheduler.hpp
@@ -2,7 +2,6 @@
 #include <boost/container/flat_map.hpp>
 #include <boost/container/static_vector.hpp>
 #include <limits>
-#include <ranges>
 
 #include "helpers.hpp"
 #include "logger.hpp"
@@ -33,11 +32,14 @@ struct Scheduler {
 	}
 
 	void removeEvent(EventType type) {
-		auto it = std::ranges::find_if(events, [type](decltype(events)::const_reference pair) { return pair.second == type; });
-
-		if (it != events.end()) {
-			events.erase(it);
-			updateNextTimestamp();
+		for (auto it = events.begin(); it != events.end(); it++) {
+			// Find first event of type "type" and remove it.
+			// Our scheduler shouldn't have duplicate events, so it's safe to exit when an event is found
+			if (it->second == type) {
+				events.erase(it);
+				updateNextTimestamp();
+				break;
+			}
 		}
 	};
 

--- a/include/scheduler.hpp
+++ b/include/scheduler.hpp
@@ -1,0 +1,50 @@
+#pragma once
+#include <boost/container/flat_map.hpp>
+#include <boost/container/static_vector.hpp>
+#include <limits>
+#include <ranges>
+
+#include "helpers.hpp"
+
+struct Scheduler {
+	enum class EventType {
+		VBlank = 0,          // End of frame event
+		Panic = 1,           // Dummy event that is always pending and should never be triggered (Timestamp = UINT64_MAX)
+		TotalNumberOfEvents  // How many event types do we have in total?
+	};
+	static constexpr usize totalNumberOfEvents = static_cast<usize>(EventType::TotalNumberOfEvents);
+
+	template <typename Key, typename Val, usize size>
+	using EventMap = boost::container::flat_multimap<Key, Val, std::less<Key>, boost::container::static_vector<std::pair<Key, Val>, size>>;
+
+	EventMap<u64, EventType, totalNumberOfEvents> events;
+	u64 currentTimestamp = 0;
+	u64 nextTimestamp = 0;
+
+	// Set nextTimestamp to the timestamp of the next event
+	void updateNextTimestamp() { nextTimestamp = events.cbegin()->first; }
+	void addCycles(u64 cycles) { currentTimestamp += cycles; }
+
+	void addEvent(EventType type, u64 timestamp) {
+		events.emplace(timestamp, type);
+		updateNextTimestamp();
+	}
+
+	void removeEvent(EventType type) {
+		auto it = std::ranges::find_if(events, [type](decltype(events)::const_reference pair) { return pair.second == type; });
+
+		if (it != events.end()) {
+			events.erase(it);
+			updateNextTimestamp();
+		}
+	};
+
+	void reset() {
+		currentTimestamp = 0;
+
+		// Clear any pending events
+		events.clear();
+		// Add a dummy event to always keep the scheduler non-empty
+		addEvent(EventType::Panic, std::numeric_limits<u64>::max());
+	}
+};

--- a/include/scheduler.hpp
+++ b/include/scheduler.hpp
@@ -18,6 +18,7 @@ struct Scheduler {
 	using EventMap = boost::container::flat_multimap<Key, Val, std::less<Key>, boost::container::static_vector<std::pair<Key, Val>, size>>;
 
 	EventMap<u64, EventType, totalNumberOfEvents> events;
+	u64 currentTimestamp = 0;
 	u64 nextTimestamp = 0;
 
 	// Set nextTimestamp to the timestamp of the next event
@@ -38,6 +39,8 @@ struct Scheduler {
 	};
 
 	void reset() {
+		currentTimestamp = 0;
+
 		// Clear any pending events
 		events.clear();
 		// Add a dummy event to always keep the scheduler non-empty

--- a/src/core/CPU/cpu_dynarmic.cpp
+++ b/src/core/CPU/cpu_dynarmic.cpp
@@ -1,32 +1,37 @@
 #ifdef CPU_DYNARMIC
 #include "cpu_dynarmic.hpp"
+
 #include "arm_defs.hpp"
 
 CPU::CPU(Memory& mem, Kernel& kernel) : mem(mem), env(mem, kernel) {
-    cp15 = std::make_shared<CP15>();
+	cp15 = std::make_shared<CP15>();
 
-    Dynarmic::A32::UserConfig config;
-    config.arch_version = Dynarmic::A32::ArchVersion::v6K;
-    config.callbacks = &env;
-    config.coprocessors[15] = cp15;
-    config.define_unpredictable_behaviour = true;
-    config.global_monitor = &exclusiveMonitor;
-    config.processor_id = 0;
-    
-    jit = std::make_unique<Dynarmic::A32::Jit>(config);
+	Dynarmic::A32::UserConfig config;
+	config.arch_version = Dynarmic::A32::ArchVersion::v6K;
+	config.callbacks = &env;
+	config.coprocessors[15] = cp15;
+	config.define_unpredictable_behaviour = true;
+	config.global_monitor = &exclusiveMonitor;
+	config.processor_id = 0;
+
+	jit = std::make_unique<Dynarmic::A32::Jit>(config);
 }
 
 void CPU::reset() {
-    setCPSR(CPSR::UserMode);
-    setFPSCR(FPSCR::MainThreadDefault);
-    env.totalTicks = 0;
+	setCPSR(CPSR::UserMode);
+	setFPSCR(FPSCR::MainThreadDefault);
+	env.totalTicks = 0;
 
-    cp15->reset();
-    cp15->setTLSBase(VirtualAddrs::TLSBase); // Set cp15 TLS pointer to the main thread's thread-local storage
-    jit->Reset();
-    jit->ClearCache();
-    jit->Regs().fill(0);
-    jit->ExtRegs().fill(0);
+	cp15->reset();
+	cp15->setTLSBase(VirtualAddrs::TLSBase);  // Set cp15 TLS pointer to the main thread's thread-local storage
+	jit->Reset();
+	jit->ClearCache();
+	jit->Regs().fill(0);
+	jit->ExtRegs().fill(0);
+
+	// Reset scheduler and add a VBlank event
+	scheduler.reset();
+	scheduler.addEvent(Scheduler::EventType::VBlank, ticksPerSec / 60);
 }
 
-#endif // CPU_DYNARMIC
+#endif  // CPU_DYNARMIC

--- a/src/core/CPU/cpu_dynarmic.cpp
+++ b/src/core/CPU/cpu_dynarmic.cpp
@@ -54,8 +54,6 @@ void CPU::runFrame() {
 			}
 		}
 	}
-
-	printf("CPU END!\n");
 }
 
 #endif  // CPU_DYNARMIC

--- a/src/core/CPU/cpu_dynarmic.cpp
+++ b/src/core/CPU/cpu_dynarmic.cpp
@@ -36,7 +36,7 @@ void CPU::runFrame() {
 
 	while (!emu.frameDone) {
 		// Run CPU until the next scheduler event
-		env.ticksLeft = scheduler.nextTimestamp;
+		env.ticksLeft = scheduler.nextTimestamp - scheduler.currentTimestamp;
 
 	execute:
 		const auto exitReason = jit->Run();
@@ -54,6 +54,8 @@ void CPU::runFrame() {
 			}
 		}
 	}
+
+	printf("CPU END!\n");
 }
 
 #endif  // CPU_DYNARMIC

--- a/src/core/CPU/cpu_dynarmic.cpp
+++ b/src/core/CPU/cpu_dynarmic.cpp
@@ -3,7 +3,7 @@
 
 #include "arm_defs.hpp"
 
-CPU::CPU(Memory& mem, Kernel& kernel) : mem(mem), env(mem, kernel) {
+CPU::CPU(Memory& mem, Kernel& kernel) : mem(mem), env(mem, kernel, scheduler) {
 	cp15 = std::make_shared<CP15>();
 
 	Dynarmic::A32::UserConfig config;
@@ -32,6 +32,8 @@ void CPU::reset() {
 	// Reset scheduler and add a VBlank event
 	scheduler.reset();
 	scheduler.addEvent(Scheduler::EventType::VBlank, ticksPerSec / 60);
+
+	printf("%lld\n", scheduler.nextTimestamp);
 }
 
 #endif  // CPU_DYNARMIC

--- a/src/core/kernel/timers.cpp
+++ b/src/core/kernel/timers.cpp
@@ -57,7 +57,6 @@ void Kernel::cancelTimer(Timer* timer) {
 }
 
 void Kernel::signalTimer(Handle timerHandle, Timer* timer) {
-	printf("DEEPFRIED\n");
 	timer->fired = true;
 	requireReschedule();
 

--- a/src/core/kernel/timers.cpp
+++ b/src/core/kernel/timers.cpp
@@ -1,5 +1,8 @@
-#include "kernel.hpp"
+#include <limits>
+
 #include "cpu.hpp"
+#include "kernel.hpp"
+#include "scheduler.hpp"
 
 Handle Kernel::makeTimer(ResetType type) {
 	Handle ret = makeObject(KernelObjectType::Timer);
@@ -13,30 +16,48 @@ Handle Kernel::makeTimer(ResetType type) {
 	return ret;
 }
 
-void Kernel::updateTimer(Handle handle, Timer* timer) {
-	if (timer->running) {
-		const u64 currentTicks = cpu.getTicks();
-		u64 elapsedTicks = currentTicks - timer->startTick;
+void Kernel::pollTimers() {
+	u64 currentTick = cpu.getTicks();
 
-		constexpr double ticksPerSec = double(CPU::ticksPerSec);
-		constexpr double nsPerTick = ticksPerSec / 1000000000.0;
-		const s64 elapsedNs = s64(double(elapsedTicks) * nsPerTick);
+	// Find the next timestamp we'll poll KTimers on. To do this, we find the minimum tick one of our timers will fire
+	u64 nextTimestamp = std::numeric_limits<u64>::max();
+	// Do we have any active timers anymore? If not, then we won't need to schedule a new timer poll event
+	bool haveActiveTimers = false;
 
-		// Timer has fired
-		if (elapsedNs >= timer->currentDelay) {
-			timer->startTick = currentTicks;
-			timer->currentDelay = timer->interval;
-			signalTimer(handle, timer);
+	for (auto handle : timerHandles) {
+		KernelObject* object = getObject(handle, KernelObjectType::Timer);
+		if (object != nullptr) {
+			Timer* timer = object->getData<Timer>();
+
+			if (timer->running) {
+				// If timer has fired, signal it and set the tick it will next time
+				if (currentTick >= timer->fireTick) {
+					signalTimer(handle, timer);
+				}
+
+				// Update our next timer fire timestamp and mark that we should schedule a new event to poll timers
+				// We recheck timer->running because signalling a timer stops it if interval == 0
+				if (timer->running) {
+					nextTimestamp = std::min<u64>(nextTimestamp, timer->fireTick);
+					haveActiveTimers = true;
+				}
+			}
 		}
+	}
+
+	// If we still have active timers, schedule next poll event
+	if (haveActiveTimers) {
+		Scheduler& scheduler = cpu.getScheduler();
+		scheduler.addEvent(Scheduler::EventType::UpdateTimers, nextTimestamp);
 	}
 }
 
 void Kernel::cancelTimer(Timer* timer) {
 	timer->running = false;
-	// TODO: When we have a scheduler this should properly cancel timer events in the scheduler
 }
 
 void Kernel::signalTimer(Handle timerHandle, Timer* timer) {
+	printf("DEEPFRIED\n");
 	timer->fired = true;
 	requireReschedule();
 
@@ -54,6 +75,8 @@ void Kernel::signalTimer(Handle timerHandle, Timer* timer) {
 
 	if (timer->interval == 0) {
 		cancelTimer(timer);
+	} else {
+		timer->fireTick = cpu.getTicks() + Scheduler::nsToCycles(timer->interval);
 	}
 }
 
@@ -87,18 +110,20 @@ void Kernel::svcSetTimer() {
 
 	Timer* timer = object->getData<Timer>();
 	cancelTimer(timer);
-	timer->currentDelay = initial;
 	timer->interval = interval;
 	timer->running = true;
-	timer->startTick = cpu.getTicks();
+	timer->fireTick = cpu.getTicks() + Scheduler::nsToCycles(initial);
+	
+	Scheduler& scheduler = cpu.getScheduler();
+	// Signal an event to poll timers as soon as possible
+	scheduler.removeEvent(Scheduler::EventType::UpdateTimers);
+	scheduler.addEvent(Scheduler::EventType::UpdateTimers, cpu.getTicks() + 1);
 
 	// If the initial delay is 0 then instantly signal the timer
 	if (initial == 0) {
 		signalTimer(handle, timer);
-	} else {
-		// This should schedule an event in the scheduler when we have one
 	}
-	
+
 	regs[0] = Result::Success;
 }
 

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -129,7 +129,6 @@ void Emulator::pollScheduler() {
 
 		switch (eventType) {
 			case Scheduler::EventType::VBlank: {
-				printf("VBLANK!!!!!!\n");
 				// Signal that we've reached the end of a frame
 				frameDone = true;
 				lua.signalEvent(LuaEvent::Frame);

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -17,10 +17,11 @@ __declspec(dllexport) DWORD AmdPowerXpressRequestHighPerformance = 1;
 #endif
 
 Emulator::Emulator()
-	: config(getConfigPath()), kernel(cpu, memory, gpu, config), cpu(memory, kernel), gpu(memory, config),
-	  memory(cpu.getTicksRef(), config), cheats(memory, kernel.getServiceManager().getHID()), lua(memory), running(false), programRunning(false)
+	: config(getConfigPath()), kernel(cpu, memory, gpu, config), cpu(memory, kernel, *this), gpu(memory, config), memory(cpu.getTicksRef(), config),
+	  cheats(memory, kernel.getServiceManager().getHID()), lua(memory), running(false), programRunning(false)
 #ifdef PANDA3DS_ENABLE_HTTP_SERVER
-	  , httpServer(this)
+	  ,
+	  httpServer(this)
 #endif
 {
 #ifdef PANDA3DS_ENABLE_DISCORD_RPC
@@ -45,6 +46,10 @@ void Emulator::reset(ReloadOption reload) {
 	cpu.reset();
 	gpu.reset();
 	memory.reset();
+	// Reset scheduler and add a VBlank event
+	scheduler.reset();
+	scheduler.addEvent(Scheduler::EventType::VBlank, CPU::ticksPerSec / 60);
+
 	// Kernel must be reset last because it depends on CPU/Memory state
 	kernel.reset();
 
@@ -99,12 +104,6 @@ void Emulator::runFrame() {
 	if (running) {
 		cpu.runFrame(); // Run 1 frame of instructions
 		gpu.display();  // Display graphics
-		lua.signalEvent(LuaEvent::Frame);
-
-		// Send VBlank interrupts
-		ServiceManager& srv = kernel.getServiceManager();
-		srv.sendGPUInterrupt(GPUInterrupt::VBlank0);
-		srv.sendGPUInterrupt(GPUInterrupt::VBlank1);
 
 		// Run cheats if any are loaded
 		if (cheats.haveCheats()) [[unlikely]] {
@@ -114,6 +113,41 @@ void Emulator::runFrame() {
 		// If the emulator is not running and a game is loaded, we still want to display the framebuffer otherwise we will get weird
 		// double-buffering issues
 		gpu.display();
+	}
+}
+
+void Emulator::pollScheduler() {
+	auto& events = scheduler.events;
+
+	// Pop events until there's none pending anymore
+	while (scheduler.currentTimestamp > scheduler.nextTimestamp) {
+		// Read event timestamp and type, pop it from the scheduler and handle it
+		auto [time, eventType] = std::move(*events.begin());
+		events.erase(events.begin());
+
+		scheduler.updateNextTimestamp();
+
+		switch (eventType) {
+			case Scheduler::EventType::VBlank: {
+				// Signal that we've reached the end of a frame
+				frameDone = true;
+				lua.signalEvent(LuaEvent::Frame);
+
+				// Send VBlank interrupts
+				ServiceManager& srv = kernel.getServiceManager();
+				srv.sendGPUInterrupt(GPUInterrupt::VBlank0);
+				srv.sendGPUInterrupt(GPUInterrupt::VBlank1);
+				
+				// Queue next VBlank event
+				scheduler.addEvent(Scheduler::EventType::VBlank, time + CPU::ticksPerSec / 60);
+				break;
+			}
+
+			default: {
+				Helpers::panic("Scheduler: Unimplemented event type received: %d\n", static_cast<int>(eventType));
+				break;
+			}
+		}
 	}
 }
 

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -128,7 +128,7 @@ void Emulator::pollScheduler() {
 		scheduler.updateNextTimestamp();
 
 		switch (eventType) {
-			case Scheduler::EventType::VBlank: {
+			case Scheduler::EventType::VBlank: [[likely]] {
 				// Signal that we've reached the end of a frame
 				frameDone = true;
 				lua.signalEvent(LuaEvent::Frame);

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -120,7 +120,7 @@ void Emulator::pollScheduler() {
 	auto& events = scheduler.events;
 
 	// Pop events until there's none pending anymore
-	while (scheduler.currentTimestamp > scheduler.nextTimestamp) {
+	while (scheduler.currentTimestamp >= scheduler.nextTimestamp) {
 		// Read event timestamp and type, pop it from the scheduler and handle it
 		auto [time, eventType] = std::move(*events.begin());
 		events.erase(events.begin());
@@ -129,6 +129,7 @@ void Emulator::pollScheduler() {
 
 		switch (eventType) {
 			case Scheduler::EventType::VBlank: {
+				printf("VBLANK!!!!!!\n");
 				// Signal that we've reached the end of a frame
 				frameDone = true;
 				lua.signalEvent(LuaEvent::Frame);
@@ -142,6 +143,8 @@ void Emulator::pollScheduler() {
 				scheduler.addEvent(Scheduler::EventType::VBlank, time + CPU::ticksPerSec / 60);
 				break;
 			}
+
+			case Scheduler::EventType::UpdateTimers: kernel.pollTimers(); break;
 
 			default: {
 				Helpers::panic("Scheduler: Unimplemented event type received: %d\n", static_cast<int>(eventType));


### PR DESCRIPTION
Currently only handles VBlank and KTimer events. Fixes or at least improves emulation of most games that use KTimer (Pokemon Dream Radar, Kid Icarus, SFIV, etc)

PR should probably add idle skipping and the like before being deemed mergeable
![image](https://github.com/wheremyfoodat/Panda3DS/assets/44909372/9f6d7b7a-578e-474d-b85e-091d7107759b)
