### PR TITLE
Remove opengl.hpp from gles.patch, use in-file gles checks

### DIFF
--- a/.github/gles.patch
+++ b/.github/gles.patch
@@ -241,35 +241,3 @@ index 057f9a88..dc735ced 100644
  
  	v_quaternion = a_quaternion;
  }
-diff --git a/third_party/opengl/opengl.hpp b/third_party/opengl/opengl.hpp
-index 607815fa..cbfcc096 100644
---- a/third_party/opengl/opengl.hpp
-+++ b/third_party/opengl/opengl.hpp
-@@ -602,22 +602,22 @@ namespace OpenGL {
- 	static void disableScissor() { glDisable(GL_SCISSOR_TEST); }
- 	static void enableBlend() { glEnable(GL_BLEND); }
- 	static void disableBlend() { glDisable(GL_BLEND); }
--	static void enableLogicOp() { glEnable(GL_COLOR_LOGIC_OP); }
--	static void disableLogicOp() { glDisable(GL_COLOR_LOGIC_OP); }
-+	static void enableLogicOp() { /* glEnable(GL_COLOR_LOGIC_OP); */ }
-+	static void disableLogicOp() { /* glDisable(GL_COLOR_LOGIC_OP); */ }
- 	static void enableDepth() { glEnable(GL_DEPTH_TEST); }
- 	static void disableDepth() { glDisable(GL_DEPTH_TEST); }
- 	static void enableStencil() { glEnable(GL_STENCIL_TEST); }
- 	static void disableStencil() { glDisable(GL_STENCIL_TEST); }
- 
--	static void enableClipPlane(GLuint index) { glEnable(GL_CLIP_DISTANCE0 + index); }
--	static void disableClipPlane(GLuint index) { glDisable(GL_CLIP_DISTANCE0 + index); }
-+	static void enableClipPlane(GLuint index) { /* glEnable(GL_CLIP_DISTANCE0 + index); */ }
-+	static void disableClipPlane(GLuint index) { /* glDisable(GL_CLIP_DISTANCE0 + index); */ }
- 
- 	static void setDepthFunc(DepthFunc func) { glDepthFunc(static_cast<GLenum>(func)); }
- 	static void setColourMask(GLboolean r, GLboolean g, GLboolean b, GLboolean a) { glColorMask(r, g, b, a); }
- 	static void setDepthMask(GLboolean mask) { glDepthMask(mask); }
- 
- 	// TODO: Add a proper enum for this
--	static void setLogicOp(GLenum op) { glLogicOp(op); }
-+	static void setLogicOp(GLenum op) { /* glLogicOp(op); */ }
- 
-     enum Primitives {
-         Triangle = GL_TRIANGLES,

--- a/third_party/opengl/opengl.hpp
+++ b/third_party/opengl/opengl.hpp
@@ -602,22 +602,36 @@ namespace OpenGL {
 	static void disableScissor() { glDisable(GL_SCISSOR_TEST); }
 	static void enableBlend() { glEnable(GL_BLEND); }
 	static void disableBlend() { glDisable(GL_BLEND); }
+#ifdef USING_GLES
+	static void enableLogicOp() { /* glEnable(GL_COLOR_LOGIC_OP); */ }
+	static void disableLogicOp() { /* glDisable(GL_COLOR_LOGIC_OP); */ }
+#else
 	static void enableLogicOp() { glEnable(GL_COLOR_LOGIC_OP); }
 	static void disableLogicOp() { glDisable(GL_COLOR_LOGIC_OP); }
+#endif
 	static void enableDepth() { glEnable(GL_DEPTH_TEST); }
 	static void disableDepth() { glDisable(GL_DEPTH_TEST); }
 	static void enableStencil() { glEnable(GL_STENCIL_TEST); }
 	static void disableStencil() { glDisable(GL_STENCIL_TEST); }
 
+#ifdef USING_GLES
+	static void enableClipPlane(GLuint index) { /* glEnable(GL_CLIP_DISTANCE0 + index); */ }
+	static void disableClipPlane(GLuint index) { /* glDisable(GL_CLIP_DISTANCE0 + index); */ }
+#else
 	static void enableClipPlane(GLuint index) { glEnable(GL_CLIP_DISTANCE0 + index); }
 	static void disableClipPlane(GLuint index) { glDisable(GL_CLIP_DISTANCE0 + index); }
+#endif
 
 	static void setDepthFunc(DepthFunc func) { glDepthFunc(static_cast<GLenum>(func)); }
 	static void setColourMask(GLboolean r, GLboolean g, GLboolean b, GLboolean a) { glColorMask(r, g, b, a); }
 	static void setDepthMask(GLboolean mask) { glDepthMask(mask); }
 
 	// TODO: Add a proper enum for this
+#ifdef USING_GLES
+	static void setLogicOp(GLenum op) { /* glLogicOp(op); */ }
+#else
 	static void setLogicOp(GLenum op) { glLogicOp(op); }
+#endif
 
     enum Primitives {
         Triangle = GL_TRIANGLES,


### PR DESCRIPTION
This prevents crashing if build with `OPENGL_PROFILE=OpenGLES` without applying the gles.patch. 