### PR TITLE
GSP_GPU: Implement ReadHwRegs

### DIFF
--- a/include/services/gsp_gpu.hpp
+++ b/include/services/gsp_gpu.hpp
@@ -73,6 +73,7 @@ class GPUService {
 	void acquireRight(u32 messagePointer);
 	void flushDataCache(u32 messagePointer);
 	void importDisplayCaptureInfo(u32 messagePointer);
+	void readHwRegs(u32 messagePointer);
 	void registerInterruptRelayQueue(u32 messagePointer);
 	void releaseRight(u32 messagePointer);
 	void restoreVramSysArea(u32 messagePointer);


### PR DESCRIPTION
Gets Driver Regenade going further, now hangs later, seemingly wanting some camera stuff. Likely also required for other games.