### PR TITLE
Guarantee toml table order

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <fstream>
+#include <map>
 #include <string>
 
 #include "helpers.hpp"
@@ -99,13 +100,13 @@ void EmulatorConfig::load() {
 }
 
 void EmulatorConfig::save() {
-	toml::basic_value<toml::preserve_comments> data;
+	toml::basic_value<toml::preserve_comments, std::map> data;
 	const std::filesystem::path& path = filePath;
 
 	std::error_code error;
 	if (std::filesystem::exists(path, error)) {
 		try {
-			data = toml::parse<toml::preserve_comments>(path);
+			data = toml::parse<toml::preserve_comments, std::map>(path);
 		} catch (const std::exception& ex) {
 			Helpers::warn("Exception trying to parse config file. Exception: %s\n", ex.what());
 			return;


### PR DESCRIPTION
I got frustrated with the toml file having randomized section and key order. This makes toml tables use std::map which preserves order.

This is a purely cosmetic change and does not need to be merged, but making a PR in case it is wanted.