### PR TITLE
panda_sdl: Use sym instead of scancode

### DIFF
--- a/src/panda_sdl/frontend_sdl.cpp
+++ b/src/panda_sdl/frontend_sdl.cpp
@@ -95,7 +95,7 @@ void FrontendSDL::run() {
 				case SDL_KEYDOWN: {
 					if (emu.romType == ROMType::None) break;
 
-					u32 key = getMapping(event.key.keysym.scancode);
+					u32 key = getMapping(event.key.keysym.sym);
 					if (key != HID::Keys::Null) {
 						switch (key) {
 							case HID::Keys::CirclePadRight:
@@ -138,7 +138,7 @@ void FrontendSDL::run() {
 				case SDL_KEYUP: {
 					if (emu.romType == ROMType::None) break;
 
-					u32 key = getMapping(event.key.keysym.scancode);
+					u32 key = getMapping(event.key.keysym.sym);
 					if (key != HID::Keys::Null) {
 						switch (key) {
 							// Err this is probably not ideal


### PR DESCRIPTION
> The scancode field is hardware specific and should be ignored unless you know what your doing. The sym field is the SDLKey value of the key being pressed or released.