### PR TITLE
WIP: DSP support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -55,3 +55,6 @@
 [submodule "third_party/libuv"]
 	path = third_party/libuv
 	url = https://github.com/libuv/libuv
+[submodule "third_party/teakra"]
+	path = third_party/teakra
+	url = https://github.com/wwylele/teakra

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ include_directories(third_party/toml11)
 include_directories(third_party/glm)
 
 add_subdirectory(third_party/cmrc)
+add_subdirectory(third_party/teakra EXCLUDE_FROM_ALL)
 
 set(BOOST_ROOT "${CMAKE_SOURCE_DIR}/third_party/boost")
 set(Boost_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/third_party/boost")
@@ -191,6 +192,7 @@ set(FS_SOURCE_FILES src/core/fs/archive_self_ncch.cpp src/core/fs/archive_save_d
 set(APPLET_SOURCE_FILES src/core/applets/applet.cpp src/core/applets/mii_selector.cpp src/core/applets/software_keyboard.cpp src/core/applets/applet_manager.cpp
                         src/core/applets/error_applet.cpp
 )
+set(AUDIO_SOURCE_FILES src/core/audio/dsp_core.cpp src/core/audio/null_core.cpp src/core/audio/teakra_core.cpp)
 set(RENDERER_SW_SOURCE_FILES src/core/renderer_sw/renderer_sw.cpp)
 
 # Frontend source files
@@ -247,6 +249,7 @@ set(HEADER_FILES include/emulator.hpp include/helpers.hpp include/termcolor.hpp
                  include/services/amiibo_device.hpp include/services/nfc_types.hpp include/swap.hpp include/services/csnd.hpp include/services/nwm_uds.hpp
                  include/fs/archive_system_save_data.hpp include/lua_manager.hpp include/memory_mapped_file.hpp include/hydra_icon.hpp
                  include/PICA/dynapica/shader_rec_emitter_arm64.hpp include/scheduler.hpp include/applets/error_applet.hpp
+                 include/audio/dsp_core.hpp include/audio/null_core.hpp include/audio/teakra_core.hpp
 )
 
 cmrc_add_resource_library(
@@ -299,6 +302,7 @@ source_group("Source Files\\Core\\Loader" FILES ${LOADER_SOURCE_FILES})
 source_group("Source Files\\Core\\Services" FILES ${SERVICE_SOURCE_FILES})
 source_group("Source Files\\Core\\Applets" FILES ${APPLET_SOURCE_FILES})
 source_group("Source Files\\Core\\PICA" FILES ${PICA_SOURCE_FILES})
+source_group("Source Files\\Core\\Audio" FILES ${AUDIO_SOURCE_FILES})
 source_group("Source Files\\Core\\Software Renderer" FILES ${RENDERER_SW_SOURCE_FILES})
 source_group("Source Files\\Third Party" FILES ${THIRD_PARTY_SOURCE_FILES})
 
@@ -397,7 +401,7 @@ endif()
 source_group("Header Files\\Core" FILES ${HEADER_FILES})
 set(ALL_SOURCES ${SOURCE_FILES} ${FRONTEND_SOURCE_FILES} ${FS_SOURCE_FILES} ${CRYPTO_SOURCE_FILES} ${KERNEL_SOURCE_FILES} 
     ${LOADER_SOURCE_FILES} ${SERVICE_SOURCE_FILES} ${APPLET_SOURCE_FILES} ${RENDERER_SW_SOURCE_FILES} ${PICA_SOURCE_FILES} ${THIRD_PARTY_SOURCE_FILES}
-    ${HEADER_FILES} ${FRONTEND_HEADER_FILES})
+    ${AUDIO_SOURCE_FILES} ${HEADER_FILES} ${FRONTEND_HEADER_FILES})
 
 if(ENABLE_OPENGL)
     # Add the OpenGL source files to ALL_SOURCES
@@ -429,7 +433,7 @@ if(ENABLE_LTO OR ENABLE_USER_BUILD)
     set_target_properties(Alber PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
 endif()
 
-target_link_libraries(Alber PRIVATE dynarmic cryptopp glad resources_console_fonts)
+target_link_libraries(Alber PRIVATE dynarmic cryptopp glad resources_console_fonts teakra)
 
 if(NOT ANDROID)
     target_link_libraries(Alber PRIVATE SDL2-static)

--- a/include/audio/dsp_core.hpp
+++ b/include/audio/dsp_core.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <array>
 #include <functional>
 #include <memory>
 #include <vector>
@@ -7,15 +8,19 @@
 #include "logger.hpp"
 #include "memory.hpp"
 
+// The DSP core must have access to the DSP service to be able to trigger interrupts properly
+class DSPService;
+
 namespace Audio {
 	class DSPCore {
 	  protected:
 		Memory& mem;
+		DSPService& dspService;
 		MAKE_LOG_FUNCTION(log, dspLogger)
 
 	  public:
 		enum class Type { Null, Teakra };
-		DSPCore(Memory& mem) : mem(mem) {}
+		DSPCore(Memory& mem, DSPService& dspService) : mem(mem), dspService(dspService) {}
 
 		virtual void reset() = 0;
 		virtual void runAudioFrame() = 0;
@@ -31,5 +36,5 @@ namespace Audio {
 		virtual void setSemaphoreMask(u16 value) = 0;
 	};
 
-	std::unique_ptr<DSPCore> makeDSPCore(DSPCore::Type type, Memory& mem);
+	std::unique_ptr<DSPCore> makeDSPCore(DSPCore::Type type, Memory& mem, DSPService& dspService);
 }  // namespace Audio

--- a/include/audio/dsp_core.hpp
+++ b/include/audio/dsp_core.hpp
@@ -1,0 +1,35 @@
+#pragma once
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "helpers.hpp"
+#include "logger.hpp"
+#include "memory.hpp"
+
+namespace Audio {
+	class DSPCore {
+	  protected:
+		Memory& mem;
+		MAKE_LOG_FUNCTION(log, dspLogger)
+
+	  public:
+		enum class Type { Null, Teakra };
+		DSPCore(Memory& mem) : mem(mem) {}
+
+		virtual void reset() = 0;
+		virtual void runAudioFrame() = 0;
+		virtual u8* getDspMemory() = 0;
+
+		virtual u16 recvData(u32 regId) = 0;
+		virtual bool recvDataIsReady(u32 regId) = 0;
+		virtual void setSemaphore(u16 value) = 0;
+		virtual void writeProcessPipe(u32 channel, u32 size, u32 buffer) = 0;
+		virtual std::vector<u8> readPipe(u32 channel, u32 peer, u32 size, u32 buffer) = 0;
+		virtual void loadComponent(std::vector<u8>& data, u32 programMask, u32 dataMask) = 0;
+		virtual void unloadComponent() = 0;
+		virtual void setSemaphoreMask(u16 value) = 0;
+	};
+
+	std::unique_ptr<DSPCore> makeDSPCore(DSPCore::Type type, Memory& mem);
+}  // namespace Audio

--- a/include/audio/dsp_core.hpp
+++ b/include/audio/dsp_core.hpp
@@ -2,15 +2,17 @@
 #include <array>
 #include <functional>
 #include <memory>
+#include <optional>
+#include <string>
 #include <vector>
 
 #include "helpers.hpp"
 #include "logger.hpp"
-#include "memory.hpp"
 #include "scheduler.hpp"
 
 // The DSP core must have access to the DSP service to be able to trigger interrupts properly
 class DSPService;
+class Memory;
 
 namespace Audio {
 	// There are 160 stereo samples in 1 audio frame, so 320 samples total
@@ -44,6 +46,9 @@ namespace Audio {
 		virtual void loadComponent(std::vector<u8>& data, u32 programMask, u32 dataMask) = 0;
 		virtual void unloadComponent() = 0;
 		virtual void setSemaphoreMask(u16 value) = 0;
+
+		static Audio::DSPCore::Type typeFromString(std::string inString);
+		static const char* typeToString(Audio::DSPCore::Type type);
 	};
 
 	std::unique_ptr<DSPCore> makeDSPCore(DSPCore::Type type, Memory& mem, Scheduler& scheduler, DSPService& dspService);

--- a/include/audio/null_core.hpp
+++ b/include/audio/null_core.hpp
@@ -20,7 +20,7 @@ namespace Audio {
 		void resetAudioPipe();
 
 	  public:
-		NullDSP(Memory& mem) : DSPCore(mem) {}
+		NullDSP(Memory& mem, DSPService& dspService) : DSPCore(mem, dspService) {}
 
 		void reset() override;
 		void runAudioFrame() override {}

--- a/include/audio/null_core.hpp
+++ b/include/audio/null_core.hpp
@@ -20,12 +20,14 @@ namespace Audio {
 		std::array<u8, Memory::DSP_RAM_SIZE> dspRam;
 
 		void resetAudioPipe();
+		bool loaded = false; // Have we loaded a component?
 
 	  public:
 		NullDSP(Memory& mem, Scheduler& scheduler, DSPService& dspService) : DSPCore(mem, scheduler, dspService) {}
 
 		void reset() override;
-		void runAudioFrame() override {}
+		void runAudioFrame() override;
+
 		u8* getDspMemory() override { return dspRam.data(); }
 
 		u16 recvData(u32 regId) override;
@@ -34,8 +36,8 @@ namespace Audio {
 		std::vector<u8> readPipe(u32 channel, u32 peer, u32 size, u32 buffer) override;
 
 		// NOPs for null DSP core
-		void loadComponent(std::vector<u8>& data, u32 programMask, u32 dataMask) override {}
-		void unloadComponent() override {}
+		void loadComponent(std::vector<u8>& data, u32 programMask, u32 dataMask) override;
+		void unloadComponent() override;
 		void setSemaphore(u16 value) override {}
 		void setSemaphoreMask(u16 value) override {}
 	};

--- a/include/audio/null_core.hpp
+++ b/include/audio/null_core.hpp
@@ -1,0 +1,41 @@
+#pragma once
+#include <array>
+#include "audio/dsp_core.hpp"
+
+namespace Audio {
+	class NullDSP : public DSPCore {
+		enum class DSPState : u32 {
+			Off,
+			On,
+			Slep,
+		};
+
+		// Number of DSP pipes
+		static constexpr size_t pipeCount = 8;
+		DSPState dspState;
+
+		std::array<std::vector<u8>, pipeCount> pipeData;  // The data of each pipe
+		std::array<u8, Memory::DSP_RAM_SIZE> dspRam;
+
+		void resetAudioPipe();
+
+	  public:
+		NullDSP(Memory& mem) : DSPCore(mem) {}
+
+		void reset() override;
+		void runAudioFrame() override {}
+		u8* getDspMemory() override { return dspRam.data(); }
+
+		u16 recvData(u32 regId) override;
+		bool recvDataIsReady(u32 regId) override { return true; } // Treat data as always ready
+		void writeProcessPipe(u32 channel, u32 size, u32 buffer) override;
+		std::vector<u8> readPipe(u32 channel, u32 peer, u32 size, u32 buffer) override;
+
+		// NOPs for null DSP core
+		void loadComponent(std::vector<u8>& data, u32 programMask, u32 dataMask) override {}
+		void unloadComponent() override {}
+		void setSemaphore(u16 value) override {}
+		void setSemaphoreMask(u16 value) override {}
+	};
+
+}  // namespace Audio

--- a/include/audio/null_core.hpp
+++ b/include/audio/null_core.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <array>
+
 #include "audio/dsp_core.hpp"
+#include "memory.hpp"
 
 namespace Audio {
 	class NullDSP : public DSPCore {
@@ -27,7 +29,7 @@ namespace Audio {
 		u8* getDspMemory() override { return dspRam.data(); }
 
 		u16 recvData(u32 regId) override;
-		bool recvDataIsReady(u32 regId) override { return true; } // Treat data as always ready
+		bool recvDataIsReady(u32 regId) override { return true; }  // Treat data as always ready
 		void writeProcessPipe(u32 channel, u32 size, u32 buffer) override;
 		std::vector<u8> readPipe(u32 channel, u32 peer, u32 size, u32 buffer) override;
 

--- a/include/audio/null_core.hpp
+++ b/include/audio/null_core.hpp
@@ -20,7 +20,7 @@ namespace Audio {
 		void resetAudioPipe();
 
 	  public:
-		NullDSP(Memory& mem, DSPService& dspService) : DSPCore(mem, dspService) {}
+		NullDSP(Memory& mem, Scheduler& scheduler, DSPService& dspService) : DSPCore(mem, scheduler, dspService) {}
 
 		void reset() override;
 		void runAudioFrame() override {}

--- a/include/audio/teakra_core.hpp
+++ b/include/audio/teakra_core.hpp
@@ -79,7 +79,7 @@ namespace Audio {
 
 		u16 recvData(u32 regId) override { return teakra.RecvData(regId); }
 		bool recvDataIsReady(u32 regId) override { return teakra.RecvDataIsReady(regId); }
-		void setSemaphore(u16 value) override { return teakra.SetSemaphore(value); }
+		void setSemaphore(u16 value) override { teakra.SetSemaphore(value); }
 		void setSemaphoreMask(u16 value) override { teakra.MaskSemaphore(value); }
 
 		void writeProcessPipe(u32 channel, u32 size, u32 buffer) override;

--- a/include/audio/teakra_core.hpp
+++ b/include/audio/teakra_core.hpp
@@ -65,14 +65,22 @@ namespace Audio {
 		bool signalledData;
 		bool signalledSemaphore;
 
+		// Run 1 slice of DSP instructions
+		void runSlice() {
+			if (running) {
+				teakra.Run(Audio::lleSlice);
+			}
+		}
+
 	  public:
-		TeakraDSP(Memory& mem, DSPService& dspService);
+		TeakraDSP(Memory& mem, Scheduler& scheduler, DSPService& dspService);
 
 		void reset() override;
+
+		// Run 1 slice of DSP instructions and schedule the next audio frame
 		void runAudioFrame() override {
-			if (running) {
-				teakra.Run(16384);
-			}
+			runSlice();
+			scheduler.addEvent(Scheduler::EventType::RunDSP, scheduler.currentTimestamp + Audio::lleSlice * 2);
 		}
 
 		u8* getDspMemory() override { return teakra.GetDspMemory().data(); }

--- a/include/audio/teakra_core.hpp
+++ b/include/audio/teakra_core.hpp
@@ -12,7 +12,12 @@ namespace Audio {
 		TeakraDSP(Memory& mem);
 
 		void reset() override;
-		void runAudioFrame() override;
+		void runAudioFrame() override {
+			if (running) {
+				teakra.Run(16384);
+			}
+		}
+
 		u8* getDspMemory() override { return teakra.GetDspMemory().data(); }
 
 		u16 recvData(u32 regId) override { return teakra.RecvData(regId); }

--- a/include/audio/teakra_core.hpp
+++ b/include/audio/teakra_core.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "audio/dsp_core.hpp"
+#include "swap.hpp"
 #include "teakra/teakra.h"
 
 namespace Audio {
@@ -8,8 +9,63 @@ namespace Audio {
 		u32 pipeBaseAddr;
 		bool running;
 
+		// Get a pointer to a data memory address
+		u8* getDataPointer(u32 address) { return getDspMemory() + Memory::DSP_DATA_MEMORY_OFFSET + address; }
+
+		enum class PipeDirection {
+			DSPtoCPU = 0,
+			CPUtoDSP = 1,
+		};
+
+		// A lot of Teakra integration code, especially pipe stuff are based on Citra's integration here:
+		// https://github.com/citra-emu/citra/blob/master/src/audio_core/lle/lle.cpp
+		struct PipeStatus {
+			// All addresses and sizes here refer to byte values, NOT 16-bit values.
+			u16_le address;
+			u16_le byteSize;
+			u16_le readPointer;
+			u16_le writePointer;
+			u8 slot;
+			u8 flags;
+
+			static constexpr u16 wrapBit = 0x8000;
+			static constexpr u16 pointerMask = 0x7FFF;
+
+			bool isFull() const { return (readPointer ^ writePointer) == wrapBit; }
+			bool isEmpty() const { return (readPointer ^ writePointer) == 0; }
+
+			 // isWrapped: Are read and write pointers in different memory passes.
+			 // true:   xxxx]----[xxxx (data is wrapping around the end of memory)
+			 // false:  ----[xxxx]----
+			bool isWrapped() const { return (readPointer ^ writePointer) >= wrapBit; }
+		};
+		static_assert(sizeof(PipeStatus) == 10, "Teakra: Pipe Status size is wrong");
+		static constexpr u8 pipeToSlotIndex(u8 pipe, PipeDirection direction) { return (pipe * 2) + u8(direction); }
+
+		PipeStatus getPipeStatus(u8 pipe, PipeDirection direction) {
+			PipeStatus ret;
+			const u8 index = pipeToSlotIndex(pipe, direction);
+
+			std::memcpy(&ret, getDataPointer(pipeBaseAddr * 2 + index * sizeof(PipeStatus)), sizeof(PipeStatus));
+			return ret;
+		}
+
+		void updatePipeStatus(const PipeStatus& status) {
+			u8 slot = status.slot;
+			u8* statusAddress = getDataPointer(pipeBaseAddr * 2 + slot * sizeof(PipeStatus));
+
+			if (slot % 2 == 0) {
+				std::memcpy(statusAddress + 4, &status.readPointer, sizeof(u16));
+			} else {
+				std::memcpy(statusAddress + 6, &status.writePointer, sizeof(u16));
+			}
+		}
+
+		bool signalledData;
+		bool signalledSemaphore;
+
 	  public:
-		TeakraDSP(Memory& mem);
+		TeakraDSP(Memory& mem, DSPService& dspService);
 
 		void reset() override;
 		void runAudioFrame() override {

--- a/include/audio/teakra_core.hpp
+++ b/include/audio/teakra_core.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#include "audio/dsp_core.hpp"
+#include "teakra/teakra.h"
+
+namespace Audio {
+	class TeakraDSP : public DSPCore {
+		Teakra::Teakra teakra;
+		u32 pipeBaseAddr;
+		bool running;
+
+	  public:
+		TeakraDSP(Memory& mem);
+
+		void reset() override;
+		void runAudioFrame() override;
+		u8* getDspMemory() override { return teakra.GetDspMemory().data(); }
+
+		u16 recvData(u32 regId) override { return teakra.RecvData(regId); }
+		bool recvDataIsReady(u32 regId) override { return teakra.RecvDataIsReady(regId); }
+		void setSemaphore(u16 value) override { return teakra.SetSemaphore(value); }
+		void setSemaphoreMask(u16 value) override { teakra.MaskSemaphore(value); }
+
+		void writeProcessPipe(u32 channel, u32 size, u32 buffer) override;
+		std::vector<u8> readPipe(u32 channel, u32 peer, u32 size, u32 buffer) override;
+		void loadComponent(std::vector<u8>& data, u32 programMask, u32 dataMask) override;
+		void unloadComponent() override;
+	};
+}  // namespace Audio

--- a/include/audio/teakra_core.hpp
+++ b/include/audio/teakra_core.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "audio/dsp_core.hpp"
+#include "memory.hpp"
 #include "swap.hpp"
 #include "teakra/teakra.h"
 
@@ -35,9 +36,9 @@ namespace Audio {
 			bool isFull() const { return (readPointer ^ writePointer) == wrapBit; }
 			bool isEmpty() const { return (readPointer ^ writePointer) == 0; }
 
-			 // isWrapped: Are read and write pointers in different memory passes.
-			 // true:   xxxx]----[xxxx (data is wrapping around the end of memory)
-			 // false:  ----[xxxx]----
+			// isWrapped: Are read and write pointers in different memory passes.
+			// true:   xxxx]----[xxxx (data is wrapping around the end of memory)
+			// false:  ----[xxxx]----
 			bool isWrapped() const { return (readPointer ^ writePointer) >= wrapBit; }
 		};
 		static_assert(sizeof(PipeStatus) == 10, "Teakra: Pipe Status size is wrong");

--- a/include/audio/teakra_core.hpp
+++ b/include/audio/teakra_core.hpp
@@ -7,7 +7,8 @@ namespace Audio {
 	class TeakraDSP : public DSPCore {
 		Teakra::Teakra teakra;
 		u32 pipeBaseAddr;
-		bool running;
+		bool running;  // Is the DSP running?
+		bool loaded;   // Have we finished loading a binary with LoadComponent?
 
 		// Get a pointer to a data memory address
 		u8* getDataPointer(u32 address) { return getDspMemory() + Memory::DSP_DATA_MEMORY_OFFSET + address; }
@@ -17,7 +18,7 @@ namespace Audio {
 			CPUtoDSP = 1,
 		};
 
-		// A lot of Teakra integration code, especially pipe stuff are based on Citra's integration here:
+		// A lot of Teakra integration code, especially pipe stuff is based on Citra's integration here:
 		// https://github.com/citra-emu/citra/blob/master/src/audio_core/lle/lle.cpp
 		struct PipeStatus {
 			// All addresses and sizes here refer to byte values, NOT 16-bit values.

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <filesystem>
 
+#include "audio/dsp_core.hpp"
 #include "renderer.hpp"
 
 // Remember to initialize every field here to its default value otherwise bad things will happen
@@ -15,6 +16,7 @@ struct EmulatorConfig {
 	bool shaderJitEnabled = shaderJitDefault;
 	bool discordRpcEnabled = false;
 	RendererType rendererType = RendererType::OpenGL;
+	Audio::DSPCore::Type dspType = Audio::DSPCore::Type::Null;
 
 	bool sdCardInserted = true;
 	bool sdWriteProtected = false;

--- a/include/emulator.hpp
+++ b/include/emulator.hpp
@@ -2,10 +2,12 @@
 
 #include <filesystem>
 #include <fstream>
+#include <memory>
 #include <optional>
 #include <span>
 
 #include "PICA/gpu.hpp"
+#include "audio/dsp_core.hpp"
 #include "cheats.hpp"
 #include "config.hpp"
 #include "cpu.hpp"
@@ -41,9 +43,11 @@ class Emulator {
 	GPU gpu;
 	Memory memory;
 	Kernel kernel;
+	std::unique_ptr<Audio::DSPCore> dsp;
+	Scheduler scheduler;
+
 	Crypto::AESEngine aesEngine;
 	Cheats cheats;
-	Scheduler scheduler;
 
 	// Variables to keep track of whether the user is controlling the 3DS analog stick with their keyboard
 	// This is done so when a gamepad is connected, we won't automatically override the 3DS analog stick settings with the gamepad's state

--- a/include/kernel/kernel.hpp
+++ b/include/kernel/kernel.hpp
@@ -245,6 +245,5 @@ public:
 	ServiceManager& getServiceManager() { return serviceManager; }
 
 	void sendGPUInterrupt(GPUInterrupt type) { serviceManager.sendGPUInterrupt(type); }
-	void signalDSPEvents() { serviceManager.signalDSPEvents(); }
 	void clearInstructionCache();
 };

--- a/include/kernel/kernel.hpp
+++ b/include/kernel/kernel.hpp
@@ -66,15 +66,20 @@ class Kernel {
 	Handle makeMemoryBlock(u32 addr, u32 size, u32 myPermission, u32 otherPermission);
 
 public:
-	Handle makeEvent(ResetType resetType); // Needs to be public to be accessible to the APT/HID services
-	Handle makeMutex(bool locked = false); // Needs to be public to be accessible to the APT/DSP services
-	Handle makeSemaphore(u32 initialCount, u32 maximumCount); // Needs to be public to be accessible to the service manager port
+	// Needs to be public to be accessible to the APT/HID services
+	Handle makeEvent(ResetType resetType, Event::CallbackType callback = Event::CallbackType::None);
+	// Needs to be public to be accessible to the APT/DSP services
+	Handle makeMutex(bool locked = false);
+	// Needs to be public to be accessible to the service manager port
+	Handle makeSemaphore(u32 initialCount, u32 maximumCount);
 	Handle makeTimer(ResetType resetType);
 	void pollTimers();
 
 	// Signals an event, returns true on success or false if the event does not exist
 	bool signalEvent(Handle e);
-	
+	// Run the callback for "special" events that have callbacks
+	void runEventCallback(Event::CallbackType callback);
+
 	void clearEvent(Handle e) {
 		KernelObject* object = getObject(e, KernelObjectType::Event);
 		if (object != nullptr) {

--- a/include/kernel/kernel_types.hpp
+++ b/include/kernel/kernel_types.hpp
@@ -62,11 +62,19 @@ struct Process {
 };
 
 struct Event {
+    // Some events (for now, only the DSP semaphore events) need to execute a callback when signalled
+    // This enum stores what kind of callback they should execute
+    enum class CallbackType : u32 {
+        None, DSPSemaphore,
+    };
+
     u64 waitlist; // A bitfield where each bit symbolizes if the thread with thread with the corresponding index is waiting on the event
     ResetType resetType = ResetType::OneShot;
+    CallbackType callback = CallbackType::None;
     bool fired = false;
 
     Event(ResetType resetType) : resetType(resetType), waitlist(0) {}
+    Event(ResetType resetType, CallbackType cb) : resetType(resetType), waitlist(0), callback(cb) {}
 };
 
 struct Port {

--- a/include/logger.hpp
+++ b/include/logger.hpp
@@ -36,6 +36,7 @@ namespace Log {
 	static Logger<false> gpuLogger;
 	static Logger<false> rendererLogger;
 	static Logger<false> shaderJITLogger;
+	static Logger<false> dspLogger;
 
 	// Service loggers
 	static Logger<false> acLogger;

--- a/include/memory.hpp
+++ b/include/memory.hpp
@@ -100,8 +100,8 @@ namespace KernelMemoryTypes {
 
 class Memory {
 	u8* fcram;
-	u8* dspRam;
-	u8* vram;  // Provided to the memory class by the GPU class
+	u8* dspRam;  // Provided to us by Audio
+	u8* vram;    // Provided to the memory class by the GPU class
 
 	u64& cpuTicks; // Reference to the CPU tick counter
 	using SharedMemoryBlock = KernelMemoryTypes::SharedMemoryBlock;
@@ -281,6 +281,8 @@ private:
 	u32 getUsedUserMem() { return usedUserMemory; }
 
 	void setVRAM(u8* pointer) { vram = pointer; }
+	void setDSPMem(u8* pointer) { dspRam = pointer; }
+
 	bool allocateMainThreadStack(u32 size);
 	Regions getConsoleRegion();
 	void copySharedFont(u8* ptr);

--- a/include/scheduler.hpp
+++ b/include/scheduler.hpp
@@ -50,7 +50,6 @@ struct Scheduler {
 		// Clear any pending events
 		events.clear();
 		addEvent(Scheduler::EventType::VBlank, arm11Clock / 60);
-		addEvent(Scheduler::EventType::RunDSP, 16384 * 2);
 
 		// Add a dummy event to always keep the scheduler non-empty
 		addEvent(EventType::Panic, std::numeric_limits<u64>::max());

--- a/include/scheduler.hpp
+++ b/include/scheduler.hpp
@@ -10,7 +10,8 @@ struct Scheduler {
 	enum class EventType {
 		VBlank = 0,          // End of frame event
 		UpdateTimers = 1,    // Update kernel timer objects
-		Panic = 2,           // Dummy event that is always pending and should never be triggered (Timestamp = UINT64_MAX)
+		RunDSP = 2,          // Make the emulated DSP run for one audio frame
+		Panic = 3,           // Dummy event that is always pending and should never be triggered (Timestamp = UINT64_MAX)
 		TotalNumberOfEvents  // How many event types do we have in total?
 	};
 	static constexpr usize totalNumberOfEvents = static_cast<usize>(EventType::TotalNumberOfEvents);
@@ -49,6 +50,7 @@ struct Scheduler {
 		// Clear any pending events
 		events.clear();
 		addEvent(Scheduler::EventType::VBlank, arm11Clock / 60);
+		addEvent(Scheduler::EventType::RunDSP, 16384 * 2);
 
 		// Add a dummy event to always keep the scheduler non-empty
 		addEvent(EventType::Panic, std::numeric_limits<u64>::max());

--- a/include/services/dsp.hpp
+++ b/include/services/dsp.hpp
@@ -1,16 +1,11 @@
 #pragma once
 #include <array>
 #include <optional>
+#include "audio/dsp_core.hpp"
 #include "helpers.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
 #include "result/result.hpp"
-
-namespace DSPPipeType {
-	enum : u32 {
-		Debug = 0, DMA = 1, Audio = 2, Binary = 3
-	};
-}
 
 // Circular dependencies!
 class Kernel;
@@ -19,15 +14,11 @@ class DSPService {
 	Handle handle = KernelHandles::DSP;
 	Memory& mem;
 	Kernel& kernel;
+	Audio::DSPCore* dsp = nullptr;
 	MAKE_LOG_FUNCTION(log, dspServiceLogger)
-
-	enum class DSPState : u32 {
-		Off, On, Slep
-	};
 
 	// Number of DSP pipes
 	static constexpr size_t pipeCount = 8;
-	DSPState dspState;
 
 	// DSP service event handles
 	using DSPEvent = std::optional<Handle>;
@@ -36,10 +27,6 @@ class DSPService {
 	DSPEvent interrupt0;
 	DSPEvent interrupt1;
 	std::array<DSPEvent, pipeCount> pipeEvents;
-	std::array<std::vector<u8>, pipeCount> pipeData; // The data of each pipe
-
-	void resetAudioPipe();
-	std::vector<u8> readPipe(u32 pipe, u32 size);
 
 	DSPEvent& getEventRef(u32 type, u32 pipe);
 	static constexpr size_t maxEventCount = 6;
@@ -67,6 +54,7 @@ public:
 	DSPService(Memory& mem, Kernel& kernel) : mem(mem), kernel(kernel) {}
 	void reset();
 	void handleSyncRequest(u32 messagePointer);
+	void setDSPCore(Audio::DSPCore* pointer) { dsp = pointer; }
 
 	enum class SoundOutputMode : u8 {
 		Mono = 0,

--- a/include/services/dsp.hpp
+++ b/include/services/dsp.hpp
@@ -63,4 +63,8 @@ public:
 	};
 
 	void signalEvents();
+	void triggerPipeEvent(int index);
+	void triggerSemaphoreEvent();
+	void triggerInterrupt0();
+	void triggerInterrupt1();
 };

--- a/include/services/dsp.hpp
+++ b/include/services/dsp.hpp
@@ -27,6 +27,7 @@ class DSPService {
 	DSPEvent interrupt0;
 	DSPEvent interrupt1;
 	std::array<DSPEvent, pipeCount> pipeEvents;
+	u16 semaphoreMask = 0;
 
 	DSPEvent& getEventRef(u32 type, u32 pipe);
 	static constexpr size_t maxEventCount = 6;
@@ -55,6 +56,9 @@ public:
 	void reset();
 	void handleSyncRequest(u32 messagePointer);
 	void setDSPCore(Audio::DSPCore* pointer) { dsp = pointer; }
+	
+	// Special callback that's ran when the semaphore event is signalled
+	void onSemaphoreEventSignal() { dsp->setSemaphore(semaphoreMask); }
 
 	enum class SoundOutputMode : u8 {
 		Mono = 0,

--- a/include/services/dsp.hpp
+++ b/include/services/dsp.hpp
@@ -66,7 +66,6 @@ public:
 		Surround = 2
 	};
 
-	void signalEvents();
 	void triggerPipeEvent(int index);
 	void triggerSemaphoreEvent();
 	void triggerInterrupt0();

--- a/include/services/service_manager.hpp
+++ b/include/services/service_manager.hpp
@@ -110,4 +110,5 @@ class ServiceManager {
 	// Input function wrappers
 	HIDService& getHID() { return hid; }
 	NFCService& getNFC() { return nfc; }
+	DSPService& getDSP() { return dsp; }
 };

--- a/include/services/service_manager.hpp
+++ b/include/services/service_manager.hpp
@@ -105,8 +105,6 @@ class ServiceManager {
 	void setHIDSharedMem(u8* ptr) { hid.setSharedMem(ptr); }
 	void setCSNDSharedMem(u8* ptr) { csnd.setSharedMemory(ptr); }
 
-	void signalDSPEvents() { dsp.signalEvents(); }
-
 	// Input function wrappers
 	HIDService& getHID() { return hid; }
 	NFCService& getNFC() { return nfc; }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -62,6 +62,16 @@ void EmulatorConfig::load() {
 		}
 	}
 
+	if (data.contains("Audio")) {
+		auto audioResult = toml::expect<toml::value>(data.at("Audio"));
+		if (audioResult.is_ok()) {
+			auto audio = audioResult.unwrap();
+
+			auto dspCoreName = toml::find_or<std::string>(audio, "DSPEmulation", "Null");
+			dspType = Audio::DSPCore::typeFromString(dspCoreName);
+		}
+	}
+
 	if (data.contains("Battery")) {
 		auto batteryResult = toml::expect<toml::value>(data.at("Battery"));
 		if (batteryResult.is_ok()) {
@@ -109,6 +119,7 @@ void EmulatorConfig::save() {
 	data["General"]["UsePortableBuild"] = usePortableBuild;
 	data["GPU"]["EnableShaderJIT"] = shaderJitEnabled;
 	data["GPU"]["Renderer"] = std::string(Renderer::typeToString(rendererType));
+	data["Audio"]["DSPEmulation"] = std::string(Audio::DSPCore::typeToString(dspType));
 
 	data["Battery"]["ChargerPlugged"] = chargerPlugged;
 	data["Battery"]["BatteryPercentage"] = batteryPercentage;

--- a/src/core/audio/dsp_core.cpp
+++ b/src/core/audio/dsp_core.cpp
@@ -1,0 +1,21 @@
+#include "audio/dsp_core.hpp"
+
+#include "audio/null_core.hpp"
+#include "audio/teakra_core.hpp"
+
+std::unique_ptr<Audio::DSPCore> Audio::makeDSPCore(DSPCore::Type type, Memory& mem) {
+	std::unique_ptr<DSPCore> core;
+
+	switch (type) {
+		case DSPCore::Type::Null: core = std::make_unique<NullDSP>(mem); break;
+		case DSPCore::Type::Teakra: core = std::make_unique<TeakraDSP>(mem); break;
+
+		default:
+			Helpers::warn("Invalid DSP core selected!");
+			core = std::make_unique<NullDSP>(mem);
+			break;
+	}
+
+	mem.setDSPMem(core->getDspMemory());
+	return core;
+}

--- a/src/core/audio/dsp_core.cpp
+++ b/src/core/audio/dsp_core.cpp
@@ -3,6 +3,10 @@
 #include "audio/null_core.hpp"
 #include "audio/teakra_core.hpp"
 
+#include <algorithm>
+#include <cctype>
+#include <unordered_map>
+
 std::unique_ptr<Audio::DSPCore> Audio::makeDSPCore(DSPCore::Type type, Memory& mem, Scheduler& scheduler, DSPService& dspService) {
 	std::unique_ptr<DSPCore> core;
 
@@ -18,4 +22,31 @@ std::unique_ptr<Audio::DSPCore> Audio::makeDSPCore(DSPCore::Type type, Memory& m
 
 	mem.setDSPMem(core->getDspMemory());
 	return core;
+}
+
+Audio::DSPCore::Type Audio::DSPCore::typeFromString(std::string inString) {
+	// Transform to lower-case to make the setting case-insensitive
+	std::transform(inString.begin(), inString.end(), inString.begin(), [](unsigned char c) { return std::tolower(c); });
+
+	static const std::unordered_map<std::string, Audio::DSPCore::Type> map = {
+		{"null", Audio::DSPCore::Type::Null},
+		{"none", Audio::DSPCore::Type::Null},
+		{"lle", Audio::DSPCore::Type::Teakra},
+		{"teakra", Audio::DSPCore::Type::Teakra},
+	};
+
+	if (auto search = map.find(inString); search != map.end()) {
+		return search->second;
+	}
+
+	printf("Invalid DSP type. Defaulting to null\n");
+	return Audio::DSPCore::Type::Null;
+}
+
+const char* Audio::DSPCore::typeToString(Audio::DSPCore::Type type) {
+	switch (type) {
+		case Audio::DSPCore::Type::Null: return "null";
+		case Audio::DSPCore::Type::Teakra: return "teakra";
+		default: return "invalid";
+	}
 }

--- a/src/core/audio/dsp_core.cpp
+++ b/src/core/audio/dsp_core.cpp
@@ -3,16 +3,16 @@
 #include "audio/null_core.hpp"
 #include "audio/teakra_core.hpp"
 
-std::unique_ptr<Audio::DSPCore> Audio::makeDSPCore(DSPCore::Type type, Memory& mem, DSPService& dspService) {
+std::unique_ptr<Audio::DSPCore> Audio::makeDSPCore(DSPCore::Type type, Memory& mem, Scheduler& scheduler, DSPService& dspService) {
 	std::unique_ptr<DSPCore> core;
 
 	switch (type) {
-		case DSPCore::Type::Null: core = std::make_unique<NullDSP>(mem, dspService); break;
-		case DSPCore::Type::Teakra: core = std::make_unique<TeakraDSP>(mem, dspService); break;
+		case DSPCore::Type::Null: core = std::make_unique<NullDSP>(mem, scheduler, dspService); break;
+		case DSPCore::Type::Teakra: core = std::make_unique<TeakraDSP>(mem, scheduler, dspService); break;
 
 		default:
 			Helpers::warn("Invalid DSP core selected!");
-			core = std::make_unique<NullDSP>(mem, dspService);
+			core = std::make_unique<NullDSP>(mem, scheduler, dspService);
 			break;
 	}
 

--- a/src/core/audio/dsp_core.cpp
+++ b/src/core/audio/dsp_core.cpp
@@ -3,16 +3,16 @@
 #include "audio/null_core.hpp"
 #include "audio/teakra_core.hpp"
 
-std::unique_ptr<Audio::DSPCore> Audio::makeDSPCore(DSPCore::Type type, Memory& mem) {
+std::unique_ptr<Audio::DSPCore> Audio::makeDSPCore(DSPCore::Type type, Memory& mem, DSPService& dspService) {
 	std::unique_ptr<DSPCore> core;
 
 	switch (type) {
-		case DSPCore::Type::Null: core = std::make_unique<NullDSP>(mem); break;
-		case DSPCore::Type::Teakra: core = std::make_unique<TeakraDSP>(mem); break;
+		case DSPCore::Type::Null: core = std::make_unique<NullDSP>(mem, dspService); break;
+		case DSPCore::Type::Teakra: core = std::make_unique<TeakraDSP>(mem, dspService); break;
 
 		default:
 			Helpers::warn("Invalid DSP core selected!");
-			core = std::make_unique<NullDSP>(mem);
+			core = std::make_unique<NullDSP>(mem, dspService);
 			break;
 	}
 

--- a/src/core/audio/null_core.cpp
+++ b/src/core/audio/null_core.cpp
@@ -1,0 +1,129 @@
+#include "audio/null_core.hpp"
+
+namespace Audio {
+	namespace DSPPipeType {
+		enum : u32 {
+			Debug = 0,
+			DMA = 1,
+			Audio = 2,
+			Binary = 3,
+		};
+	}
+
+	void NullDSP::resetAudioPipe() {
+		// Hardcoded responses for now
+		// These are DSP DRAM offsets for various variables
+		// https://www.3dbrew.org/wiki/DSP_Memory_Region
+		static constexpr std::array<u16, 16> responses = {
+			0x000F,  // Number of responses
+			0xBFFF,  // Frame counter
+			0x9E92,  // Source configs
+			0x8680,  // Source statuses
+			0xA792,  // ADPCM coefficients
+			0x9430,  // DSP configs
+			0x8400,  // DSP status
+			0x8540,  // Final samples
+			0x9492,  // Intermediate mix samples
+			0x8710,  // Compressor
+			0x8410,  // Debug
+			0xA912,  // ??
+			0xAA12,  // ??
+			0xAAD2,  // ??
+			0xAC52,  // Surround sound biquad filter 1
+			0xAC5C   // Surround sound biquad filter 2
+		};
+
+		std::vector<u8>& audioPipe = pipeData[DSPPipeType::Audio];
+		audioPipe.resize(responses.size() * sizeof(u16));
+
+		// Push back every response to the audio pipe
+		size_t index = 0;
+		for (auto e : responses) {
+			audioPipe[index++] = e & 0xff;
+			audioPipe[index++] = e >> 8;
+		}
+	}
+
+	void NullDSP::reset() {
+		for (auto& e : pipeData) e.clear();
+
+		// Note: Reset audio pipe AFTER resetting all pipes, otherwise the new data will be yeeted
+		resetAudioPipe();
+	}
+	
+	u16 NullDSP::recvData(u32 regId) {
+		if (regId != 0) {
+			Helpers::panic("Audio: invalid register in null frontend");
+		}
+
+		return dspState == DSPState::On;
+	}
+
+	void NullDSP::writeProcessPipe(u32 channel, u32 size, u32 buffer) {
+		enum class StateChange : u8 {
+			Initialize = 0,
+			Shutdown = 1,
+			Wakeup = 2,
+			Sleep = 3,
+		};
+
+		switch (channel) {
+			case DSPPipeType::Audio: {
+				if (size != 4) {
+					printf("Invalid size written to DSP Audio Pipe\n");
+					break;
+				}
+
+				// Get new state
+				const u8 state = mem.read8(buffer);
+				if (state > 3) {
+					log("WriteProcessPipe::Audio: Unknown state change type");
+				} else {
+					switch (static_cast<StateChange>(state)) {
+						case StateChange::Initialize:
+							// TODO: Other initialization stuff here
+							dspState = DSPState::On;
+							resetAudioPipe();
+							break;
+
+						case StateChange::Shutdown:
+							dspState = DSPState::Off;
+							break;
+
+						default: Helpers::panic("Unimplemented DSP audio pipe state change %d", state);
+					}
+				}
+				break;
+			}
+
+			case DSPPipeType::Binary:
+				Helpers::warn("Unimplemented write to binary pipe! Size: %d\n", size);
+				break;
+
+			default: log("Audio::NullDSP: Wrote to unimplemented pipe %d\n", channel); break;
+		}
+	}
+
+	std::vector<u8> NullDSP::readPipe(u32 pipe, u32 peer, u32 size, u32 buffer) {
+		if (size & 1) Helpers::panic("Tried to read odd amount of bytes from DSP pipe");
+		if (pipe >= pipeCount || size > 0xffff) {
+			return {};
+		}
+
+		if (pipe != DSPPipeType::Audio) {
+			log("Reading from non-audio pipe! This might be broken, might need to check what pipe is being read from and implement writing to it\n");
+		}
+
+		std::vector<u8>& data = pipeData[pipe];
+		size = std::min<u32>(size, data.size());  // Clamp size to the maximum available data size
+
+		if (size == 0) {
+			return {};
+		}
+
+		// Return "size" bytes from the audio pipe and erase them
+		std::vector<u8> out(data.begin(), data.begin() + size);
+		data.erase(data.begin(), data.begin() + size);
+		return out;
+	}
+}  // namespace Audio

--- a/src/core/audio/teakra_core.cpp
+++ b/src/core/audio/teakra_core.cpp
@@ -1,0 +1,150 @@
+#include "audio/teakra_core.hpp"
+
+using namespace Audio;
+
+struct Dsp1 {
+	// All sizes are in bytes unless otherwise specified
+
+	u8 signature[0x100];
+	u8 magic[4];
+	u32 size;
+	u8 codeMemLayout;
+	u8 dataMemLayout;
+	u8 pad[3];
+	u8 specialType;
+	u8 segmentCount;
+	u8 flags;
+	u32 specialStart;
+	u32 specialSize;
+	u64 zeroBits;
+
+	struct Segment {
+		u32 offs;     // Offset of the segment data
+		u32 dspAddr;  // Start of the segment in 16-bit units
+		u32 size;
+		u8 pad[3];
+		u8 type;
+		u8 hash[0x20];
+	};
+
+	Segment segments[10];
+};
+
+TeakraDSP::TeakraDSP(Memory& mem) : DSPCore(mem), pipeBaseAddr(0), running(false) {
+	teakra.Reset();
+
+	// Set up callbacks for Teakra
+	Teakra::AHBMCallback ahbm;
+
+	ahbm.read8 = [&](u32 addr) -> u8 { return mem.read8(addr); };
+	ahbm.read16 = [&](u32 addr) -> u16 { return mem.read16(addr); };
+	ahbm.read32 = [&](u32 addr) -> u32 { return mem.read32(addr); };
+
+	ahbm.write8 = [&](u32 addr, u8 value) { mem.write8(addr, value); };
+	ahbm.write16 = [&](u32 addr, u16 value) { mem.write16(addr, value); };
+	ahbm.write32 = [&](u32 addr, u32 value) { mem.write32(addr, value); };
+
+	teakra.SetAHBMCallback(ahbm);
+	teakra.SetAudioCallback([=](std::array<s16, 2> sample) {
+		// NOP for now
+	});
+}
+
+void TeakraDSP::reset() {
+	teakra.Reset();
+	running = false;
+}
+
+void TeakraDSP::runAudioFrame() {
+	if (running) {
+		teakra.Run(16384);
+	}
+}
+
+void TeakraDSP::writeProcessPipe(u32 channel, u32 size, u32 buffer) {
+	// TODO
+}
+
+std::vector<u8> TeakraDSP::readPipe(u32 channel, u32 peer, u32 size, u32 buffer) {
+	// TODO
+	return std::vector<u8>();
+}
+
+void TeakraDSP::loadComponent(std::vector<u8>& data, u32 programMask, u32 dataMask) {
+	// TODO: maybe move this to the DSP service
+
+	u8* dspCode = teakra.GetDspMemory().data();
+	u8* dspData = dspCode + 0x40000;
+
+	Dsp1 dsp1;
+	memcpy(&dsp1, data.data(), sizeof(dsp1));
+
+	// TODO: verify DSP1 signature
+
+	// Load DSP segments to DSP RAM
+	// TODO: verify hashes
+	for (unsigned int i = 0; i < dsp1.segmentCount; i++) {
+		auto& segment = dsp1.segments[i];
+		u32 addr = segment.dspAddr << 1;
+		u8* src = data.data() + segment.offs;
+		u8* dst = nullptr;
+
+		switch (segment.type) {
+			case 0:
+			case 1: dst = dspCode + addr; break;
+			default: dst = dspData + addr; break;
+		}
+
+		memcpy(dst, src, segment.size);
+	}
+
+	bool syncWithDsp = dsp1.flags & 0x1;
+	bool loadSpecialSegment = (dsp1.flags >> 1) & 0x1;
+
+	// TODO: how does the special segment work?
+	if (loadSpecialSegment) {
+		log("LoadComponent: special segment not supported");
+	}
+
+	running = true;
+
+	if (syncWithDsp) {
+		// Wait for the DSP to reply with 1s in all RECV registers
+		for (int i = 0; i < 3; i++) {
+			do {
+				while (!teakra.RecvDataIsReady(i)) {
+					runAudioFrame();
+				}
+			} while (teakra.RecvData(i) != 1);
+		}
+	}
+
+	// Retrieve the pipe base address
+	while (!teakra.RecvDataIsReady(2)) {
+		runAudioFrame();
+	}
+
+	pipeBaseAddr = teakra.RecvData(2);
+}
+
+void TeakraDSP::unloadComponent() {
+	if (!running) {
+		Helpers::panic("Audio: unloadComponent called without a running program");
+	}
+
+	// Wait for SEND2 to be ready, then send the shutdown command to the DSP
+	while (!teakra.SendDataIsEmpty(2)) {
+		runAudioFrame();
+	}
+
+	teakra.SendData(2, 0x8000);
+
+	// Wait for shutdown to be acknowledged
+	while (!teakra.RecvDataIsReady(2)) {
+		runAudioFrame();
+	}
+
+	// Read the value and discard it, completing shutdown
+	teakra.RecvData(2);
+	running = false;
+}

--- a/src/core/audio/teakra_core.cpp
+++ b/src/core/audio/teakra_core.cpp
@@ -55,12 +55,6 @@ void TeakraDSP::reset() {
 	running = false;
 }
 
-void TeakraDSP::runAudioFrame() {
-	if (running) {
-		teakra.Run(16384);
-	}
-}
-
 void TeakraDSP::writeProcessPipe(u32 channel, u32 size, u32 buffer) {
 	// TODO
 }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -15,7 +15,6 @@ using namespace KernelMemoryTypes;
 
 Memory::Memory(u64& cpuTicks, const EmulatorConfig& config) : cpuTicks(cpuTicks), config(config) {
 	fcram = new uint8_t[FCRAM_SIZE]();
-	dspRam = new uint8_t[DSP_RAM_SIZE]();
 
 	readTable.resize(totalPageCount, 0);
 	writeTable.resize(totalPageCount, 0);

--- a/src/core/services/dsp.cpp
+++ b/src/core/services/dsp.cpp
@@ -262,16 +262,6 @@ void DSPService::invalidateDCache(u32 messagePointer) {
 	mem.write32(messagePointer + 4, Result::Success);
 }
 
-void DSPService::signalEvents() {
-	for (const DSPEvent& e : pipeEvents) {
-		if (e.has_value()) { kernel.signalEvent(e.value()); }
-	}
-
-	if (semaphoreEvent.has_value()) { kernel.signalEvent(semaphoreEvent.value()); }
-	if (interrupt0.has_value()) { kernel.signalEvent(interrupt0.value()); }
-	if (interrupt1.has_value()) { kernel.signalEvent(interrupt1.value()); }
-}
-
 void DSPService::triggerPipeEvent(int index) {
 	if (index < pipeCount && pipeEvents[index].has_value()) {
 		kernel.signalEvent(*pipeEvents[index]);

--- a/src/core/services/dsp.cpp
+++ b/src/core/services/dsp.cpp
@@ -84,7 +84,6 @@ void DSPService::loadComponent(u32 messagePointer) {
 	for (u32 i = 0; i < size; i++) {
 		data[i] = mem.read8(buffer + i);
 	}
-	printf("Loado compartment: %08X %08X %08X %08X\n", data[0], data[1], data[2], data[3]);
 
 	log("DSP::LoadComponent (size = %08X, program mask = %X, data mask = %X\n", size, programMask, dataMask);
 	dsp->loadComponent(data, programMask, dataMask);

--- a/src/core/services/dsp.cpp
+++ b/src/core/services/dsp.cpp
@@ -269,3 +269,27 @@ void DSPService::signalEvents() {
 	if (interrupt0.has_value()) { kernel.signalEvent(interrupt0.value()); }
 	if (interrupt1.has_value()) { kernel.signalEvent(interrupt1.value()); }
 }
+
+void DSPService::triggerPipeEvent(int index) {
+	if (index < pipeCount && pipeEvents[index].has_value()) {
+		kernel.signalEvent(*pipeEvents[index]);
+	}
+}
+
+void DSPService::triggerSemaphoreEvent() {
+	if (semaphoreEvent.has_value()) {
+		kernel.signalEvent(*semaphoreEvent);
+	}
+}
+
+void DSPService::triggerInterrupt0() {
+	if (interrupt0.has_value()) {
+		kernel.signalEvent(*interrupt0);
+	}
+}
+
+void DSPService::triggerInterrupt1() {
+	if (interrupt1.has_value()) {
+		kernel.signalEvent(*interrupt1);
+	}
+}

--- a/src/core/services/dsp.cpp
+++ b/src/core/services/dsp.cpp
@@ -124,7 +124,6 @@ void DSPService::recvData(u32 messagePointer) {
 	log("DSP::RecvData (register = %d)\n", registerIndex);
 	if (registerIndex != 0) Helpers::panic("Unknown register in DSP::RecvData");
 
-	// Return 0 if the DSP is running, otherwise 1
 	const u16 data = dsp->recvData(registerIndex);
 
 	mem.write32(messagePointer, IPC::responseHeader(0x01, 2, 0));

--- a/src/core/services/gsp_gpu.cpp
+++ b/src/core/services/gsp_gpu.cpp
@@ -125,7 +125,7 @@ void GPUService::registerInterruptRelayQueue(u32 messagePointer) {
 void GPUService::requestInterrupt(GPUInterrupt type) {
 	// HACK: Signal DSP events on GPU interrupt for now until we have the DSP since games need DSP events
 	// Maybe there's a better alternative?
-	kernel.signalDSPEvents();
+	// kernel.signalDSPEvents();
 
 	if (sharedMem == nullptr) [[unlikely]] { // Shared memory hasn't been set up yet
 		return;

--- a/src/core/services/gsp_gpu.cpp
+++ b/src/core/services/gsp_gpu.cpp
@@ -123,10 +123,6 @@ void GPUService::registerInterruptRelayQueue(u32 messagePointer) {
 }
 
 void GPUService::requestInterrupt(GPUInterrupt type) {
-	// HACK: Signal DSP events on GPU interrupt for now until we have the DSP since games need DSP events
-	// Maybe there's a better alternative?
-	//kernel.signalDSPEvents();
-
 	if (sharedMem == nullptr) [[unlikely]] { // Shared memory hasn't been set up yet
 		return;
 	}

--- a/src/core/services/gsp_gpu.cpp
+++ b/src/core/services/gsp_gpu.cpp
@@ -125,7 +125,7 @@ void GPUService::registerInterruptRelayQueue(u32 messagePointer) {
 void GPUService::requestInterrupt(GPUInterrupt type) {
 	// HACK: Signal DSP events on GPU interrupt for now until we have the DSP since games need DSP events
 	// Maybe there's a better alternative?
-	// kernel.signalDSPEvents();
+	//kernel.signalDSPEvents();
 
 	if (sharedMem == nullptr) [[unlikely]] { // Shared memory hasn't been set up yet
 		return;

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -24,7 +24,8 @@ Emulator::Emulator()
 	  httpServer(this)
 #endif
 {
-	dsp = Audio::makeDSPCore(Audio::DSPCore::Type::Null, memory);
+	dsp = Audio::makeDSPCore(Audio::DSPCore::Type::Teakra, memory);
+	kernel.getServiceManager().getDSP().setDSPCore(dsp.get());
 
 #ifdef PANDA3DS_ENABLE_DISCORD_RPC
 	if (config.discordRpcEnabled) {

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -26,7 +26,7 @@ Emulator::Emulator()
 {
 	DSPService& dspService = kernel.getServiceManager().getDSP();
 
-	dsp = Audio::makeDSPCore(Audio::DSPCore::Type::Teakra, memory, scheduler, dspService);
+	dsp = Audio::makeDSPCore(config.dspType, memory, scheduler, dspService);
 	dspService.setDSPCore(dsp.get());
 
 #ifdef PANDA3DS_ENABLE_DISCORD_RPC

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -24,6 +24,8 @@ Emulator::Emulator()
 	  httpServer(this)
 #endif
 {
+	dsp = Audio::makeDSPCore(Audio::DSPCore::Type::Null, memory);
+
 #ifdef PANDA3DS_ENABLE_DISCORD_RPC
 	if (config.discordRpcEnabled) {
 		discordRpc.init();

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -26,7 +26,7 @@ Emulator::Emulator()
 {
 	DSPService& dspService = kernel.getServiceManager().getDSP();
 
-	dsp = Audio::makeDSPCore(Audio::DSPCore::Type::Teakra, memory, dspService);
+	dsp = Audio::makeDSPCore(Audio::DSPCore::Type::Teakra, memory, scheduler, dspService);
 	dspService.setDSPCore(dsp.get());
 
 #ifdef PANDA3DS_ENABLE_DISCORD_RPC
@@ -151,7 +151,6 @@ void Emulator::pollScheduler() {
 
 			case Scheduler::EventType::UpdateTimers: kernel.pollTimers(); break;
 			case Scheduler::EventType::RunDSP: {
-				scheduler.addEvent(Scheduler::EventType::RunDSP, time + 16384 * 2);
 				dsp->runAudioFrame();
 				break;
 			}


### PR DESCRIPTION
This PR is the first step for full audio support and for fixing games that are still broken due to needing feedback from the DSP (eg Pokemon XY, Yoshi's Island, Prof Layton, Sonic LW, etc)

The PR revamps the way the DSP interface works by adding a nice interface allowing for easily swappable DSP cores. Currently 2 cores are provided: A "null" core (which is the same as current upstream, fast but no audio) and an LLE core using Teakra. HLE DSP core is going to come at a later date (and potentially more DSP cores for trying out different emulation methods).

Credits go to @PSI-Rockin for making the initial version of this DSP interface and starting Teakra integration, and Citra since its Teakra integration code helped a lot

The LLE core is already booting games, but I'll merge the PR after I fix some broken games and make a proper way of swapping between cores that doesn't have to happen at compile time.
https://media.discordapp.net/attachments/845022869007368252/1208539104996761671/image.png?ex=65e3a6c0&is=65d131c0&hm=9f69b50ff9cd8108b7e0edba5f86f1ba8b98c419382a006fdfc2b7fae1d54ae2&=&format=webp&quality=lossless&width=550&height=700.