### PR TITLE
[CRO] Fix faulty data relocations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ fb.bat
 *.smdh
 
 config.toml
+CMakeSettings.json

--- a/src/core/services/ldr_ro.cpp
+++ b/src/core/services/ldr_ro.cpp
@@ -437,7 +437,7 @@ public:
 			const u32 segmentID = mem.read32(segmentTable.offset + 12 * segment + SegmentTable::ID);
 			switch (segmentID) {
 				case SegmentTable::SegmentID::DATA:
-					*oldDataVaddr = segmentOffset + dataVaddr; oldDataSegmentOffset = segmentOffset; segmentOffset = dataVaddr; break;
+					*oldDataVaddr = segmentOffset + croPointer; oldDataSegmentOffset = segmentOffset; segmentOffset = dataVaddr; break;
 				case SegmentTable::SegmentID::BSS: segmentOffset = bssVaddr; break;
 				case SegmentTable::SegmentID::TEXT:
 				case SegmentTable::SegmentID::RODATA:


### PR DESCRIPTION
The old code based the data pointer used for data relocations off the buffer passed by the application. This is incorrect - the old data segment offset needs to be based upon the start of the CRO file. As a result, data relocations were written to the wrong addresses, potentially causing a crash.

Fixes the NULL pointer crash in ORAS. It likely fixes other crashes in games that use CROs, but this PR needs more testing.