### PR TITLE
Rename Handle to HorizonHandle, add metal-cpp submodule, format

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "third_party/hips"]
 	path = third_party/hips
 	url = https://github.com/wheremyfoodat/Hips
+[submodule "third_party/metal-cpp"]
+	path = third_party/metal-cpp
+	url = https://github.com/Panda3DS-emu/metal-cpp

--- a/include/kernel/handles.hpp
+++ b/include/kernel/handles.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "helpers.hpp"
 
-using Handle = u32;
+using HorizonHandle = u32;
 
 namespace KernelHandles {
 	enum : u32 {
@@ -61,17 +61,17 @@ namespace KernelHandles {
 	};
 
 	// Returns whether "handle" belongs to one of the OS services
-	static constexpr bool isServiceHandle(Handle handle) {
+	static constexpr bool isServiceHandle(HorizonHandle handle) {
 		return handle >= MinServiceHandle && handle <= MaxServiceHandle;
 	}
 
 	// Returns whether "handle" belongs to one of the OS services' shared memory areas
-	static constexpr bool isSharedMemHandle(Handle handle) {
+	static constexpr bool isSharedMemHandle(HorizonHandle handle) {
 		return handle >= MinSharedMemHandle && handle <= MaxSharedMemHandle;
 	}
 
 	// Returns the name of a handle as a string based on the given handle
-	static const char* getServiceName(Handle handle) {
+	static const char* getServiceName(HorizonHandle handle) {
 		switch (handle) {
 			case AC: return "AC";
 			case ACT: return "ACT";

--- a/include/kernel/kernel.hpp
+++ b/include/kernel/kernel.hpp
@@ -18,6 +18,8 @@ class CPU;
 struct Scheduler;
 
 class Kernel {
+	using Handle = HorizonHandle;
+
 	std::span<u32, 16> regs;
 	CPU& cpu;
 	Memory& mem;

--- a/include/kernel/kernel_types.hpp
+++ b/include/kernel/kernel_types.hpp
@@ -47,7 +47,7 @@ enum class ProcessorID : s32 {
 struct AddressArbiter {};
 
 struct ResourceLimits {
-    Handle handle;
+    HorizonHandle handle;
 
     s32 currentCommit = 0;
 };
@@ -91,6 +91,8 @@ struct Port {
 };
 
 struct Session {
+	using Handle = HorizonHandle;
+
 	Handle portHandle;  // The port this session is subscribed to
 	Session(Handle portHandle) : portHandle(portHandle) {}
 };
@@ -109,6 +111,8 @@ enum class ThreadStatus {
 };
 
 struct Thread {
+	using Handle = HorizonHandle;
+
 	u32 initialSP;   // Initial r13 value
 	u32 entrypoint;  // Initial r15 value
 	u32 priority;
@@ -161,6 +165,8 @@ static const char* kernelObjectTypeToString(KernelObjectType t) {
 }
 
 struct Mutex {
+    using Handle = HorizonHandle;
+
     u64 waitlist;           // Refer to the getWaitlist function below for documentation
     Handle ownerThread = 0; // Index of the thread that holds the mutex if it's locked
     Handle handle; // Handle of the mutex itself
@@ -203,6 +209,8 @@ struct MemoryBlock {
 
 // Generic kernel object class
 struct KernelObject {
+	using Handle = HorizonHandle;
+
     Handle handle = 0; // A u32 the OS will use to identify objects
     void* data = nullptr;
     KernelObjectType type;

--- a/include/memory.hpp
+++ b/include/memory.hpp
@@ -102,6 +102,8 @@ namespace KernelMemoryTypes {
 }
 
 class Memory {
+	using Handle = HorizonHandle;
+
 	u8* fcram;
 	u8* dspRam;  // Provided to us by Audio
 	u8* vram;    // Provided to the memory class by the GPU class
@@ -213,8 +215,14 @@ private:
 	}
 
 	enum class BatteryLevel {
-		Empty = 0, AlmostEmpty, OneBar, TwoBars, ThreeBars, FourBars
+		Empty = 0,
+		AlmostEmpty,
+		OneBar,
+		TwoBars,
+		ThreeBars,
+		FourBars,
 	};
+
 	u8 getBatteryState(bool adapterConnected, bool charging, BatteryLevel batteryLevel) {
 		u8 value = static_cast<u8>(batteryLevel) << 2; // Bits 2:4 are the battery level from 0 to 5
 		if (adapterConnected) value |= 1 << 0; // Bit 0 shows if the charger is connected

--- a/include/services/ac.hpp
+++ b/include/services/ac.hpp
@@ -8,6 +8,8 @@
 #include "result/result.hpp"
 
 class ACService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::AC;
 	Memory& mem;
 	MAKE_LOG_FUNCTION(log, acLogger)

--- a/include/services/act.hpp
+++ b/include/services/act.hpp
@@ -6,6 +6,8 @@
 #include "result/result.hpp"
 
 class ACTService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::ACT;
 	Memory& mem;
 	MAKE_LOG_FUNCTION(log, actLogger)
@@ -15,7 +17,7 @@ class ACTService {
 	void generateUUID(u32 messagePointer);
 	void getAccountDataBlock(u32 messagePointer);
 
-public:
+  public:
 	ACTService(Memory& mem) : mem(mem) {}
 	void reset();
 	void handleSyncRequest(u32 messagePointer);

--- a/include/services/am.hpp
+++ b/include/services/am.hpp
@@ -6,6 +6,8 @@
 #include "result/result.hpp"
 
 class AMService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::AM;
 	Memory& mem;
 	MAKE_LOG_FUNCTION(log, amLogger)
@@ -15,7 +17,7 @@ class AMService {
 	void getPatchTitleInfo(u32 messagePointer);
 	void listTitleInfo(u32 messagePointer);
 
-public:
+  public:
 	AMService(Memory& mem) : mem(mem) {}
 	void reset();
 	void handleSyncRequest(u32 messagePointer);

--- a/include/services/apt.hpp
+++ b/include/services/apt.hpp
@@ -12,7 +12,8 @@
 class Kernel;
 
 enum class ConsoleModel : u32 {
-	Old3DS, New3DS
+	Old3DS,
+	New3DS,
 };
 
 // https://www.3dbrew.org/wiki/NS_and_APT_Services#Command
@@ -41,6 +42,8 @@ namespace APT::Transitions {
 }
 
 class APTService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::APT;
 	Memory& mem;
 	Kernel& kernel;
@@ -99,7 +102,7 @@ class APTService {
 
 	u32 screencapPostPermission;
 
-public:
+  public:
 	APTService(Memory& mem, Kernel& kernel) : mem(mem), kernel(kernel), appletManager(mem) {}
 	void reset();
 	void handleSyncRequest(u32 messagePointer);

--- a/include/services/boss.hpp
+++ b/include/services/boss.hpp
@@ -6,6 +6,8 @@
 #include "result/result.hpp"
 
 class BOSSService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::BOSS;
 	Memory& mem;
 	MAKE_LOG_FUNCTION(log, bossLogger)
@@ -17,7 +19,7 @@ class BOSSService {
 	void getNewArrivalFlag(u32 messagePointer);
 	void getNsDataIdList(u32 messagePointer, u32 commandWord);
 	void getOptoutFlag(u32 messagePointer);
-	void getStorageEntryInfo(u32 messagePointer); // Unknown what this is, name taken from Citra
+	void getStorageEntryInfo(u32 messagePointer);  // Unknown what this is, name taken from Citra
 	void getTaskIdList(u32 messagePointer);
 	void getTaskInfo(u32 messagePointer);
 	void getTaskServiceStatus(u32 messagePointer);
@@ -35,7 +37,8 @@ class BOSSService {
 	void unregisterTask(u32 messagePointer);
 
 	s8 optoutFlag;
-public:
+
+  public:
 	BOSSService(Memory& mem) : mem(mem) {}
 	void reset();
 	void handleSyncRequest(u32 messagePointer);

--- a/include/services/cam.hpp
+++ b/include/services/cam.hpp
@@ -12,6 +12,7 @@
 class Kernel;
 
 class CAMService {
+	using Handle = HorizonHandle;
 	using Event = std::optional<Handle>;
 
 	struct Port {

--- a/include/services/cecd.hpp
+++ b/include/services/cecd.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <optional>
+
 #include "helpers.hpp"
 #include "kernel_types.hpp"
 #include "logger.hpp"
@@ -9,6 +10,8 @@
 class Kernel;
 
 class CECDService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::CECD;
 	Memory& mem;
 	Kernel& kernel;
@@ -20,7 +23,7 @@ class CECDService {
 	void getInfoEventHandle(u32 messagePointer);
 	void openAndRead(u32 messagePointer);
 
-public:
+  public:
 	CECDService(Memory& mem, Kernel& kernel) : mem(mem), kernel(kernel) {}
 	void reset();
 	void handleSyncRequest(u32 messagePointer);

--- a/include/services/cfg.hpp
+++ b/include/services/cfg.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstring>
+
 #include "helpers.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
@@ -7,8 +8,10 @@
 #include "result/result.hpp"
 
 class CFGService {
+	using Handle = HorizonHandle;
+
 	Memory& mem;
-	CountryCodes country = CountryCodes::US; // Default to USA
+	CountryCodes country = CountryCodes::US;  // Default to USA
 	MAKE_LOG_FUNCTION(log, cfgLogger)
 
 	void writeStringU16(u32 pointer, const std::u16string& string);
@@ -27,12 +30,12 @@ class CFGService {
 
 	void getConfigInfo(u32 output, u32 blockID, u32 size, u32 permissionMask);
 
-public:
+  public:
 	enum class Type {
-		U, // cfg:u
-		I, // cfg:i
-		S, // cfg:s
-		NOR, // cfg:nor
+		U,    // cfg:u
+		I,    // cfg:i
+		S,    // cfg:s
+		NOR,  // cfg:nor
 	};
 
 	CFGService(Memory& mem) : mem(mem) {}

--- a/include/services/csnd.hpp
+++ b/include/services/csnd.hpp
@@ -10,6 +10,8 @@
 class Kernel;
 
 class CSNDService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::CSND;
 	Memory& mem;
 	Kernel& kernel;
@@ -30,7 +32,5 @@ class CSNDService {
 	void reset();
 	void handleSyncRequest(u32 messagePointer);
 
-	void setSharedMemory(u8* ptr) {
-		sharedMemory = ptr;
-	}
+	void setSharedMemory(u8* ptr) { sharedMemory = ptr; }
 };

--- a/include/services/dlp_srvr.hpp
+++ b/include/services/dlp_srvr.hpp
@@ -8,6 +8,8 @@
 // Please forgive me for how everything in this file is named
 // "dlp:SRVR" is not a nice name to work with
 class DlpSrvrService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::DLP_SRVR;
 	Memory& mem;
 	MAKE_LOG_FUNCTION(log, dlpSrvrLogger)
@@ -15,7 +17,7 @@ class DlpSrvrService {
 	// Service commands
 	void isChild(u32 messagePointer);
 
-public:
+  public:
 	DlpSrvrService(Memory& mem) : mem(mem) {}
 	void reset();
 	void handleSyncRequest(u32 messagePointer);

--- a/include/services/dsp.hpp
+++ b/include/services/dsp.hpp
@@ -14,6 +14,8 @@
 class Kernel;
 
 class DSPService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::DSP;
 	Memory& mem;
 	Kernel& kernel;

--- a/include/services/frd.hpp
+++ b/include/services/frd.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <cassert>
+
 #include "helpers.hpp"
 #include "kernel_types.hpp"
 #include "logger.hpp"
@@ -15,6 +16,8 @@ struct FriendKey {
 static_assert(sizeof(FriendKey) == 16);
 
 class FRDService {
+	using Handle = HorizonHandle;
+
 	Memory& mem;
 	MAKE_LOG_FUNCTION(log, frdLogger)
 
@@ -51,11 +54,11 @@ class FRDService {
 	};
 	static_assert(sizeof(Profile) == 8);
 
-public:
+  public:
 	enum class Type {
-		A,    // frd:a
-		N,    // frd:n
-		U,    // frd:u
+		A,  // frd:a
+		N,  // frd:n
+		U,  // frd:u
 	};
 
 	FRDService(Memory& mem) : mem(mem) {}

--- a/include/services/fs.hpp
+++ b/include/services/fs.hpp
@@ -16,6 +16,8 @@
 class Kernel;
 
 class FSService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::FS;
 	Memory& mem;
 	Kernel& kernel;
@@ -81,7 +83,7 @@ class FSService {
 	// Used for set/get priority: Not sure what sort of priority this is referring to
 	u32 priority;
 
-public:
+  public:
 	FSService(Memory& mem, Kernel& kernel, const EmulatorConfig& config)
 		: mem(mem), saveData(mem), sharedExtSaveData_nand(mem, "../SharedFiles/NAND", true), extSaveData_sdmc(mem, "SDMC"), sdmc(mem),
 		  sdmcWriteOnly(mem, true), selfNcch(mem), ncch(mem), userSaveData1(mem, ArchiveID::UserSaveData1),

--- a/include/services/gsp_gpu.hpp
+++ b/include/services/gsp_gpu.hpp
@@ -22,6 +22,8 @@ enum class GPUInterrupt : u8 {
 class Kernel;
 
 class GPUService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::GPU;
 	Memory& mem;
 	GPU& gpu;

--- a/include/services/gsp_lcd.hpp
+++ b/include/services/gsp_lcd.hpp
@@ -6,6 +6,8 @@
 #include "result/result.hpp"
 
 class LCDService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::LCD;
 	Memory& mem;
 	MAKE_LOG_FUNCTION(log, gspLCDLogger)

--- a/include/services/hid.hpp
+++ b/include/services/hid.hpp
@@ -38,6 +38,8 @@ namespace HID::Keys {
 class Kernel;
 
 class HIDService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::HID;
 	Memory& mem;
 	Kernel& kernel;

--- a/include/services/http.hpp
+++ b/include/services/http.hpp
@@ -5,6 +5,8 @@
 #include "memory.hpp"
 
 class HTTPService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::HTTP;
 	Memory& mem;
 	MAKE_LOG_FUNCTION(log, httpLogger)

--- a/include/services/ir_user.hpp
+++ b/include/services/ir_user.hpp
@@ -11,6 +11,8 @@
 class Kernel;
 
 class IRUserService {
+	using Handle = HorizonHandle;
+
 	enum class DeviceID : u8 {
 		CirclePadPro = 1,
 	};

--- a/include/services/ldr_ro.hpp
+++ b/include/services/ldr_ro.hpp
@@ -8,6 +8,8 @@
 class Kernel;
 
 class LDRService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::LDR_RO;
 	Memory& mem;
 	Kernel& kernel;
@@ -22,7 +24,7 @@ class LDRService {
 	void loadCRR(u32 messagePointer);
 	void unloadCRO(u32 messagePointer);
 
-public:
+  public:
 	LDRService(Memory& mem, Kernel& kernel) : mem(mem), kernel(kernel) {}
 	void reset();
 	void handleSyncRequest(u32 messagePointer);

--- a/include/services/mcu/mcu_hwc.hpp
+++ b/include/services/mcu/mcu_hwc.hpp
@@ -7,6 +7,8 @@
 
 namespace MCU {
 	class HWCService {
+		using Handle = HorizonHandle;
+
 		Handle handle = KernelHandles::MCU_HWC;
 		Memory& mem;
 		MAKE_LOG_FUNCTION(log, mcuLogger)

--- a/include/services/mic.hpp
+++ b/include/services/mic.hpp
@@ -9,6 +9,8 @@
 class Kernel;
 
 class MICService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::MIC;
 	Memory& mem;
 	Kernel& kernel;
@@ -29,14 +31,14 @@ class MICService {
 	void unmapSharedMem(u32 messagePointer);
 	void theCaptainToadFunction(u32 messagePointer);
 
-	u8 gain = 0; // How loud our microphone input signal is
+	u8 gain = 0;  // How loud our microphone input signal is
 	bool micEnabled = false;
 	bool shouldClamp = false;
 	bool currentlySampling = false;
 
 	std::optional<Handle> eventHandle;
 
-public:
+  public:
 	MICService(Memory& mem, Kernel& kernel) : mem(mem), kernel(kernel) {}
 	void reset();
 	void handleSyncRequest(u32 messagePointer);

--- a/include/services/ndm.hpp
+++ b/include/services/ndm.hpp
@@ -6,7 +6,14 @@
 #include "result/result.hpp"
 
 class NDMService {
-	enum class ExclusiveState : u32 { None = 0, Infrastructure = 1, LocalComms = 2, StreetPass = 3, StreetPassData = 4 };
+	using Handle = HorizonHandle;
+	enum class ExclusiveState : u32 {
+		None = 0,
+		Infrastructure = 1,
+		LocalComms = 2,
+		StreetPass = 3,
+		StreetPassData = 4,
+	};
 
 	Handle handle = KernelHandles::NDM;
 	Memory& mem;
@@ -25,7 +32,7 @@ class NDMService {
 
 	ExclusiveState exclusiveState = ExclusiveState::None;
 
-public:
+  public:
 	NDMService(Memory& mem) : mem(mem) {}
 	void reset();
 	void handleSyncRequest(u32 messagePointer);

--- a/include/services/news_u.hpp
+++ b/include/services/news_u.hpp
@@ -5,6 +5,8 @@
 #include "memory.hpp"
 
 class NewsUService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::NEWS_U;
 	Memory& mem;
 	MAKE_LOG_FUNCTION(log, newsLogger)

--- a/include/services/nfc.hpp
+++ b/include/services/nfc.hpp
@@ -12,6 +12,8 @@
 class Kernel;
 
 class NFCService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::NFC;
 	Memory& mem;
 	Kernel& kernel;

--- a/include/services/nim.hpp
+++ b/include/services/nim.hpp
@@ -6,6 +6,8 @@
 #include "result/result.hpp"
 
 class NIMService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::NIM;
 	Memory& mem;
 	MAKE_LOG_FUNCTION(log, nimLogger)
@@ -13,7 +15,7 @@ class NIMService {
 	// Service commands
 	void initialize(u32 messagePointer);
 
-public:
+  public:
 	NIMService(Memory& mem) : mem(mem) {}
 	void reset();
 	void handleSyncRequest(u32 messagePointer);

--- a/include/services/nwm_uds.hpp
+++ b/include/services/nwm_uds.hpp
@@ -10,6 +10,8 @@
 class Kernel;
 
 class NwmUdsService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::NWM_UDS;
 	Memory& mem;
 	Kernel& kernel;

--- a/include/services/ptm.hpp
+++ b/include/services/ptm.hpp
@@ -22,7 +22,7 @@ class PTMService {
 	void getStepHistoryAll(u32 messagePointer);
 	void getTotalStepCount(u32 messagePointer);
 
-public:
+  public:
 	enum class Type {
 		U,     // ptm:u
 		SYSM,  // ptm:sysm

--- a/include/services/service_manager.hpp
+++ b/include/services/service_manager.hpp
@@ -42,6 +42,8 @@ struct EmulatorConfig;
 class Kernel;
 
 class ServiceManager {
+	using Handle = HorizonHandle;
+
 	std::span<u32, 16> regs;
 	Memory& mem;
 	Kernel& kernel;

--- a/include/services/soc.hpp
+++ b/include/services/soc.hpp
@@ -5,6 +5,8 @@
 #include "memory.hpp"
 
 class SOCService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::SOC;
 	Memory& mem;
 	MAKE_LOG_FUNCTION(log, socLogger)
@@ -14,7 +16,7 @@ class SOCService {
 	// Service commands
 	void initializeSockets(u32 messagePointer);
 
-public:
+  public:
 	SOCService(Memory& mem) : mem(mem) {}
 	void reset();
 	void handleSyncRequest(u32 messagePointer);

--- a/include/services/ssl.hpp
+++ b/include/services/ssl.hpp
@@ -1,17 +1,19 @@
 #pragma once
+#include <random>
+
 #include "helpers.hpp"
 #include "kernel_types.hpp"
 #include "logger.hpp"
 #include "memory.hpp"
 
-#include <random>
-
 class SSLService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::SSL;
 	Memory& mem;
 	MAKE_LOG_FUNCTION(log, sslLogger)
 
-	std::mt19937 rng; // Use a Mersenne Twister for RNG since this service is supposed to have better rng than just rand()
+	std::mt19937 rng;  // Use a Mersenne Twister for RNG since this service is supposed to have better rng than just rand()
 	bool initialized;
 
 	// Service commands

--- a/include/services/y2r.hpp
+++ b/include/services/y2r.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <array>
 #include <optional>
+
 #include "helpers.hpp"
 #include "kernel_types.hpp"
 #include "logger.hpp"
@@ -10,6 +11,8 @@
 class Kernel;
 
 class Y2RService {
+	using Handle = HorizonHandle;
+
 	Handle handle = KernelHandles::Y2R;
 	Memory& mem;
 	Kernel& kernel;
@@ -20,7 +23,7 @@ class Y2RService {
 
 	enum class BusyStatus : u32 {
 		NotBusy = 0,
-		Busy = 1
+		Busy = 1,
 	};
 
 	enum class InputFormat : u32 {
@@ -35,7 +38,7 @@ class Y2RService {
 		RGB32 = 0,
 		RGB24 = 1,
 		RGB15 = 2,
-		RGB565 = 3
+		RGB565 = 3,
 	};
 
 	// Clockwise rotation
@@ -43,12 +46,12 @@ class Y2RService {
 		None = 0,
 		Rotate90 = 1,
 		Rotate180 = 2,
-		Rotate270 = 3
+		Rotate270 = 3,
 	};
 
 	enum class BlockAlignment : u32 {
-		Line = 0, // Output buffer's pixels are arranged linearly. Used when outputting to the framebuffer.
-		Block8x8 = 1, // Output buffer's pixels are morton swizzled. Used when outputting to a GPU texture.
+		Line = 0,      // Output buffer's pixels are arranged linearly. Used when outputting to the framebuffer.
+		Block8x8 = 1,  // Output buffer's pixels are morton swizzled. Used when outputting to a GPU texture.
 	};
 
 	// https://github.com/citra-emu/citra/blob/ac9d72a95ca9a60de8d39484a14aecf489d6d016/src/core/hle/service/cam/y2r_u.cpp#L33
@@ -60,7 +63,7 @@ class Y2RService {
 		{{0x12A, 0x1CA, 0x88, 0x36, 0x21C, -0x1F04, 0x99C, -0x2421}},   // ITU_Rec709_Scaling
 	}};
 
-	CoefficientSet conversionCoefficients; // Current conversion coefficients
+	CoefficientSet conversionCoefficients;  // Current conversion coefficients
 
 	InputFormat inputFmt;
 	OutputFormat outputFmt;

--- a/src/core/kernel/address_arbiter.cpp
+++ b/src/core/kernel/address_arbiter.cpp
@@ -12,7 +12,7 @@ static const char* arbitrationTypeToString(u32 type) {
 	}
 }
 
-Handle Kernel::makeArbiter() {
+HorizonHandle Kernel::makeArbiter() {
 	if (arbiterCount >= appResourceLimits.maxAddressArbiters) {
 		Helpers::panic("Overflowed the number of address arbiters");
 	}

--- a/src/core/kernel/events.cpp
+++ b/src/core/kernel/events.cpp
@@ -12,7 +12,7 @@ const char* Kernel::resetTypeToString(u32 type) {
 	}
 }
 
-Handle Kernel::makeEvent(ResetType resetType, Event::CallbackType callback) {
+HorizonHandle Kernel::makeEvent(ResetType resetType, Event::CallbackType callback) {
 	Handle ret = makeObject(KernelObjectType::Event);
 	objects[ret].data = new Event(resetType, callback);
 	return ret;

--- a/src/core/kernel/kernel.cpp
+++ b/src/core/kernel/kernel.cpp
@@ -82,7 +82,7 @@ void Kernel::setVersion(u8 major, u8 minor) {
 	mem.kernelVersion = descriptor; // The memory objects needs a copy because you can read the kernel ver from config mem
 }
 
-Handle Kernel::makeProcess(u32 id) {
+HorizonHandle Kernel::makeProcess(u32 id) {
 	const Handle processHandle = makeObject(KernelObjectType::Process);
 	const Handle resourceLimitHandle = makeObject(KernelObjectType::ResourceLimit);
 

--- a/src/core/kernel/memory_management.cpp
+++ b/src/core/kernel/memory_management.cpp
@@ -154,7 +154,7 @@ void Kernel::mapMemoryBlock() {
 	regs[0] = Result::Success;
 }
 
-Handle Kernel::makeMemoryBlock(u32 addr, u32 size, u32 myPermission, u32 otherPermission) {
+HorizonHandle Kernel::makeMemoryBlock(u32 addr, u32 size, u32 myPermission, u32 otherPermission) {
 	Handle ret = makeObject(KernelObjectType::MemoryBlock);
 	objects[ret].data = new MemoryBlock(addr, size, myPermission, otherPermission);
 

--- a/src/core/kernel/ports.cpp
+++ b/src/core/kernel/ports.cpp
@@ -1,7 +1,7 @@
 #include "kernel.hpp"
 #include <cstring>
 
-Handle Kernel::makePort(const char* name) {
+HorizonHandle Kernel::makePort(const char* name) {
 	Handle ret = makeObject(KernelObjectType::Port);
 	portHandles.push_back(ret); // Push the port handle to our cache of port handles
 	objects[ret].data = new Port(name);
@@ -9,7 +9,7 @@ Handle Kernel::makePort(const char* name) {
 	return ret;
 }
 
-Handle Kernel::makeSession(Handle portHandle) {
+HorizonHandle Kernel::makeSession(Handle portHandle) {
 	const auto port = getObject(portHandle, KernelObjectType::Port);
 	if (port == nullptr) [[unlikely]] {
 		Helpers::panic("Trying to make session for non-existent port");
@@ -23,7 +23,7 @@ Handle Kernel::makeSession(Handle portHandle) {
 
 // Get the handle of a port based on its name
 // If there's no such port, return nullopt
-std::optional<Handle> Kernel::getPortHandle(const char* name) {
+std::optional<HorizonHandle> Kernel::getPortHandle(const char* name) {
 	for (auto handle : portHandles) {
 		const auto data = objects[handle].getData<Port>();
 		if (std::strncmp(name, data->name, Port::maxNameLen) == 0) {

--- a/src/core/kernel/threads.cpp
+++ b/src/core/kernel/threads.cpp
@@ -109,7 +109,7 @@ void Kernel::rescheduleThreads() {
 }
 
 // Internal OS function to spawn a thread
-Handle Kernel::makeThread(u32 entrypoint, u32 initialSP, u32 priority, ProcessorID id, u32 arg, ThreadStatus status) {
+HorizonHandle Kernel::makeThread(u32 entrypoint, u32 initialSP, u32 priority, ProcessorID id, u32 arg, ThreadStatus status) {
 	int index; // Index of the created thread in the  threads array
 
 	if (threadCount < appResourceLimits.maxThreads) [[likely]] { // If we have not yet created over too many threads
@@ -161,7 +161,7 @@ Handle Kernel::makeThread(u32 entrypoint, u32 initialSP, u32 priority, Processor
 	return ret;
 }
 
-Handle Kernel::makeMutex(bool locked) {
+HorizonHandle Kernel::makeMutex(bool locked) {
 	Handle ret = makeObject(KernelObjectType::Mutex);
 	objects[ret].data = new Mutex(locked, ret);
 
@@ -201,7 +201,7 @@ void Kernel::releaseMutex(Mutex* moo) {
 	}
 }
 
-Handle Kernel::makeSemaphore(u32 initialCount, u32 maximumCount) {
+HorizonHandle Kernel::makeSemaphore(u32 initialCount, u32 maximumCount) {
 	Handle ret = makeObject(KernelObjectType::Semaphore);
 	objects[ret].data = new Semaphore(initialCount, maximumCount);
 

--- a/src/core/kernel/timers.cpp
+++ b/src/core/kernel/timers.cpp
@@ -4,7 +4,7 @@
 #include "kernel.hpp"
 #include "scheduler.hpp"
 
-Handle Kernel::makeTimer(ResetType type) {
+HorizonHandle Kernel::makeTimer(ResetType type) {
 	Handle ret = makeObject(KernelObjectType::Timer);
 	objects[ret].data = new Timer(type);
 

--- a/src/core/services/fs.cpp
+++ b/src/core/services/fs.cpp
@@ -105,7 +105,7 @@ ArchiveBase* FSService::getArchiveFromID(u32 id, const FSPath& archivePath) {
 	}
 }
 
-std::optional<Handle> FSService::openFileHandle(ArchiveBase* archive, const FSPath& path, const FSPath& archivePath, const FilePerms& perms) {
+std::optional<HorizonHandle> FSService::openFileHandle(ArchiveBase* archive, const FSPath& path, const FSPath& archivePath, const FilePerms& perms) {
 	FileDescriptor opened = archive->openFile(path, perms);
 	if (opened.has_value()) { // If opened doesn't have a value, we failed to open the file
 		auto handle = kernel.makeObject(KernelObjectType::File);
@@ -119,7 +119,7 @@ std::optional<Handle> FSService::openFileHandle(ArchiveBase* archive, const FSPa
 	}
 }
 
-Rust::Result<Handle, Result::HorizonResult> FSService::openDirectoryHandle(ArchiveBase* archive, const FSPath& path) {
+Rust::Result<HorizonHandle, Result::HorizonResult> FSService::openDirectoryHandle(ArchiveBase* archive, const FSPath& path) {
 	Rust::Result<DirectorySession, Result::HorizonResult> opened = archive->openDirectory(path);
 	if (opened.isOk()) { // If opened doesn't have a value, we failed to open the directory
 		auto handle = kernel.makeObject(KernelObjectType::Directory);
@@ -132,7 +132,7 @@ Rust::Result<Handle, Result::HorizonResult> FSService::openDirectoryHandle(Archi
 	}
 }
 
-Rust::Result<Handle, Result::HorizonResult> FSService::openArchiveHandle(u32 archiveID, const FSPath& path) {
+Rust::Result<HorizonHandle, Result::HorizonResult> FSService::openArchiveHandle(u32 archiveID, const FSPath& path) {
 	ArchiveBase* archive = getArchiveFromID(archiveID, path);
 
 	if (archive == nullptr) [[unlikely]] {

--- a/src/core/services/service_manager.cpp
+++ b/src/core/services/service_manager.cpp
@@ -93,7 +93,7 @@ void ServiceManager::registerClient(u32 messagePointer) {
 }
 
 // clang-format off
-static std::map<std::string, Handle> serviceMap = {
+static std::map<std::string, HorizonHandle> serviceMap = {
 	{ "ac:u", KernelHandles::AC },
 	{ "act:a", KernelHandles::ACT },
 	{ "act:u", KernelHandles::ACT },


### PR DESCRIPTION
Should hopefully fix conflicts with Apple's Foundation SDK defining `Handle` globally