### PR TITLE
Index with iterator value rather than getSingleIndex() in CAMService::startCapture

### DIFF
--- a/src/core/services/cam.cpp
+++ b/src/core/services/cam.cpp
@@ -343,7 +343,7 @@ void CAMService::startCapture(u32 messagePointer) {
 
 	if (port.isValid()) {
 		for (int i : port.getPortIndices()) {
-			auto& event = ports[port.getSingleIndex()].receiveEvent;
+			auto& event = ports[i].receiveEvent;
 
 			// Until we properly implement cameras, immediately signal the receive event
 			if (event.has_value()) {


### PR DESCRIPTION
The port may have a value of 3 in this function, which will cause a panic when using getSingleIndex(). getPortIndices() handles this case for us already, so the iterator value is safe to use.

Fixes a crash in The Denpa Men: They Came By Wave (USA).