### PR TITLE
General improvements to the windowing system (MASSIVE COMPATIBILITY FIXES)

### DIFF
--- a/src/panda_sdl/frontend_sdl.cpp
+++ b/src/panda_sdl/frontend_sdl.cpp
@@ -35,7 +35,7 @@ FrontendSDL::FrontendSDL() : keyboardMappings(InputMappings::defaultKeyboardMapp
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, config.rendererType == RendererType::Software ? 3 : 4);
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, config.rendererType == RendererType::Software ? 3 : 1);
-		window = SDL_CreateWindow("Alber", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 400, 480, SDL_WINDOW_OPENGL);
+		window = SDL_CreateWindow("Citra", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 400, 480, SDL_WINDOW_OPENGL);
 
 		if (window == nullptr) {
 			Helpers::panic("Window creation failed: %s", SDL_GetError());


### PR DESCRIPTION
### Purpose

Now that Citra is no longer an option for end users, there is a clear need for a new 3DS (not New3DS) emulator to take the scene by storm. After careful consideration, it has been determined that Panda3DS is the best option going forward. Pandas are well known for being the national animal of Japan, and as the 3DS was made by Nintendo, a Japanese company, it stands to reason that Panda3DS should in turn represent the 3DS community.

### Description

This PR redesigns the windowing system from the ground up. Instead of using the host operating system to create the window, this PR includes a copy of the 3DS LCD driver inside Panda3DS. This makes the emulation more authentic to the console and has resulted in a surge of new 3DS (not New3DS) games working. This includes classics such as Pokemon, Persona, God of War, Netflix, Jak and Daxter, Miss Kobayashi's Dragon Maid, and many more.

### Known issues

* Currently these changes only affect the SDL version of the emulator. Qt support is planned for a future date. Unfortunately, Android support is not possible at this time as the compatibility improvements would cause any phones to explode due to accurate emulation.
* New3DS support is not provided, as the console differs so drastically from a 3DS that a new New3DS 3DS emulator would need to be created for this to be possible.
* LLE DSP is still slow. There is no software workaround for this, as accurate LCD emulation makes it impossible for the emulator to do anything other than display graphics. It is recommended to use a separate 3DS console to reproduce game sounds while using the emulator.

I understand that this PR is large, so please take your time reviewing it. Constructive criticism is welcome.