### PR TITLE
Fix shadowed variable in ubershader

### DIFF
--- a/src/host_shaders/opengl_fragment_shader.frag
+++ b/src/host_shaders/opengl_fragment_shader.frag
@@ -307,8 +307,8 @@ void calcLighting(out vec4 primary_color, out vec4 secondary_color) {
 	primary_color = vec4(vec3(0.0), 1.0);
 	secondary_color = vec4(vec3(0.0), 1.0);
 
-	uint GPUREG_LIGHTING_LUTINPUT_SCALE = readPicaReg(0x01D2u);
 	uint GPUREG_LIGHTING_CONFIG0 = readPicaReg(0x01C3u);
+	GPUREG_LIGHTING_LUTINPUT_SCALE = readPicaReg(0x01D2u);
 	GPUREG_LIGHTING_CONFIG1 = readPicaReg(0x01C4u);
 	GPUREG_LIGHTING_LUTINPUT_ABS = readPicaReg(0x01D0u);
 	GPUREG_LIGHTING_LUTINPUT_SELECT = readPicaReg(0x01D1u);


### PR DESCRIPTION
This PR removes Luigi's Latex suit in Luigi's Mansion
Before:
![image](https://github.com/user-attachments/assets/e9bc1913-9f80-4d7c-a8a8-0a664a2c5ce5)
After:
![image](https://github.com/user-attachments/assets/9b9c9590-567b-4245-b43b-41882bc56814)
