### PR TITLE
Remove dependency of PICA regs in fragment config

### DIFF
--- a/include/PICA/pica_frag_config.hpp
+++ b/include/PICA/pica_frag_config.hpp
@@ -73,18 +73,7 @@ namespace PICA {
 			BitField<22, 2, u32> shadowSelector;
 		};
 
-		LightingLUTConfig d0{};
-		LightingLUTConfig d1{};
-		LightingLUTConfig sp{};
-		LightingLUTConfig fr{};
-		LightingLUTConfig rr{};
-		LightingLUTConfig rg{};
-		LightingLUTConfig rb{};
-
-		u32 config1;
-		u32 lutAbs;
-		u32 lutScale;
-		u32 lutSelect;
+		LightingLUTConfig luts[7]{};
 
 		std::array<Light, 8> lights{};
 
@@ -95,12 +84,8 @@ namespace PICA {
 			}
 
 			const u32 config0 = regs[InternalRegs::LightConfig0];
+			const u32 config1 = regs[InternalRegs::LightConfig1];
 			const u32 totalLightCount = Helpers::getBits<0, 3>(regs[InternalRegs::LightNumber]) + 1;
-
-			config1 = regs[InternalRegs::LightConfig1];
-			lutAbs = regs[InternalRegs::LightLUTAbs];
-			lutScale = regs[InternalRegs::LightLUTScale];
-			lutSelect = regs[InternalRegs::LightLUTSelect];
 
 			enable = 1;
 			lightNum = totalLightCount;
@@ -137,6 +122,14 @@ namespace PICA {
 				light.spotAttenuationEnable = ((config1 >> (8 + i)) & 1) ^ 1;       // Same here
 				light.distanceAttenuationEnable = ((config1 >> (24 + i)) & 1) ^ 1;  // Of course same here
 			}
+
+			LightingLUTConfig& d0 = luts[Lights::LUT_D0];
+			LightingLUTConfig& d1 = luts[Lights::LUT_D1];
+			LightingLUTConfig& sp = luts[spotlightLutIndex];
+			LightingLUTConfig& fr = luts[Lights::LUT_FR];
+			LightingLUTConfig& rb = luts[Lights::LUT_RB];
+			LightingLUTConfig& rg = luts[Lights::LUT_RG];
+			LightingLUTConfig& rr = luts[Lights::LUT_RR];
 
 			d0.enable = Helpers::getBit<16>(config1) == 0;
 			d1.enable = Helpers::getBit<17>(config1) == 0;

--- a/include/PICA/pica_frag_config.hpp
+++ b/include/PICA/pica_frag_config.hpp
@@ -110,17 +110,17 @@ namespace PICA {
 
 			for (int i = 0; i < totalLightCount; i++) {
 				auto& light = lights[i];
-				const u32 lightConfig = regs[InternalRegs::Light0Config + 0x10 * i];
-
 				light.num = (regs[InternalRegs::LightPermutation] >> (i * 4)) & 0x7;
+
+				const u32 lightConfig = regs[InternalRegs::Light0Config + 0x10 * light.num];
 				light.directional = Helpers::getBit<0>(lightConfig);
 				light.twoSidedDiffuse = Helpers::getBit<1>(lightConfig);
 				light.geometricFactor0 = Helpers::getBit<2>(lightConfig);
 				light.geometricFactor1 = Helpers::getBit<3>(lightConfig);
 
-				light.shadowEnable = ((config1 >> i) & 1) ^ 1;                      // This also does 0 = enabled
-				light.spotAttenuationEnable = ((config1 >> (8 + i)) & 1) ^ 1;       // Same here
-				light.distanceAttenuationEnable = ((config1 >> (24 + i)) & 1) ^ 1;  // Of course same here
+				light.shadowEnable = ((config1 >> light.num) & 1) ^ 1;                      // This also does 0 = enabled
+				light.spotAttenuationEnable = ((config1 >> (8 + light.num)) & 1) ^ 1;       // Same here
+				light.distanceAttenuationEnable = ((config1 >> (24 + light.num)) & 1) ^ 1;  // Of course same here
 			}
 
 			LightingLUTConfig& d0 = luts[Lights::LUT_D0];

--- a/include/PICA/pica_frag_config.hpp
+++ b/include/PICA/pica_frag_config.hpp
@@ -212,7 +212,7 @@ namespace PICA {
 			// {Source, Operand, Combiner, Color, Scale} and we want to skip the color register since it's uploaded via UBO
 #define setupTevStage(stage)                                                                                    \
 	std::memcpy(&texConfig.tevConfigs[stage * 4], &regs[InternalRegs::TexEnv##stage##Source], 3 * sizeof(u32)); \
-	texConfig.tevConfigs[stage * 4 + 3] = regs[InternalRegs::TexEnv##stage##Source + 5];
+	texConfig.tevConfigs[stage * 4 + 3] = regs[InternalRegs::TexEnv##stage##Source + 4];
 
 			setupTevStage(0);
 			setupTevStage(1);

--- a/include/PICA/pica_frag_config.hpp
+++ b/include/PICA/pica_frag_config.hpp
@@ -73,7 +73,7 @@ namespace PICA {
 			BitField<22, 2, u32> shadowSelector;
 		};
 
-		LightingLUTConfig luts[7]{};
+		std::array<LightingLUTConfig, 7> luts{};
 
 		std::array<Light, 8> lights{};
 

--- a/include/PICA/pica_frag_config.hpp
+++ b/include/PICA/pica_frag_config.hpp
@@ -146,7 +146,7 @@ namespace PICA {
 
 			if (d0.enable) {
 				d0.absInput = Helpers::getBit<1>(lutAbs) == 0;
-				d0.type = Helpers::getBits<0, 3>(lutSelect);	
+				d0.type = Helpers::getBits<0, 3>(lutSelect);
 				d0.scale = scales[Helpers::getBits<0, 3>(lutScale)];
 			}
 
@@ -197,12 +197,12 @@ namespace PICA {
 			return std::memcmp(this, &config, sizeof(FragmentConfig)) == 0;
 		}
 
-		FragmentConfig(const std::array<u32, 0x300>& regs) : lighting(regs)
-		{
+		FragmentConfig(const std::array<u32, 0x300>& regs) : lighting(regs) {
 			auto alphaTestConfig = regs[InternalRegs::AlphaTestConfig];
 			auto alphaTestFunction = Helpers::getBits<4, 3>(alphaTestConfig);
 
-			outConfig.alphaTestFunction = (alphaTestConfig & 1) ? static_cast<PICA::CompareFunction>(alphaTestFunction) : PICA::CompareFunction::Always;
+			outConfig.alphaTestFunction =
+				(alphaTestConfig & 1) ? static_cast<PICA::CompareFunction>(alphaTestFunction) : PICA::CompareFunction::Always;
 			outConfig.depthMapEnable = regs[InternalRegs::DepthmapEnable] & 1;
 
 			texConfig.texUnitConfig = regs[InternalRegs::TexUnitCfg];
@@ -210,9 +210,9 @@ namespace PICA {
 
 			// Set up TEV stages. Annoyingly we can't just memcpy as the TEV registers are arranged like
 			// {Source, Operand, Combiner, Color, Scale} and we want to skip the color register since it's uploaded via UBO
-		#define setupTevStage(stage)                                                                                    \
-			std::memcpy(&texConfig.tevConfigs[stage * 4], &regs[InternalRegs::TexEnv##stage##Source], 3 * sizeof(u32)); \
-			texConfig.tevConfigs[stage * 4 + 3] = regs[InternalRegs::TexEnv##stage##Source + 5];
+#define setupTevStage(stage)                                                                                    \
+	std::memcpy(&texConfig.tevConfigs[stage * 4], &regs[InternalRegs::TexEnv##stage##Source], 3 * sizeof(u32)); \
+	texConfig.tevConfigs[stage * 4 + 3] = regs[InternalRegs::TexEnv##stage##Source + 5];
 
 			setupTevStage(0);
 			setupTevStage(1);
@@ -220,7 +220,7 @@ namespace PICA {
 			setupTevStage(3);
 			setupTevStage(4);
 			setupTevStage(5);
-		#undef setupTevStage
+#undef setupTevStage
 		}
 	};
 

--- a/include/PICA/regs.hpp
+++ b/include/PICA/regs.hpp
@@ -278,6 +278,11 @@ namespace PICA {
 		};
 	}
 
+	// There's actually 8 different LUTs (SP0-SP7), one for each light with different indices (8-15)
+	// We use an unused LUT value for "this light source's spotlight" instead and figure out which light source to use in compileLutLookup
+	// This is particularly intuitive in several places, such as checking if a LUT is enabled
+	static constexpr int spotlightLutIndex = 2;
+
 	enum class TextureFmt : u32 {
 		RGBA8 = 0x0,
 		RGB8 = 0x1,

--- a/include/PICA/shader_gen.hpp
+++ b/include/PICA/shader_gen.hpp
@@ -14,27 +14,24 @@ namespace PICA::ShaderGen {
 	enum class Language { GLSL };
 
 	class FragmentGenerator {
-		using PICARegs = std::array<u32, 0x300>;
 		API api;
 		Language language;
 
-		void compileTEV(std::string& shader, int stage, const PICARegs& regs);
-		void getSource(std::string& shader, PICA::TexEnvConfig::Source source, int index);
-		void getColorOperand(std::string& shader, PICA::TexEnvConfig::Source source, PICA::TexEnvConfig::ColorOperand color, int index);
-		void getAlphaOperand(std::string& shader, PICA::TexEnvConfig::Source source, PICA::TexEnvConfig::AlphaOperand alpha, int index);
+		void compileTEV(std::string& shader, int stage, const PICA::FragmentConfig& config);
+		void getSource(std::string& shader, PICA::TexEnvConfig::Source source, int index, const PICA::FragmentConfig& config);
+		void getColorOperand(std::string& shader, PICA::TexEnvConfig::Source source, PICA::TexEnvConfig::ColorOperand color, int index, const PICA::FragmentConfig& config);
+		void getAlphaOperand(std::string& shader, PICA::TexEnvConfig::Source source, PICA::TexEnvConfig::AlphaOperand alpha, int index, const PICA::FragmentConfig& config);
 		void getColorOperation(std::string& shader, PICA::TexEnvConfig::Operation op);
 		void getAlphaOperation(std::string& shader, PICA::TexEnvConfig::Operation op);
 
-		void applyAlphaTest(std::string& shader, const PICARegs& regs);
-		void compileLights(std::string& shader, const PICA::FragmentConfig& config, const PICARegs& regs);
-		void compileLUTLookup(std::string& shader, const PICA::FragmentConfig& config, const PICARegs& regs, u32 lightIndex, u32 lutID);
+		void applyAlphaTest(std::string& shader, const PICA::FragmentConfig& config);
+		void compileLights(std::string& shader, const PICA::FragmentConfig& config);
+		void compileLUTLookup(std::string& shader, const PICA::FragmentConfig& config, u32 lightIndex, u32 lutID);
 		bool isSamplerEnabled(u32 environmentID, u32 lutID);
-
-		u32 textureConfig = 0;
 
 	  public:
 		FragmentGenerator(API api, Language language) : api(api), language(language) {}
-		std::string generate(const PICARegs& regs, const PICA::FragmentConfig& config);
+		std::string generate(const PICA::FragmentConfig& config);
 		std::string getDefaultVertexShader();
 
 		void setTarget(API api, Language language) {

--- a/src/core/PICA/shader_gen_glsl.cpp
+++ b/src/core/PICA/shader_gen_glsl.cpp
@@ -594,23 +594,24 @@ bool FragmentGenerator::isSamplerEnabled(u32 environmentID, u32 lutID) {
 }
 
 void FragmentGenerator::compileLUTLookup(std::string& shader, const PICA::FragmentConfig& config, u32 lightIndex, u32 lutID) {
+	const LightingLUTConfig& lut = config.lighting.luts[lutID];
 	uint lutIndex = 0;
-	bool spotAttenuationEnable = true;
+	bool lutEnabled = false;
 
 	if (lutID == spotlightLutIndex) {
 		// These are the spotlight attenuation LUTs
 		lutIndex = 8u + lightIndex;
-		spotAttenuationEnable = config.lighting.lights[lightIndex].spotAttenuationEnable;
+		lutEnabled = config.lighting.lights[lightIndex].spotAttenuationEnable;
 	} else if (lutID <= 6) {
 		lutIndex = lutID;
+		lutEnabled = lut.enable;
 	} else {
 		Helpers::warn("Shadergen: Unimplemented LUT value");
 	}
 
 	const bool samplerEnabled = isSamplerEnabled(config.lighting.config, lutID);
-	const LightingLUTConfig& lut = config.lighting.luts[lutID];
 
-	if (!samplerEnabled || !lut.enable || !spotAttenuationEnable) {
+	if (!samplerEnabled || !lutEnabled) {
 		shader += "lut_lookup_result = 1.0;\n";
 		return;
 	}

--- a/src/core/PICA/shader_gen_glsl.cpp
+++ b/src/core/PICA/shader_gen_glsl.cpp
@@ -595,14 +595,13 @@ bool FragmentGenerator::isSamplerEnabled(u32 environmentID, u32 lutID) {
 
 void FragmentGenerator::compileLUTLookup(std::string& shader, const PICA::FragmentConfig& config, u32 lightIndex, u32 lutID) {
 	uint lutIndex = 0;
-	int bitInConfig1 = 0;
+	bool spotAttenuationEnable = true;
 
 	if (lutID == spotlightLutIndex) {
 		// These are the spotlight attenuation LUTs
-		bitInConfig1 = 8 + (lightIndex & 0x7);
 		lutIndex = 8u + lightIndex;
+		spotAttenuationEnable = config.lighting.lights[lightIndex].spotAttenuationEnable;
 	} else if (lutID <= 6) {
-		bitInConfig1 = 16 + lutID;
 		lutIndex = lutID;
 	} else {
 		Helpers::warn("Shadergen: Unimplemented LUT value");
@@ -611,7 +610,7 @@ void FragmentGenerator::compileLUTLookup(std::string& shader, const PICA::Fragme
 	const bool samplerEnabled = isSamplerEnabled(config.lighting.config, lutID);
 	const LightingLUTConfig& lut = config.lighting.luts[lutID];
 
-	if (!samplerEnabled || !lut.enable) {
+	if (!samplerEnabled || !lut.enable || !spotAttenuationEnable) {
 		shader += "lut_lookup_result = 1.0;\n";
 		return;
 	}


### PR DESCRIPTION
Should be helpful with needing less copies for when we move to hybrid shaders 