### PR TITLE
Qt: Stop emuThread on closeEvent

### DIFF
--- a/include/panda_qt/main_window.hpp
+++ b/include/panda_qt/main_window.hpp
@@ -139,6 +139,7 @@ class MainWindow : public QMainWindow {
 	MainWindow(QApplication* app, QWidget* parent = nullptr);
 	~MainWindow();
 
+	void closeEvent(QCloseEvent *event) override;
 	void keyPressEvent(QKeyEvent* event) override;
 	void keyReleaseEvent(QKeyEvent* event) override;
 	void mousePressEvent(QMouseEvent* event) override;

--- a/src/panda_qt/main_window.cpp
+++ b/src/panda_qt/main_window.cpp
@@ -204,14 +204,19 @@ void MainWindow::selectLuaFile() {
 	}
 }
 
-// Cleanup when the main window closes
-MainWindow::~MainWindow() {
+// Stop emulator thread when the main window closes
+void MainWindow::closeEvent(QCloseEvent *event) {
 	appRunning = false;  // Set our running atomic to false in order to make the emulator thread stop, and join it
 
 	if (emuThread.joinable()) {
 		emuThread.join();
 	}
 
+	SDL_Quit();
+}
+
+// Cleanup when the main window closes
+MainWindow::~MainWindow() {
 	delete emu;
 	delete menuBar;
 	delete aboutWindow;

--- a/src/panda_qt/main_window.cpp
+++ b/src/panda_qt/main_window.cpp
@@ -211,8 +211,6 @@ void MainWindow::closeEvent(QCloseEvent *event) {
 	if (emuThread.joinable()) {
 		emuThread.join();
 	}
-
-	SDL_Quit();
 }
 
 // Cleanup when the main window closes


### PR DESCRIPTION
This moves emuThread stopping to main window closeEvent. Without this the app keeps running even if the window is closed. Also added `SDL_Quit`, but I'm not sure if it is necessary.