### PR TITLE
Pandroid: Fix Navigation bar.

### DIFF
--- a/src/pandroid/app/src/main/java/com/panda3ds/pandroid/app/GameActivity.java
+++ b/src/pandroid/app/src/main/java/com/panda3ds/pandroid/app/GameActivity.java
@@ -1,6 +1,7 @@
 package com.panda3ds.pandroid.app;
 
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -72,6 +73,9 @@ public class GameActivity extends BaseActivity {
 		InputHandler.reset();
 		InputHandler.setMotionDeadZone(InputMap.getDeadZone());
 		InputHandler.setEventListener(inputListener);
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+			getTheme().applyStyle(R.style.GameActivityNavigationBar, true);
+		}
 	}
 
 	@Override

--- a/src/pandroid/app/src/main/java/com/panda3ds/pandroid/app/base/BasePreferenceFragment.java
+++ b/src/pandroid/app/src/main/java/com/panda3ds/pandroid/app/base/BasePreferenceFragment.java
@@ -3,6 +3,7 @@ package com.panda3ds.pandroid.app.base;
 import android.annotation.SuppressLint;
 
 import androidx.annotation.StringRes;
+import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
@@ -22,6 +23,9 @@ public abstract class BasePreferenceFragment extends PreferenceFragmentCompat {
 	}
 
 	protected void setActivityTitle(@StringRes int titleId) {
-		((AppCompatActivity) requireActivity()).getSupportActionBar().setTitle(titleId);
+		ActionBar header = ((AppCompatActivity) requireActivity()).getSupportActionBar();
+		if (header != null) {
+			header.setTitle(titleId);
+		}
 	}
 }

--- a/src/pandroid/app/src/main/java/com/panda3ds/pandroid/app/main/SettingsFragment.java
+++ b/src/pandroid/app/src/main/java/com/panda3ds/pandroid/app/main/SettingsFragment.java
@@ -8,7 +8,7 @@ import com.panda3ds.pandroid.R;
 import com.panda3ds.pandroid.app.PreferenceActivity;
 import com.panda3ds.pandroid.app.base.BasePreferenceFragment;
 import com.panda3ds.pandroid.app.preferences.AppearancePreferences;
-import com.panda3ds.pandroid.app.preferences.DeveloperPreferences;
+import com.panda3ds.pandroid.app.preferences.AdvancedPreferences;
 import com.panda3ds.pandroid.app.preferences.InputPreferences;
 
 public class SettingsFragment extends BasePreferenceFragment {
@@ -17,6 +17,6 @@ public class SettingsFragment extends BasePreferenceFragment {
         setPreferencesFromResource(R.xml.start_preferences, rootKey);
         setItemClick("input", (item) -> PreferenceActivity.launch(requireContext(), InputPreferences.class));
         setItemClick("appearance", (item)-> PreferenceActivity.launch(requireContext(), AppearancePreferences.class));
-        setItemClick("developer", (item)-> PreferenceActivity.launch(requireContext(), DeveloperPreferences.class));
+        setItemClick("advanced", (item)-> PreferenceActivity.launch(requireContext(), AdvancedPreferences.class));
     }
 }

--- a/src/pandroid/app/src/main/java/com/panda3ds/pandroid/app/preferences/AdvancedPreferences.java
+++ b/src/pandroid/app/src/main/java/com/panda3ds/pandroid/app/preferences/AdvancedPreferences.java
@@ -17,7 +17,7 @@ public class AdvancedPreferences extends BasePreferenceFragment {
     @Override
     public void onCreatePreferences(@Nullable Bundle savedInstanceState, @Nullable String rootKey) {
         setPreferencesFromResource(R.xml.advanced_preferences, rootKey);
-        setActivityTitle(R.string.developer_options);
+        setActivityTitle(R.string.advanced_options);
 
         setItemClick("performanceMonitor", pref -> GlobalConfig.set(GlobalConfig.KEY_SHOW_PERFORMANCE_OVERLAY, ((SwitchPreference) pref).isChecked()));
         setItemClick("shaderJit", pref -> GlobalConfig.set(GlobalConfig.KEY_SHADER_JIT, ((SwitchPreference) pref).isChecked()));

--- a/src/pandroid/app/src/main/java/com/panda3ds/pandroid/app/preferences/AdvancedPreferences.java
+++ b/src/pandroid/app/src/main/java/com/panda3ds/pandroid/app/preferences/AdvancedPreferences.java
@@ -13,10 +13,10 @@ import com.panda3ds.pandroid.app.base.BasePreferenceFragment;
 import com.panda3ds.pandroid.app.services.LoggerService;
 import com.panda3ds.pandroid.data.config.GlobalConfig;
 
-public class DeveloperPreferences extends BasePreferenceFragment {
+public class AdvancedPreferences extends BasePreferenceFragment {
     @Override
     public void onCreatePreferences(@Nullable Bundle savedInstanceState, @Nullable String rootKey) {
-        setPreferencesFromResource(R.xml.developer_preferences, rootKey);
+        setPreferencesFromResource(R.xml.advanced_preferences, rootKey);
         setActivityTitle(R.string.developer_options);
 
         setItemClick("performanceMonitor", pref -> GlobalConfig.set(GlobalConfig.KEY_SHOW_PERFORMANCE_OVERLAY, ((SwitchPreference) pref).isChecked()));

--- a/src/pandroid/app/src/main/java/com/panda3ds/pandroid/app/preferences/AppearancePreferences.java
+++ b/src/pandroid/app/src/main/java/com/panda3ds/pandroid/app/preferences/AppearancePreferences.java
@@ -15,7 +15,7 @@ public class AppearancePreferences extends BasePreferenceFragment {
     public void onCreatePreferences(@Nullable Bundle savedInstanceState, @Nullable String rootKey) {
         setPreferencesFromResource(R.xml.appearance_preference, rootKey);
 
-        ((BaseActivity) requireActivity()).getSupportActionBar().setTitle(R.string.appearance);
+        setActivityTitle(R.string.appearance);
 
         SingleSelectionPreferences themePreference = findPreference("theme");
         themePreference.setSelectedItem(GlobalConfig.get(GlobalConfig.KEY_APP_THEME));

--- a/src/pandroid/app/src/main/java/com/panda3ds/pandroid/app/preferences/ControllerMapperPreferences.java
+++ b/src/pandroid/app/src/main/java/com/panda3ds/pandroid/app/preferences/ControllerMapperPreferences.java
@@ -37,7 +37,9 @@ public class ControllerMapperPreferences extends Fragment {
 
         currentProfile = ControllerProfileManager.get(getArguments().getString("profile")).clone();
 
-        ((BaseActivity) requireActivity()).getSupportActionBar().hide();
+        if (((BaseActivity)requireActivity()).getSupportActionBar() != null) {
+            ((BaseActivity) requireActivity()).getSupportActionBar().hide();
+        }
         mapper = view.findViewById(R.id.mapper);
         mapper.initialize(this::onLocationChanged, currentProfile);
 

--- a/src/pandroid/app/src/main/java/com/panda3ds/pandroid/app/preferences/InputMapPreferences.java
+++ b/src/pandroid/app/src/main/java/com/panda3ds/pandroid/app/preferences/InputMapPreferences.java
@@ -27,7 +27,7 @@ public class InputMapPreferences extends BasePreferenceFragment implements Activ
     public void onCreatePreferences(@Nullable Bundle savedInstanceState, @Nullable String rootKey) {
         setPreferencesFromResource(R.xml.input_map_preferences, rootKey);
 
-        ((BaseActivity) requireActivity()).getSupportActionBar().setTitle(R.string.controller_mapping);
+        setActivityTitle(R.string.controller_mapping);
 
         for (KeyName key : KeyName.values()) {
             if (key == KeyName.NULL) {

--- a/src/pandroid/app/src/main/res/drawable/color_surface.xml
+++ b/src/pandroid/app/src/main/res/drawable/color_surface.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <solid android:color="?colorSurface"/>
+        </shape>
+    </item>
+</selector>

--- a/src/pandroid/app/src/main/res/drawable/switch_thumb.xml
+++ b/src/pandroid/app/src/main/res/drawable/switch_thumb.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true">
+        <layer-list>
+            <item>
+                <shape>
+                    <padding android:bottom="3dp" android:top="3dp" android:right="3dp" android:left="3dp"/>
+                    <solid android:color="#0000"/>
+                </shape>
+            </item>
+            <item>
+                <shape>
+                    <size android:width="18dp" android:height="18dp"/>
+                    <corners android:radius="999dp"/>
+                    <solid android:color="?colorPrimary"/>
+                </shape>
+            </item>
+        </layer-list>
+    </item>
+    <item>
+        <layer-list>
+            <item>
+                <shape>
+                    <padding android:bottom="3dp" android:top="3dp" android:right="3dp" android:left="3dp"/>
+                    <solid android:color="#0000"/>
+                </shape>
+            </item>
+            <item>
+                <shape  android:tintMode="multiply" android:tint="#2FFF">
+                    <size android:width="18dp" android:height="18dp"/>
+                    <corners android:radius="999dp"/>
+                    <solid android:color="?colorOnSurface"/>
+                </shape>
+            </item>
+        </layer-list>
+    </item>
+</selector>

--- a/src/pandroid/app/src/main/res/drawable/switch_track.xml
+++ b/src/pandroid/app/src/main/res/drawable/switch_track.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true">
+        <shape  android:tintMode="multiply" android:tint="#5FFF">
+            <padding android:left="5dp" android:right="5dp" />
+            <solid android:color="?colorPrimary"/>
+            <corners android:radius="24dp"/>
+            <size android:width="32dp" android:height="22dp"/>
+        </shape>
+    </item>
+    <item>
+        <shape  android:tintMode="multiply" android:tint="#2FFF">
+            <padding android:left="5dp" android:right="5dp" />
+            <solid android:color="?colorOnSurface"/>
+            <corners android:radius="24dp"/>
+            <size android:width="32dp" android:height="22dp"/>
+        </shape>
+    </item>
+</selector>

--- a/src/pandroid/app/src/main/res/layout-land/activity_main.xml
+++ b/src/pandroid/app/src/main/res/layout-land/activity_main.xml
@@ -5,7 +5,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".app.MainActivity">
+    tools:context=".app.MainActivity"
+    android:background="?colorSurface">
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"
@@ -25,6 +26,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:menu="@menu/main_activity_navigation"
         app:labelVisibilityMode="selected"
-        style="@style/ThemedNavigationBottom"/>
+        style="@style/ThemedNavigationBottom"
+        android:background="@drawable/color_surface"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/src/pandroid/app/src/main/res/layout/activity_input_map.xml
+++ b/src/pandroid/app/src/main/res/layout/activity_input_map.xml
@@ -4,7 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:gravity="center">
+    android:gravity="center"
+    android:background="?colorSurface">
 
     <View
         android:layout_width="100dp"

--- a/src/pandroid/app/src/main/res/layout/activity_main.xml
+++ b/src/pandroid/app/src/main/res/layout/activity_main.xml
@@ -5,7 +5,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".app.MainActivity">
+    tools:context=".app.MainActivity"
+    android:background="?colorSurface">
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"
@@ -24,6 +25,7 @@
         app:layout_constraintTop_toBottomOf="@id/fragment_container"
         app:labelVisibilityMode="selected"
         app:menu="@menu/main_activity_navigation"
-        style="@style/ThemedNavigationBottom"/>
+        style="@style/ThemedNavigationBottom"
+        android:background="@drawable/color_surface"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/src/pandroid/app/src/main/res/layout/activity_preference.xml
+++ b/src/pandroid/app/src/main/res/layout/activity_preference.xml
@@ -3,7 +3,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:background="?colorSurface">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"

--- a/src/pandroid/app/src/main/res/layout/fragment_search.xml
+++ b/src/pandroid/app/src/main/res/layout/fragment_search.xml
@@ -35,14 +35,14 @@
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:paddingStart="10dp"
-        android:paddingEnd="10dp">
+        android:layout_height="match_parent">
 
         <com.panda3ds.pandroid.view.gamesgrid.GamesGridView
             android:id="@+id/games"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"/>
+            android:layout_height="match_parent"
+            android:paddingStart="15dp"
+            android:paddingEnd="15dp"/>
 
     </FrameLayout>
 

--- a/src/pandroid/app/src/main/res/values-pt-rBR/strings.xml
+++ b/src/pandroid/app/src/main/res/values-pt-rBR/strings.xml
@@ -45,8 +45,8 @@
     <string name="open_file">Abrir arquivo</string>
     <string name="create_new">Criar novo</string>
     <string name="running_ff">Executando \"%s\" ...</string>
-    <string name="developer_options">Opções avançada.</string>
-    <string name="pref_developer_summary">Depuração, mostrar fps, etc.</string>
+    <string name="advanced_options">Opções avançada.</string>
+    <string name="pref_advanced_summary">Depuração, mostrar fps, etc.</string>
     <string name="pref_performance_monitor_title">Monitor de desempenho</string>
     <string name="pref_performance_monitor_summary">Mostrar um overlay com fps, memoria, etc.</string>
     <string name="pref_logger_service_title">Depuração</string>

--- a/src/pandroid/app/src/main/res/values-pt-rBR/strings.xml
+++ b/src/pandroid/app/src/main/res/values-pt-rBR/strings.xml
@@ -45,7 +45,7 @@
     <string name="open_file">Abrir arquivo</string>
     <string name="create_new">Criar novo</string>
     <string name="running_ff">Executando \"%s\" ...</string>
-    <string name="developer_options">Opções de desenvolvedor</string>
+    <string name="developer_options">Opções avançada.</string>
     <string name="pref_developer_summary">Depuração, mostrar fps, etc.</string>
     <string name="pref_performance_monitor_title">Monitor de desempenho</string>
     <string name="pref_performance_monitor_summary">Mostrar um overlay com fps, memoria, etc.</string>

--- a/src/pandroid/app/src/main/res/values-v27/themes.xml
+++ b/src/pandroid/app/src/main/res/values-v27/themes.xml
@@ -5,5 +5,12 @@
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowTranslucentNavigation">false</item>
     </style>
+    <style name="GameActivityNavigationBar">
+        <item name="android:statusBarColor">#5000</item>
+        <item name="android:navigationBarColor">#5000</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
+        <item name="android:windowTranslucentNavigation">false</item>
+    </style>
     <style name="Theme.Pandroid" parent="Base.Theme.Pandroid.V27"/>
 </resources>

--- a/src/pandroid/app/src/main/res/values-v27/themes.xml
+++ b/src/pandroid/app/src/main/res/values-v27/themes.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Base.Theme.Pandroid.V27"  parent="Base.Theme.Pandroid">
+        <item name="android:windowLightNavigationBar">?isLightTheme</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowTranslucentNavigation">false</item>
+    </style>
+    <style name="Theme.Pandroid" parent="Base.Theme.Pandroid.V27"/>
+</resources>

--- a/src/pandroid/app/src/main/res/values-v29/themes.xml
+++ b/src/pandroid/app/src/main/res/values-v29/themes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Base.Theme.Pandroid.V29" parent="Base.Theme.Pandroid.V27">
+        <item name="android:enforceNavigationBarContrast">false</item>
+    </style>
+    <style name="Theme.Pandroid" parent="Base.Theme.Pandroid.V29"/>
+</resources>

--- a/src/pandroid/app/src/main/res/values/strings.xml
+++ b/src/pandroid/app/src/main/res/values/strings.xml
@@ -46,8 +46,8 @@
     <string name="open_file">Open file</string>
     <string name="create_new">Create new</string>
     <string name="running_ff">Running \"%s\" ...</string>
-    <string name="developer_options">Advanced options</string>
-    <string name="pref_developer_summary">Logger, performance statistics, etc.</string>
+    <string name="advanced_options">Advanced options</string>
+    <string name="pref_advanced_summary">Logger, performance statistics, etc.</string>
     <string name="pref_performance_monitor_title">Performance monitor</string>
     <string name="pref_performance_monitor_summary">Show overlay with fps, memory, etc.</string>
     <string name="pref_logger_service_title">Logger</string>

--- a/src/pandroid/app/src/main/res/values/strings.xml
+++ b/src/pandroid/app/src/main/res/values/strings.xml
@@ -46,8 +46,8 @@
     <string name="open_file">Open file</string>
     <string name="create_new">Create new</string>
     <string name="running_ff">Running \"%s\" ...</string>
-    <string name="developer_options">Developer options</string>
-    <string name="pref_developer_summary">Logger, FPS Counter, etc.</string>
+    <string name="developer_options">Advanced options</string>
+    <string name="pref_developer_summary">Logger, performance statistics, etc.</string>
     <string name="pref_performance_monitor_title">Performance monitor</string>
     <string name="pref_performance_monitor_summary">Show overlay with fps, memory, etc.</string>
     <string name="pref_logger_service_title">Logger</string>

--- a/src/pandroid/app/src/main/res/values/themes.xml
+++ b/src/pandroid/app/src/main/res/values/themes.xml
@@ -5,6 +5,8 @@
         <!-- <item name="colorPrimary">@color/my_light_primary</item> -->
         <item name="alertDialogTheme">@style/AlertDialog</item>
         <item name="preferenceTheme">@style/PreferenceTheme</item>
+        <item name="android:statusBarColor">?colorSurfaceVariant</item>
+        <item name="android:windowLightStatusBar">?isLightTheme</item>
     </style>
 
     <style name="PreferenceTheme" parent="PreferenceThemeOverlay">
@@ -24,17 +26,12 @@
         <item name="android:textSize">32sp</item>
     </style>
 
-    <style name="Theme.Pandroid" parent="Base.Theme.Pandroid">
-        <item name="android:enforceNavigationBarContrast">false</item>
-        <item name="android:navigationBarColor">@android:color/transparent</item>
-        <item name="android:windowTranslucentNavigation">false</item>
-    </style>
+    <style name="Theme.Pandroid" parent="Base.Theme.Pandroid"/>
 
     <style name="Theme.Pandroid.Custom" parent="Theme.Pandroid">
         <item name="android:textColor">?colorOnSurface</item>
         <item name="android:textSize">16sp</item>
         <item name="android:textColorHint">?colorOnSurfaceVariant</item>
-        <item name="android:statusBarColor">?colorSurfaceVariant</item>
         <item name="android:windowBackground">?colorSurface</item>
         <item name="titleTextColor">?colorOnSurface</item>
         <item name="hintTextColor">?colorOnSurfaceVariant</item>
@@ -57,8 +54,7 @@
 
         <item name="android:textColorPrimary">@color/text_secondary_light</item>
         <item name="android:textColorSecondary">@color/text_secondary_light</item>
-        <item name="android:windowLightStatusBar">false</item>
-        <item name="android:windowLightNavigationBar">false</item>
+        <item name="isLightTheme">false</item>
     </style>
 
     <style name="Theme.Pandroid.Black" parent="Theme.Pandroid.Custom">
@@ -76,8 +72,7 @@
 
         <item name="android:textColorPrimary">@color/text_secondary_light</item>
         <item name="android:textColorSecondary">@color/text_secondary_light</item>
-        <item name="android:windowLightStatusBar">false</item>
-        <item name="android:windowLightNavigationBar">false</item>
+        <item name="isLightTheme">false</item>
     </style>
 
     <style name="Theme.Pandroid.Light" parent="Theme.Pandroid.Custom">
@@ -93,10 +88,9 @@
         <item name="colorSecondary">#B37749</item>
         <item name="colorOnSecondary">#FFF</item>
 
-        <item name="android:windowLightStatusBar">true</item>
         <item name="android:textColorPrimary">@color/text_secondary_dark</item>
         <item name="android:textColorSecondary">@color/text_secondary_dark</item>
-        <item name="android:windowLightNavigationBar">true</item>
+        <item name="isLightTheme">true</item>
     </style>
 
 </resources>

--- a/src/pandroid/app/src/main/res/values/themes.xml
+++ b/src/pandroid/app/src/main/res/values/themes.xml
@@ -5,8 +5,22 @@
         <!-- <item name="colorPrimary">@color/my_light_primary</item> -->
         <item name="alertDialogTheme">@style/AlertDialog</item>
         <item name="preferenceTheme">@style/PreferenceTheme</item>
-        <item name="android:statusBarColor">?colorSurfaceVariant</item>
+        <item name="android:statusBarColor">?colorSurface</item>
         <item name="android:windowLightStatusBar">?isLightTheme</item>
+
+        <item name="switchStyle">@style/SwitchStyle</item>
+        <item name="materialSwitchStyle">@style/SwitchStyle</item>
+        <item name="android:switchStyle">@style/SwitchStyle</item>
+    </style>
+
+    <style name="SwitchStyle" parent="Widget.Material3.CompoundButton.MaterialSwitch">
+        <item name="android:thumb">@drawable/switch_thumb</item>
+        <item name="android:track">@drawable/switch_track</item>
+        <item name="thumbRadius">0dp</item>
+        <item name="android:thumbOffset">0dp</item>
+        <item name="android:padding">0dp</item>
+        <item name="showText">false</item>
+        <item name="android:showText">false</item>
     </style>
 
     <style name="PreferenceTheme" parent="PreferenceThemeOverlay">

--- a/src/pandroid/app/src/main/res/xml/advanced_preferences.xml
+++ b/src/pandroid/app/src/main/res/xml/advanced_preferences.xml
@@ -12,6 +12,7 @@
         android:key="loggerService"
         app:iconSpaceReserved="false"
         app:title="@string/pref_logger_service_title"
+        app:defaultValue="true"
         android:summary="@string/pref_logger_service_summary"/>
 
     <PreferenceCategory

--- a/src/pandroid/app/src/main/res/xml/start_preferences.xml
+++ b/src/pandroid/app/src/main/res/xml/start_preferences.xml
@@ -26,8 +26,8 @@
     <Preference
         app:key="advanced"
         app:icon="@drawable/ic_code"
-        app:title="@string/developer_options"
-        app:summary="@string/pref_developer_summary"
+        app:title="@string/advanced_options"
+        app:summary="@string/pref_advanced_summary"
         app:layout="@layout/preference_start_item"/>
 
 </PreferenceScreen>

--- a/src/pandroid/app/src/main/res/xml/start_preferences.xml
+++ b/src/pandroid/app/src/main/res/xml/start_preferences.xml
@@ -24,7 +24,7 @@
         app:layout="@layout/preference_start_item"/>
 
     <Preference
-        app:key="developer"
+        app:key="advanced"
         app:icon="@drawable/ic_code"
         app:title="@string/developer_options"
         app:summary="@string/pref_developer_summary"


### PR DESCRIPTION
# What is new

- Fix navigation bar pr #381 crashes on android 8 or lowness
- Fix android 7 ui render
- Fix BottomNavigationBar color in some devices
- Fix inconsistent icon size in search category
- Fix navigation bar color in GameActivity caused by #381 
- Change switch widget to modern style.
- Rename "Developer options" to "advanced options".

# Screenshots

![screenshot-2024-02-02_17 13 53 636](https://github.com/wheremyfoodat/Panda3DS/assets/97042217/974a3548-87eb-4b88-aac4-f24183a7f76e)
![screenshot-2024-02-02_17 14 01 226](https://github.com/wheremyfoodat/Panda3DS/assets/97042217/5c68e99c-61f3-4cda-9287-f57d38b2063f)
![screenshot-2024-02-02_17 14 16 33](https://github.com/wheremyfoodat/Panda3DS/assets/97042217/6d34d97a-6865-4a01-9ee8-de5cb5d2d042)

