### PR TITLE
Implement GetResourceLimitValue for thread count

### DIFF
--- a/src/core/kernel/resource_limits.cpp
+++ b/src/core/kernel/resource_limits.cpp
@@ -82,6 +82,7 @@ s32 Kernel::getCurrentResourceValue(const KernelObject* limit, u32 resourceName)
 	const auto data = static_cast<ResourceLimits*>(limit->data);
 	switch (resourceName) {
 		case ResourceType::Commit: return mem.usedUserMemory;
+		case ResourceType::Thread: return threadIndices.size();
 		default: Helpers::panic("Attempted to get current value of unknown kernel resource: %d\n", resourceName);
 	}
 }


### PR DESCRIPTION
Fixes Langrisser Re:Incarnation and probably some more stuff. Need to wait for #430 to be handled before merging this though

![image](https://github.com/wheremyfoodat/Panda3DS/assets/44909372/71235f1b-5be1-4a39-83a5-35a9697562c3)
