### PR TITLE
Prevent app crash when miniaudio samples bigger than capacity

### DIFF
--- a/src/core/audio/miniaudio_device.cpp
+++ b/src/core/audio/miniaudio_device.cpp
@@ -90,16 +90,17 @@ void MiniAudioDevice::init(Samples& samples, bool safe) {
 	deviceConfig.dataCallback = [](ma_device* device, void* out, const void* input, ma_uint32 frameCount) {
 		auto self = reinterpret_cast<MiniAudioDevice*>(device->pUserData);
 		s16* output = reinterpret_cast<ma_int16*>(out);
+		usize maxSamples = std::min(self->samples->Capacity(), (usize)(frameCount * channelCount));
 
 		// Wait until there's enough samples to pop
-		while (self->samples->size() < frameCount * channelCount) {
+		while (self->samples->size() < maxSamples) {
 			// If audio output is disabled from the emulator thread, make sure that this callback will return and not hang
 			if (!self->running) {
 				return;
 			}
 		}
 
-		self->samples->pop(output, frameCount * channelCount);
+		self->samples->pop(output, maxSamples);
 	};
 
 	if (ma_device_init(&context, &deviceConfig, &device) != MA_SUCCESS) {

--- a/src/core/audio/miniaudio_device.cpp
+++ b/src/core/audio/miniaudio_device.cpp
@@ -90,7 +90,7 @@ void MiniAudioDevice::init(Samples& samples, bool safe) {
 	deviceConfig.dataCallback = [](ma_device* device, void* out, const void* input, ma_uint32 frameCount) {
 		auto self = reinterpret_cast<MiniAudioDevice*>(device->pUserData);
 		s16* output = reinterpret_cast<ma_int16*>(out);
-		usize maxSamples = std::min(self->samples->Capacity(), (usize)(frameCount * channelCount));
+		const usize maxSamples = std::min(self->samples->Capacity(), usize(frameCount * channelCount));
 
 		// Wait until there's enough samples to pop
 		while (self->samples->size() < maxSamples) {


### PR DESCRIPTION
On linux and macos the app crashes when enabling audio due to `frameCount * channelCount` being bigger than samples capacity. This prevents the crash, but audio still not working (only noises).