### PR TITLE
Renderer GL: Add UB checks

### DIFF
--- a/include/PICA/gpu.hpp
+++ b/include/PICA/gpu.hpp
@@ -167,7 +167,8 @@ class GPU {
 			u32 index = paddr - PhysicalAddrs::VRAM;
 			return (T*)&vram[index];
 		} else [[unlikely]] {
-			Helpers::panic("[GPU] Tried to access unknown physical address: %08X", paddr);
+			Helpers::warn("[GPU] Tried to access unknown physical address: %08X", paddr);
+			return nullptr;
 		}
 	}
 


### PR DESCRIPTION
As the best-behaving Pokemon game, PSMD loves using 0-width texture copies and accessing textures from OoB VRAM, proving that the best anti-emulator protection is Gamefreak writing your code.

Anyways this fixes PSMD though still needs LLE DSP to get past some hangs, HLE seems to be missing something.
![image](https://github.com/user-attachments/assets/b7c4e5ba-2bce-46a3-b40c-87bb41674918)