### PR TITLE
Implement controller-based gyroscope on both Qt and SDL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,7 @@ set(HEADER_FILES include/emulator.hpp include/helpers.hpp include/termcolor.hpp 
                  include/audio/miniaudio_device.hpp include/ring_buffer.hpp include/bitfield.hpp include/audio/dsp_shared_mem.hpp
                  include/audio/hle_core.hpp include/capstone.hpp include/audio/aac.hpp include/PICA/pica_frag_config.hpp
                  include/PICA/pica_frag_uniforms.hpp include/PICA/shader_gen_types.hpp include/PICA/shader_decompiler.hpp
+                 include/sdl_gyro.hpp
 )
 
 cmrc_add_resource_library(

--- a/include/panda_qt/main_window.hpp
+++ b/include/panda_qt/main_window.hpp
@@ -122,6 +122,7 @@ class MainWindow : public QMainWindow {
 	void showAboutMenu();
 	void initControllers();
 	void pollControllers();
+	void setupControllerSensors(SDL_GameController* controller);
 	void sendMessage(const EmulatorMessage& message);
 	void dispatchMessage(const EmulatorMessage& message);
 

--- a/include/panda_sdl/frontend_sdl.hpp
+++ b/include/panda_sdl/frontend_sdl.hpp
@@ -37,4 +37,6 @@ class FrontendSDL {
 	// And so the user can still use the keyboard to control the analog
 	bool keyboardAnalogX = false;
 	bool keyboardAnalogY = false;
+
+	void setupControllerSensors(SDL_GameController* controller);
 };

--- a/include/sdl_gyro.hpp
+++ b/include/sdl_gyro.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <glm/glm.hpp>
+#include <numbers>
+
+#include "services/hid.hpp"
+
+namespace Gyro::SDL {
+	// Convert the rotation data we get from SDL sensor events to rotation data we can feed right to HID
+	// Returns [pitch, roll, yaw]
+	static glm::vec3 convertRotation(glm::vec3 rotation) { 
+		// Flip axes
+		glm::vec3 ret = -rotation;
+		// Convert from radians/s to deg/s and scale by the gyroscope coefficient from the HID service
+		ret *= 180.f / std::numbers::pi;
+		ret *= HIDService::gyroscopeCoeff;
+
+		return ret;
+	}
+}  // namespace Gyro::SDL

--- a/include/services/hid.hpp
+++ b/include/services/hid.hpp
@@ -88,6 +88,8 @@ class HIDService {
 	}
 
   public:
+	static constexpr float gyroscopeCoeff = 14.375f;  // Same as retail 3DS
+
 	HIDService(Memory& mem, Kernel& kernel) : mem(mem), kernel(kernel) {}
 	void reset();
 	void handleSyncRequest(u32 messagePointer);

--- a/src/core/services/hid.cpp
+++ b/src/core/services/hid.cpp
@@ -103,7 +103,6 @@ void HIDService::getGyroscopeLowCalibrateParam(u32 messagePointer) {
 void HIDService::getGyroscopeCoefficient(u32 messagePointer) {
 	log("HID::GetGyroscopeLowRawToDpsCoefficient\n");
 
-	constexpr float gyroscopeCoeff = 14.375f; // Same as retail 3DS
 	mem.write32(messagePointer, IPC::responseHeader(0x15, 2, 0));
 	mem.write32(messagePointer + 4, Result::Success);
 	mem.write32(messagePointer + 8, Helpers::bit_cast<u32, float>(gyroscopeCoeff));

--- a/src/panda_sdl/frontend_sdl.cpp
+++ b/src/panda_sdl/frontend_sdl.cpp
@@ -289,7 +289,7 @@ void FrontendSDL::run() {
 									
 				case SDL_CONTROLLERSENSORUPDATE: {
 					if (event.csensor.sensor == SDL_SENSOR_GYRO) {
-						glm::vec3 rotation = Gyro::SDL::convertRotation({
+						auto rotation = Gyro::SDL::convertRotation({
 							event.csensor.data[0],
 							event.csensor.data[1],
 							event.csensor.data[2],

--- a/src/panda_sdl/frontend_sdl.cpp
+++ b/src/panda_sdl/frontend_sdl.cpp
@@ -2,6 +2,8 @@
 
 #include <glad/gl.h>
 
+#include "sdl_gyro.hpp"
+
 FrontendSDL::FrontendSDL() : keyboardMappings(InputMappings::defaultKeyboardMappings()) {
 	if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS) < 0) {
 		Helpers::panic("Failed to initialize SDL2");
@@ -20,6 +22,8 @@ FrontendSDL::FrontendSDL() : keyboardMappings(InputMappings::defaultKeyboardMapp
 			SDL_Joystick* stick = SDL_GameControllerGetJoystick(gameController);
 			gameControllerID = SDL_JoystickInstanceID(stick);
 		}
+
+		setupControllerSensors(gameController);
 	}
 
 	const EmulatorConfig& config = emu.getConfig();
@@ -200,6 +204,8 @@ void FrontendSDL::run() {
 					if (gameController == nullptr) {
 						gameController = SDL_GameControllerOpen(event.cdevice.which);
 						gameControllerID = event.cdevice.which;
+
+						setupControllerSensors(gameController);
 					}
 					break;
 
@@ -280,6 +286,21 @@ void FrontendSDL::run() {
 					}
 					break;
 				}
+									
+				case SDL_CONTROLLERSENSORUPDATE: {
+					if (event.csensor.sensor == SDL_SENSOR_GYRO) {
+						glm::vec3 rotation = Gyro::SDL::convertRotation({
+							event.csensor.data[0],
+							event.csensor.data[1],
+							event.csensor.data[2],
+						});
+
+						hid.setPitch(s16(rotation.x));
+						hid.setRoll(s16(rotation.y));
+						hid.setYaw(s16(rotation.z));
+					}
+					break;
+				}
 
 				case SDL_DROPFILE: {
 					char* droppedDir = event.drop.file;
@@ -340,5 +361,13 @@ void FrontendSDL::run() {
 		// kernel.evalReschedule();
 
 		SDL_GL_SwapWindow(window);
+	}
+}
+
+void FrontendSDL::setupControllerSensors(SDL_GameController* controller) {
+	bool haveGyro = SDL_GameControllerHasSensor(controller, SDL_SENSOR_GYRO) == SDL_TRUE;
+
+	if (haveGyro) {
+		SDL_GameControllerSetSensorEnabled(controller, SDL_SENSOR_GYRO, SDL_TRUE);
 	}
 }


### PR DESCRIPTION
Allows players to control the 3DS gyroscope by moving around their controller, provided their controller has a gyroscope sensor. Makes games like Kirby's Triple Deluxe, Yoshi's New Island and Pokemon X, all of which require gyroscope to some degree, a lot more playable.

Tested with my Sony DualShock 4 on Windows.