### PR TITLE
Downgrade SetFileSize failure to warning

### DIFF
--- a/src/core/kernel/file_operations.cpp
+++ b/src/core/kernel/file_operations.cpp
@@ -184,7 +184,8 @@ void Kernel::setFileSize(u32 messagePointer, Handle fileHandle) {
 		if (success) {
 			mem.write32(messagePointer + 4, Result::Success);
 		} else {
-			Helpers::panic("FileOp::SetFileSize failed");
+			Helpers::warn("FileOp::SetFileSize failed");
+			mem.write32(messagePointer + 4, Result::FailurePlaceholder);
 		}
 	} else {
 		Helpers::panic("Tried to set file size of file without file descriptor");


### PR DESCRIPTION
Fixes Luigi's Mansion on Linux which tries to change the size of a file which doesn't have write permissions...