### PR TITLE
macOS CI fixes

### DIFF
--- a/.github/workflows/MacOS_Build.yml
+++ b/.github/workflows/MacOS_Build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: macos-13
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Fetch submodules
       run: git submodule update --init --recursive
 

--- a/.github/workflows/MacOS_Build.yml
+++ b/.github/workflows/MacOS_Build.yml
@@ -40,7 +40,7 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
     - name: Install bundle dependencies
-      run: brew install --overwrite python@3.12 && brew install dylibbundler imagemagick
+      run: brew install dylibbundler imagemagick
 
     - name: Run bundle script
       run: ./.github/mac-bundle.sh

--- a/.github/workflows/MacOS_Build.yml
+++ b/.github/workflows/MacOS_Build.yml
@@ -52,7 +52,7 @@ jobs:
       run: zip -r Alber Alber.app
 
     - name: Upload MacOS App
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: MacOS Alber App Bundle
         path: 'Alber.zip'

--- a/.github/workflows/Qt_Build.yml
+++ b/.github/workflows/Qt_Build.yml
@@ -67,7 +67,7 @@ jobs:
 
     - name: Install bundle dependencies
       run: |
-        brew install --overwrite python@3.12 && brew install dylibbundler imagemagick
+        brew install dylibbundler imagemagick
 
     - name: Install qt
       run: brew install qt && which macdeployqt

--- a/.github/workflows/Qt_Build.yml
+++ b/.github/workflows/Qt_Build.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: macos-13
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Fetch submodules
       run: git submodule update --init --recursive
 
@@ -90,7 +90,7 @@ jobs:
       run: zip -r Alber Alber.app
 
     - name: Upload MacOS App
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: MacOS Alber App Bundle
         path: 'Alber.zip'


### PR DESCRIPTION
This PR updates the macOS build yaml with the following changes:
- Update `checkout` from v2 to v4
- Update `upload-artifact` from v2 to v4
- Removes install step for Python 3.12

Reason for changes: Resolving deprecation warnings
- v2 of `checkout` and `upload-artifact` are deprecated. 
- Python 3.12 is already installed and up to date

Testing: 
- Ensure CI still builds