### PR TITLE
Delay Y2R completion events

### DIFF
--- a/include/kernel/kernel.hpp
+++ b/include/kernel/kernel.hpp
@@ -15,6 +15,7 @@
 #include "services/service_manager.hpp"
 
 class CPU;
+struct Scheduler;
 
 class Kernel {
 	std::span<u32, 16> regs;
@@ -243,6 +244,7 @@ public:
 	}
 
 	ServiceManager& getServiceManager() { return serviceManager; }
+	Scheduler& getScheduler();
 
 	void sendGPUInterrupt(GPUInterrupt type) { serviceManager.sendGPUInterrupt(type); }
 	void clearInstructionCache();

--- a/include/scheduler.hpp
+++ b/include/scheduler.hpp
@@ -11,7 +11,8 @@ struct Scheduler {
 		VBlank = 0,          // End of frame event
 		UpdateTimers = 1,    // Update kernel timer objects
 		RunDSP = 2,          // Make the emulated DSP run for one audio frame
-		Panic = 3,           // Dummy event that is always pending and should never be triggered (Timestamp = UINT64_MAX)
+		SignalY2R = 3,       // Signal that a Y2R conversion has finished
+		Panic = 4,           // Dummy event that is always pending and should never be triggered (Timestamp = UINT64_MAX)
 		TotalNumberOfEvents  // How many event types do we have in total?
 	};
 	static constexpr usize totalNumberOfEvents = static_cast<usize>(EventType::TotalNumberOfEvents);

--- a/include/services/service_manager.hpp
+++ b/include/services/service_manager.hpp
@@ -109,4 +109,5 @@ class ServiceManager {
 	HIDService& getHID() { return hid; }
 	NFCService& getNFC() { return nfc; }
 	DSPService& getDSP() { return dsp; }
+	Y2RService& getY2R() { return y2r; }
 };

--- a/include/services/y2r.hpp
+++ b/include/services/y2r.hpp
@@ -113,8 +113,12 @@ class Y2RService {
 	void startConversion(u32 messagePointer);
 	void stopConversion(u32 messagePointer);
 
-public:
+	bool isBusy;
+
+  public:
 	Y2RService(Memory& mem, Kernel& kernel) : mem(mem), kernel(kernel) {}
 	void reset();
 	void handleSyncRequest(u32 messagePointer);
+
+	void signalConversionDone();
 };

--- a/src/core/kernel/kernel.cpp
+++ b/src/core/kernel/kernel.cpp
@@ -399,3 +399,5 @@ std::string Kernel::getProcessName(u32 pid) {
 		Helpers::panic("Attempted to name non-current process");
 	}
 }
+
+Scheduler& Kernel::getScheduler() { return cpu.getScheduler(); }

--- a/src/core/services/y2r.cpp
+++ b/src/core/services/y2r.cpp
@@ -61,6 +61,7 @@ void Y2RService::reset() {
 	inputLineWidth = 420;
 
 	conversionCoefficients.fill(0);
+	isBusy = false;
 }
 
 void Y2RService::handleSyncRequest(u32 messagePointer) {
@@ -156,6 +157,11 @@ void Y2RService::setTransferEndInterrupt(u32 messagePointer) {
 void Y2RService::stopConversion(u32 messagePointer) {
 	log("Y2R::StopConversion\n");
 
+	if (isBusy) {
+		isBusy = false;
+		kernel.getScheduler().removeEvent(Scheduler::EventType::SignalY2R);
+	}
+
 	mem.write32(messagePointer, IPC::responseHeader(0x27, 1, 0));
 	mem.write32(messagePointer + 4, Result::Success);
 }
@@ -167,7 +173,7 @@ void Y2RService::isBusyConversion(u32 messagePointer) {
 
 	mem.write32(messagePointer, IPC::responseHeader(0x28, 2, 0));
 	mem.write32(messagePointer + 4, Result::Success);
-	mem.write32(messagePointer + 8, static_cast<u32>(BusyStatus::NotBusy));
+	mem.write32(messagePointer + 8, static_cast<u32>(isBusy ? BusyStatus::Busy : BusyStatus::NotBusy));
 }
 
 void Y2RService::setBlockAlignment(u32 messagePointer) {
@@ -434,11 +440,14 @@ void Y2RService::startConversion(u32 messagePointer) {
 	mem.write32(messagePointer, IPC::responseHeader(0x26, 1, 0));
 	mem.write32(messagePointer + 4, Result::Success);
 
-	// Make Y2R conversion end instantly.
-	// Signal the transfer end event if it's been created. TODO: Is this affected by SetTransferEndInterrupt?
-	if (transferEndEvent.has_value()) {
-		kernel.signalEvent(transferEndEvent.value());
-	}
+	// Schedule Y2R conversion end event.
+	static constexpr u64 delayTicks = 60'000;
+	isBusy = true;
+
+	// Remove any potential pending Y2R event and schedule a new one
+	Scheduler& scheduler = kernel.getScheduler();
+	scheduler.removeEvent(Scheduler::EventType::SignalY2R);
+	scheduler.addEvent(Scheduler::EventType::SignalY2R, scheduler.currentTimestamp + delayTicks);
 }
 
 void Y2RService::isFinishedSendingYUV(u32 messagePointer) {
@@ -484,4 +493,15 @@ void Y2RService::isFinishedReceiving(u32 messagePointer) {
 	mem.write32(messagePointer, IPC::responseHeader(0x17, 2, 0));
 	mem.write32(messagePointer + 4, Result::Success);
 	mem.write32(messagePointer + 8, finished ? 1 : 0);
+}
+
+void Y2RService::signalConversionDone() {
+	if (isBusy) {
+		isBusy = false;
+
+		// Signal the transfer end event if it's been created. TODO: Is this affected by SetTransferEndInterrupt?
+		if (transferEndEvent.has_value()) {
+			kernel.signalEvent(transferEndEvent.value());
+		}
+	}
 }

--- a/src/core/services/y2r.cpp
+++ b/src/core/services/y2r.cpp
@@ -441,7 +441,8 @@ void Y2RService::startConversion(u32 messagePointer) {
 	mem.write32(messagePointer + 4, Result::Success);
 
 	// Schedule Y2R conversion end event.
-	static constexpr u64 delayTicks = 60'000;
+	// The tick value is tweaked based on the minimum delay needed to get FIFA 15 to not hang due to a race condition on its title screen
+	static constexpr u64 delayTicks = 1'350'000;
 	isBusy = true;
 
 	// Remove any potential pending Y2R event and schedule a new one

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -169,6 +169,8 @@ void Emulator::pollScheduler() {
 				break;
 			}
 
+			case Scheduler::EventType::SignalY2R: kernel.getServiceManager().getY2R().signalConversionDone(); break;
+
 			default: {
 				Helpers::panic("Scheduler: Unimplemented event type received: %d\n", static_cast<int>(eventType));
 				break;


### PR DESCRIPTION
Fixes a race condition in FIFA15 that would make the game hang in the title screen. The delay needed to get FIFA not to race seems a bit high, but reasonable, and several other FMV-using games were tested without any apparent breakage. Might need more testing and tweaking though.
![image](https://github.com/wheremyfoodat/Panda3DS/assets/44909372/dbefd9e2-db1f-447b-a52d-1db28b1b283f)
