### PR TITLE
Separate graphics API/Language types from the fragment recompiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,7 @@ set(HEADER_FILES include/emulator.hpp include/helpers.hpp include/termcolor.hpp 
                  include/audio/dsp_core.hpp include/audio/null_core.hpp include/audio/teakra_core.hpp
                  include/audio/miniaudio_device.hpp include/ring_buffer.hpp include/bitfield.hpp include/audio/dsp_shared_mem.hpp
                  include/audio/hle_core.hpp include/capstone.hpp include/audio/aac.hpp include/PICA/pica_frag_config.hpp
-                 include/PICA/pica_frag_uniforms.hpp
+                 include/PICA/pica_frag_uniforms.hpp include/PICA/shader_gen_types.hpp
 )
 
 cmrc_add_resource_library(

--- a/include/PICA/shader_gen.hpp
+++ b/include/PICA/shader_gen.hpp
@@ -4,15 +4,10 @@
 #include "PICA/gpu.hpp"
 #include "PICA/pica_frag_config.hpp"
 #include "PICA/regs.hpp"
+#include "PICA/shader_gen_types.hpp"
 #include "helpers.hpp"
 
 namespace PICA::ShaderGen {
-	// Graphics API this shader is targetting
-	enum class API { GL, GLES, Vulkan };
-
-	// Shading language to use (Only GLSL for the time being)
-	enum class Language { GLSL };
-
 	class FragmentGenerator {
 		API api;
 		Language language;

--- a/include/PICA/shader_gen_types.hpp
+++ b/include/PICA/shader_gen_types.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace PICA::ShaderGen {
+	// Graphics API this shader is targetting
+	enum class API { GL, GLES, Vulkan };
+
+	// Shading language to use (Only GLSL for the time being)
+	enum class Language { GLSL };
+}  // namespace PICA::ShaderGen


### PR DESCRIPTION
Need these enum definitions to be easily accessible from the vertex shader decompiler and any other potential GPU recompilation