### PR TITLE
Optimize gyro calculation

### DIFF
--- a/include/sdl_gyro.hpp
+++ b/include/sdl_gyro.hpp
@@ -8,13 +8,10 @@
 namespace Gyro::SDL {
 	// Convert the rotation data we get from SDL sensor events to rotation data we can feed right to HID
 	// Returns [pitch, roll, yaw]
-	static glm::vec3 convertRotation(glm::vec3 rotation) { 
-		// Flip axes
-		glm::vec3 ret = -rotation;
-		// Convert from radians/s to deg/s and scale by the gyroscope coefficient from the HID service
-		ret *= 180.f / std::numbers::pi;
-		ret *= HIDService::gyroscopeCoeff;
-
-		return ret;
+	static glm::vec3 convertRotation(glm::vec3 rotation) {
+		// Convert the rotation from rad/s to deg/s and scale by the gyroscope coefficient in HID
+		constexpr float scale = 180.f / std::numbers::pi * HIDService::gyroscopeCoeff;
+		// The axes are also inverted, so invert scale before the multiplication.
+		return rotation * -scale;
 	}
 }  // namespace Gyro::SDL


### PR DESCRIPTION
Avoids copies and multiplications which MSVC was failing to optimize
![image](https://github.com/user-attachments/assets/ed6c07e4-9692-4969-968d-127e6e96a900)
