### PR TITLE
[WIP] Memory management improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,7 @@ set(KERNEL_SOURCE_FILES src/core/kernel/kernel.cpp src/core/kernel/resource_limi
                         src/core/kernel/address_arbiter.cpp src/core/kernel/error.cpp
                         src/core/kernel/file_operations.cpp src/core/kernel/directory_operations.cpp
                         src/core/kernel/idle_thread.cpp src/core/kernel/timers.cpp
+                        src/core/kernel/fcram.cpp
 )
 set(SERVICE_SOURCE_FILES src/core/services/service_manager.cpp src/core/services/apt.cpp src/core/services/hid.cpp
                          src/core/services/fs.cpp src/core/services/gsp_gpu.cpp src/core/services/gsp_lcd.cpp

--- a/include/kernel/fcram.hpp
+++ b/include/kernel/fcram.hpp
@@ -1,0 +1,47 @@
+#pragma once
+#include <list>
+#include <memory>
+#include "kernel_types.hpp"
+
+class Memory;
+
+typedef std::list<FcramBlock> FcramBlockList;
+
+class KFcram {
+	struct Region {
+		struct Block {
+			s32 pages;
+			s32 pageOffs;
+			bool used;
+
+			Block(s32 pages, u32 pageOffs) : pages(pages), pageOffs(pageOffs), used(false) {}
+		};
+
+		std::list<Block> blocks;
+		u32 start;
+		s32 pages;
+		s32 freePages;
+	public:
+		Region() : start(0), pages(0) {}
+		void reset(u32 start, size_t size);
+		void alloc(std::list<FcramBlock>& out, s32 pages, bool linear);
+
+		u32 getUsedCount();
+		u32 getFreeCount();
+	};
+
+	Memory& mem;
+
+	Region appRegion, sysRegion, baseRegion;
+	uint8_t* fcram;
+	std::unique_ptr<u32> refs;
+public:
+	KFcram(Memory& memory);
+	void reset(size_t ramSize, size_t appSize, size_t sysSize, size_t baseSize);
+	void alloc(FcramBlockList& out, s32 pages, FcramRegion region, bool linear);
+
+	void incRef(FcramBlockList& list);
+	void decRef(FcramBlockList& list);
+
+	u32 getUsedCount(FcramRegion region);
+};

--- a/include/kernel/kernel.hpp
+++ b/include/kernel/kernel.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "config.hpp"
+#include "fcram.hpp"
 #include "helpers.hpp"
 #include "kernel_types.hpp"
 #include "logger.hpp"
@@ -20,6 +21,8 @@ class Kernel {
 	std::span<u32, 16> regs;
 	CPU& cpu;
 	Memory& mem;
+
+	KFcram fcramManager;
 
 	// The handle number for the next kernel object to be created
 	u32 handleCounter;
@@ -243,6 +246,7 @@ public:
 	}
 
 	ServiceManager& getServiceManager() { return serviceManager; }
+	KFcram& getFcramManager() { return fcramManager; }
 
 	void sendGPUInterrupt(GPUInterrupt type) { serviceManager.sendGPUInterrupt(type); }
 	void clearInstructionCache();

--- a/include/kernel/kernel_types.hpp
+++ b/include/kernel/kernel_types.hpp
@@ -44,6 +44,12 @@ enum class ProcessorID : s32 {
     New3DSExtra2 = 3
 };
 
+enum class FcramRegion {
+    App = 0x100,
+    Sys = 0x200,
+    Base = 0x300
+};
+
 struct AddressArbiter {};
 
 struct ResourceLimits {
@@ -242,4 +248,11 @@ struct KernelObject {
                 Helpers::panic("Called GetWaitList on kernel object without a waitlist (Type: %s)", getTypeName());
 		}
 	}
+};
+
+struct FcramBlock {
+    u32 paddr;
+    s32 pages;
+
+    FcramBlock(u32 paddr, s32 pages) : paddr(paddr), pages(pages) {}
 };

--- a/src/core/kernel/fcram.cpp
+++ b/src/core/kernel/fcram.cpp
@@ -1,0 +1,106 @@
+#include "fcram.hpp"
+#include "memory.hpp"
+
+void KFcram::Region::reset(u32 start, size_t size) {
+	this->start = start;
+	pages = size >> 12;
+	freePages = pages;
+
+	Block initialBlock(pages, 0);
+	blocks.push_back(initialBlock);
+}
+
+void KFcram::Region::alloc(std::list<FcramBlock>& out, s32 allocPages, bool linear) {
+	for (auto it = blocks.begin(); it != blocks.end(); it++) {
+		if (it->used) continue;
+
+		// On linear allocations, only a single contiguous block may be used
+		if (it->pages < allocPages && linear) continue;
+
+		// If the current block is bigger than the allocation, split it
+		if (it->pages > allocPages) {
+			Block newBlock(it->pages - allocPages, it->pageOffs + allocPages);
+			it->pages = allocPages;
+			blocks.insert(it, newBlock);
+		}
+
+		// Mark the block as allocated and add it to the output list
+		it->used = true;
+		allocPages -= it->pages;
+		freePages -= it->pages;
+
+		u32 paddr = start + (it->pageOffs << 12);
+		FcramBlock outBlock(paddr, it->pages);
+		out.push_back(outBlock);
+
+		if (allocPages < 1) return;
+	}
+
+	// Official kernel panics here
+	Helpers::panic("Failed to allocate FCRAM, not enough guest memory");
+}
+
+u32 KFcram::Region::getUsedCount() {
+	return pages - freePages;
+}
+
+u32 KFcram::Region::getFreeCount() {
+	return freePages;
+}
+
+KFcram::KFcram(Memory& mem) : mem(mem) {}
+
+void KFcram::reset(size_t ramSize, size_t appSize, size_t sysSize, size_t baseSize) {
+	fcram = mem.getFCRAM();
+	refs = std::unique_ptr<u32>(new u32[ramSize >> 12]);
+	memset(refs.get(), 0, (ramSize >> 12) * sizeof(u32));
+
+	appRegion.reset(0, appSize);
+	sysRegion.reset(appSize, sysSize);
+	baseRegion.reset(appSize + sysSize, baseSize);
+}
+
+void KFcram::alloc(FcramBlockList& out, s32 pages, FcramRegion region, bool linear) {
+	switch (region) {
+		case FcramRegion::App:
+			appRegion.alloc(out, pages, linear);
+			break;
+		case FcramRegion::Sys:
+			sysRegion.alloc(out, pages, linear);
+			break;
+		case FcramRegion::Base:
+			baseRegion.alloc(out, pages, linear);
+			break;
+		default: Helpers::panic("Invalid FCRAM region chosen for allocation!"); break;
+	}
+
+	incRef(out);
+}
+
+void KFcram::incRef(FcramBlockList& list) {
+	for (auto it = list.begin(); it != list.end(); it++) {
+		for (int i = 0; i < it->pages; i++) {
+			u32 index = (it->paddr >> 12) + i;
+			refs.get()[index]++;
+		}
+	}
+}
+
+void KFcram::decRef(FcramBlockList& list) {
+	for (auto it = list.begin(); it != list.end(); it++) {
+		for (int i = 0; i < it->pages; i++) {
+			u32 index = (it->paddr >> 12) + i;
+			refs.get()[index]--;
+			if (!refs.get()[index]) Helpers::panic("TODO: Freeing FCRAM");
+		}
+	}
+}
+
+u32 KFcram::getUsedCount(FcramRegion region) {
+	switch (region) {
+		case FcramRegion::App: return appRegion.getUsedCount();
+		case FcramRegion::Sys: return sysRegion.getUsedCount();
+		case FcramRegion::Base: return baseRegion.getUsedCount();
+		default: Helpers::panic("Invalid FCRAM region in getUsedCount!");
+	}
+}

--- a/src/core/kernel/resource_limits.cpp
+++ b/src/core/kernel/resource_limits.cpp
@@ -81,7 +81,7 @@ void Kernel::getResourceLimitCurrentValues() {
 s32 Kernel::getCurrentResourceValue(const KernelObject* limit, u32 resourceName) {
 	const auto data = static_cast<ResourceLimits*>(limit->data);
 	switch (resourceName) {
-		case ResourceType::Commit: return mem.usedUserMemory;
+		case ResourceType::Commit: return 0; // TODO: needs to use the current amount of memory allocated by the process
 		case ResourceType::Thread: return threadIndices.size();
 		default: Helpers::panic("Attempted to get current value of unknown kernel resource: %d\n", resourceName);
 	}

--- a/src/core/loader/3dsx.cpp
+++ b/src/core/loader/3dsx.cpp
@@ -26,7 +26,7 @@ namespace {
 }  // namespace
 
 bool Memory::map3DSX(HB3DSX& hb3dsx, const HB3DSX::Header& header) {
-	const LoadInfo hbInfo = {
+/*	const LoadInfo hbInfo = {
 		.codeSegSizeAligned = (header.codeSegSize + 0xFFF) & ~0xFFF,
 		.rodataSegSizeAligned = (header.rodataSegSize + 0xFFF) & ~0xFFF,
 		.dataSegSizeAligned = (header.dataSegSize + 0xFFF) & ~0xFFF,
@@ -186,10 +186,10 @@ bool Memory::map3DSX(HB3DSX& hb3dsx, const HB3DSX::Header& header) {
 				return false;
 			}
 		}
-	}
+	}*/
 
 	// Detect and fill _prm structure
-	HB3DSX::PrmStruct pst;
+	/*HB3DSX::PrmStruct pst;
 	std::memcpy(&pst, &code[4], sizeof(pst));
 	if (pst.magic[0] == '_' && pst.magic[1] == 'p' && pst.magic[2] == 'r' && pst.magic[3] == 'm') {
 		// if there was any argv to put, it would go there
@@ -205,7 +205,7 @@ bool Memory::map3DSX(HB3DSX& hb3dsx, const HB3DSX::Header& header) {
 
 		// RUNFLAG_APTREINIT: Reinitialize APT.
 		// From libctru. Because there's no previously running software here
-		pst.runFlags |= 1 << 1;
+		pst.runFlags |= 1 << 1;*/
 
 		/* s64 dummy;
 		bool isN3DS = svcGetSystemInfo(&dummy, 0x10001, 0) == 0;
@@ -213,7 +213,7 @@ bool Memory::map3DSX(HB3DSX& hb3dsx, const HB3DSX::Header& header) {
 		{
 			pst->heapSize = u32(48_MB);
 			pst->linearHeapSize = u32(64_MB);
-		} else */ {
+		} else *//* {
 			pst.heapSize = u32(24_MB);
 			pst.linearHeapSize = u32(32_MB);
 		}
@@ -228,7 +228,8 @@ bool Memory::map3DSX(HB3DSX& hb3dsx, const HB3DSX::Header& header) {
 	allocateMemory(rodataSegAddr, paddr + rodataOffset, hbInfo.rodataSegSizeAligned, true, true, false, false);    // Rodata is R--
 	allocateMemory(dataSegAddr, paddr + dataOffset, hbInfo.dataSegSizeAligned + 0x1000, true, true, true, false);  // Data+BSS+Extra is RW-
 
-	return true;
+	return true;*/
+return false;
 }
 
 std::optional<u32> Memory::load3DSX(const std::filesystem::path& path) {

--- a/src/core/loader/elf.cpp
+++ b/src/core/loader/elf.cpp
@@ -6,7 +6,7 @@
 using namespace ELFIO;
 
 std::optional<u32> Memory::loadELF(std::ifstream& file) {
-    loadedCXI = std::nullopt; // ELF files don't have a CXI, so set this to null
+/*    loadedCXI = std::nullopt; // ELF files don't have a CXI, so set this to null
 
 	elfio reader;
 	if (!file.good() || !reader.load(file)) {
@@ -65,5 +65,6 @@ std::optional<u32> Memory::loadELF(std::ifstream& file) {
 
     // ELF can't specify a region, make it default to USA
     region = Regions::USA;
-    return static_cast<u32>(reader.get_entry());
+    return static_cast<u32>(reader.get_entry());*/
+    return std::nullopt;
 }

--- a/src/core/services/ldr_ro.cpp
+++ b/src/core/services/ldr_ro.cpp
@@ -1236,7 +1236,8 @@ void LDRService::initialize(u32 messagePointer) {
 	}
 
 	// Map CRO to output address
-	mem.mirrorMapping(mapVaddr, crsPointer, size);
+	// TODO: how to handle permissions?
+	mem.mapVirtualMemory(mapVaddr, crsPointer, size >> 12, true, true, true);
 
 	CRO crs(mem, mapVaddr, false);
 
@@ -1326,7 +1327,8 @@ void LDRService::loadCRO(u32 messagePointer, bool isNew) {
 	}
 
 	// Map CRO to output address
-	mem.mirrorMapping(mapVaddr, croPointer, size);
+	// TODO: how to handle permissions?
+	mem.mapVirtualMemory(mapVaddr, croPointer, size >> 12, true, true, true);
 
 	CRO cro(mem, mapVaddr, true);
 
@@ -1387,6 +1389,8 @@ void LDRService::unloadCRO(u32 messagePointer) {
 	if (!cro.unrebase()) {
 		Helpers::panic("Failed to unrebase CRO");
 	}
+
+	// TODO: unmap the CRO from the pagetable
 
 	kernel.clearInstructionCache();
 

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -17,7 +17,7 @@ __declspec(dllexport) DWORD AmdPowerXpressRequestHighPerformance = 1;
 #endif
 
 Emulator::Emulator()
-	: config(getConfigPath()), kernel(cpu, memory, gpu, config), cpu(memory, kernel, *this), gpu(memory, config), memory(cpu.getTicksRef(), config),
+	: config(getConfigPath()), kernel(cpu, memory, gpu, config), cpu(memory, kernel, *this), gpu(memory, config), memory(kernel.getFcramManager(), cpu.getTicksRef(), config),
 	  cheats(memory, kernel.getServiceManager().getHID()), lua(*this), running(false)
 #ifdef PANDA3DS_ENABLE_HTTP_SERVER
 	  ,


### PR DESCRIPTION
The existing memory management system is somewhat dodgy, to put it lightly. This PR aims to rewrite it almost entirely to improve overall accuracy of the emulator. This is currently a work in progress and will require quite a bit of time to implement all the planned features.

What needs to be done next (in no particular order):

- [ ] Move virtual memory management out of Memory to a KPageTable class to allow for multiple processes in the future
- [ ] Map the configuration and shared memory pages properly
- [ ] Add accurate MemoryState tracking
- [ ] Add memory unmapping
- [ ] Readd 3dsx/ELF loading, which was disabled in the initial commit
- [ ] Implement Protect in ControlMemory
- [ ] Parse kernel capabilities in the exheader to map memory regions such as VRAM (this is currently hardcoded)
- [ ] Reduce the size of TLS to 0x200 bytes per thread, rather than the current 0x1000
- [ ] Add support for large memory applications (e.g. Sun and Moon, which requires 96 MB of application memory)
- [ ] Make services responsible for creating shared memory blocks