### PR TITLE
Add build option for opengl profile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,12 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-interference-size")
 endif() 
 
+if(ANDROID)
+    set(DEFAULT_OPENGL_PROFILE OpenGLES)
+else()
+    set(DEFAULT_OPENGL_PROFILE OpenGL)
+endif()
+
 option(DISABLE_PANIC_DEV "Make a build with fewer and less intrusive asserts" ON)
 option(GPU_DEBUG_INFO "Enable additional GPU debugging info" OFF)
 option(ENABLE_OPENGL "Enable OpenGL rendering backend" ON)
@@ -48,6 +54,14 @@ option(ENABLE_GIT_VERSIONING "Enables querying git for the emulator version" ON)
 option(BUILD_HYDRA_CORE "Build a Hydra core" OFF)
 option(BUILD_LIBRETRO_CORE "Build a Libretro core" OFF)
 option(ENABLE_RENDERDOC_API "Build with support for Renderdoc's capture API for graphics debugging" ON)
+
+set(OPENGL_PROFILE ${DEFAULT_OPENGL_PROFILE} CACHE STRING "OpenGL profile to use if OpenGL is enabled. Valid values are 'OpenGL' and 'OpenGLES'.")
+set_property(CACHE OPENGL_PROFILE PROPERTY STRINGS OpenGL OpenGLES)
+
+if(ENABLE_OPENGL AND (OPENGL_PROFILE STREQUAL "OpenGLES"))
+    message(STATUS "Building with OpenGLES support")
+    add_compile_definitions(USING_GLES)
+endif()
 
 if(BUILD_HYDRA_CORE)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/src/core/renderer_gl/renderer_gl.cpp
+++ b/src/core/renderer_gl/renderer_gl.cpp
@@ -49,7 +49,7 @@ void RendererGL::reset() {
 		gl.useProgram(oldProgram);  // Switch to old GL program
 	}
 
-#ifdef __ANDROID__
+#ifdef USING_GLES
 	fragShaderGen.setTarget(PICA::ShaderGen::API::GLES, PICA::ShaderGen::Language::GLSL);
 #endif
 }

--- a/src/hydra_core.cpp
+++ b/src/hydra_core.cpp
@@ -114,7 +114,7 @@ hydra::Size HydraCore::getNativeSize() { return {400, 480}; }
 void HydraCore::setOutputSize(hydra::Size size) {}
 
 void HydraCore::resetContext() {
-#ifdef __ANDROID__
+#ifdef USING_GLES
 	if (!gladLoadGLES2Loader(reinterpret_cast<GLADloadproc>(getProcAddress))) {
 		Helpers::panic("OpenGL ES init failed");
 	}


### PR DESCRIPTION
This adds `OPENGL_PROFILE` option to allow building for OpenGLES devices such as RPi.