### PR TITLE
Qt: Fix Linguist issues and format files

### DIFF
--- a/.github/workflows/HTTP_Build.yml
+++ b/.github/workflows/HTTP_Build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Fetch submodules
       run: git submodule update --init --recursive
       

--- a/.github/workflows/Hydra_Build.yml
+++ b/.github/workflows/Hydra_Build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Fetch submodules
       run: git submodule update --init --recursive
 
@@ -58,7 +58,7 @@ jobs:
     runs-on: macos-13
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Fetch submodules
       run: git submodule update --init --recursive
 
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Fetch submodules
       run: git submodule update --init --recursive
 
@@ -154,7 +154,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Fetch submodules
       run: git submodule update --init --recursive
 

--- a/.github/workflows/Linux_AppImage_Build.yml
+++ b/.github/workflows/Linux_AppImage_Build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Fetch submodules
       run: git submodule update --init --recursive
 
@@ -52,7 +52,7 @@ jobs:
       run:  ./.github/linux-appimage.sh
 
     - name: Upload executable
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Linux executable
         path: './Alber-x86_64.AppImage' 

--- a/.github/workflows/Linux_Build.yml
+++ b/.github/workflows/Linux_Build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Fetch submodules
       run: git submodule update --init --recursive
 
@@ -49,7 +49,7 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
     - name: Upload executable
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Linux executable
         path: './build/Alber'

--- a/.github/workflows/Qt_Build.yml
+++ b/.github/workflows/Qt_Build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Fetch submodules
       run: git submodule update --init --recursive
 
@@ -45,7 +45,7 @@ jobs:
         windeployqt --dir upload upload/Alber.exe
 
     - name: Upload executable
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Windows executable
         path: upload
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Fetch submodules
       run: git submodule update --init --recursive
 
@@ -135,7 +135,7 @@ jobs:
         ./.github/linux-appimage-qt.sh
 
     - name: Upload executable
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Linux executable
         path: './Alber-x86_64.AppImage' 

--- a/.github/workflows/Windows_Build.yml
+++ b/.github/workflows/Windows_Build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Fetch submodules
       run: git submodule update --init --recursive
 
@@ -40,7 +40,7 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
     - name: Upload executable
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Windows executable
         path: './build/${{ env.BUILD_TYPE }}/Alber.exe'

--- a/include/panda_qt/cheats_window.hpp
+++ b/include/panda_qt/cheats_window.hpp
@@ -1,6 +1,13 @@
 #pragma once
 
 #include <QAction>
+#include <QCheckBox>
+#include <QDialog>
+#include <QLabel>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QPushButton>
+#include <QTextEdit>
 #include <QWidget>
 #include <filesystem>
 #include <memory>
@@ -23,4 +30,61 @@ class CheatsWindow final : public QWidget {
 	QListWidget* cheatList;
 	std::filesystem::path cheatPath;
 	Emulator* emu;
+};
+
+struct CheatMetadata {
+	u32 handle = Cheats::badCheatHandle;
+	std::string name = "New cheat";
+	std::string code;
+	bool enabled = true;
+};
+
+class CheatEntryWidget : public QWidget {
+	Q_OBJECT
+
+  public:
+	CheatEntryWidget(Emulator* emu, CheatMetadata metadata, QListWidget* parent);
+
+	void Update() {
+		name->setText(metadata.name.c_str());
+		enabled->setChecked(metadata.enabled);
+		update();
+	}
+
+	void Remove() {
+		emu->getCheats().removeCheat(metadata.handle);
+		cheatList->takeItem(cheatList->row(listItem));
+		deleteLater();
+	}
+
+	const CheatMetadata& getMetadata() { return metadata; }
+	void setMetadata(const CheatMetadata& metadata) { this->metadata = metadata; }
+
+  private:
+	void checkboxChanged(int state);
+	void editClicked();
+
+	Emulator* emu;
+	CheatMetadata metadata;
+	u32 handle;
+	QLabel* name;
+	QCheckBox* enabled;
+	QListWidget* cheatList;
+	QListWidgetItem* listItem;
+};
+
+class CheatEditDialog : public QDialog {
+	Q_OBJECT
+
+  public:
+	CheatEditDialog(Emulator* emu, CheatEntryWidget& cheatEntry);
+
+	void accepted();
+	void rejected();
+
+  private:
+	Emulator* emu;
+	CheatEntryWidget& cheatEntry;
+	QTextEdit* codeEdit;
+	QLineEdit* nameEdit;
 };

--- a/include/panda_qt/main_window.hpp
+++ b/include/panda_qt/main_window.hpp
@@ -140,7 +140,7 @@ class MainWindow : public QMainWindow {
 	MainWindow(QApplication* app, QWidget* parent = nullptr);
 	~MainWindow();
 
-	void closeEvent(QCloseEvent *event) override;
+	void closeEvent(QCloseEvent* event) override;
 	void keyPressEvent(QKeyEvent* event) override;
 	void keyReleaseEvent(QKeyEvent* event) override;
 	void mousePressEvent(QMouseEvent* event) override;

--- a/src/panda_qt/about_window.cpp
+++ b/src/panda_qt/about_window.cpp
@@ -1,10 +1,12 @@
 #include "panda_qt/about_window.hpp"
-#include "version.hpp"
 
+#include <QHBoxLayout>
 #include <QLabel>
 #include <QTextEdit>
 #include <QVBoxLayout>
 #include <QtGlobal>
+
+#include "version.hpp"
 
 // Based on https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/DolphinQt/AboutDialog.cpp
 

--- a/src/panda_qt/cheats_window.cpp
+++ b/src/panda_qt/cheats_window.cpp
@@ -1,15 +1,9 @@
 #include "panda_qt/cheats_window.hpp"
 
-#include <QCheckBox>
-#include <QDialog>
 #include <QDialogButtonBox>
-#include <QLabel>
-#include <QLineEdit>
-#include <QListWidget>
-#include <QPushButton>
-#include <QTextEdit>
-#include <QVBoxLayout>
+#include <QHBoxLayout>
 #include <QTimer>
+#include <QVBoxLayout>
 #include <functional>
 
 #include "cheats.hpp"
@@ -18,70 +12,16 @@
 
 MainWindow* mainWindow = nullptr;
 
-struct CheatMetadata {
-	u32 handle = Cheats::badCheatHandle;
-	std::string name = "New cheat";
-	std::string code;
-	bool enabled = true;
-};
-
 void dispatchToMainThread(std::function<void()> callback) {
-    QTimer* timer = new QTimer();
-    timer->moveToThread(qApp->thread());
-    timer->setSingleShot(true);
-    QObject::connect(timer, &QTimer::timeout, [=]()
-    {
-        callback();
-        timer->deleteLater();
-    });
-    QMetaObject::invokeMethod(timer, "start", Qt::QueuedConnection, Q_ARG(int, 0));
+	QTimer* timer = new QTimer();
+	timer->moveToThread(qApp->thread());
+	timer->setSingleShot(true);
+	QObject::connect(timer, &QTimer::timeout, [=]() {
+		callback();
+		timer->deleteLater();
+	});
+	QMetaObject::invokeMethod(timer, "start", Qt::QueuedConnection, Q_ARG(int, 0));
 }
-
-class CheatEntryWidget : public QWidget {
-  public:
-	CheatEntryWidget(Emulator* emu, CheatMetadata metadata, QListWidget* parent);
-
-	void Update() {
-		name->setText(metadata.name.c_str());
-		enabled->setChecked(metadata.enabled);
-		update();
-	}
-
-	void Remove() {
-		emu->getCheats().removeCheat(metadata.handle);
-		cheatList->takeItem(cheatList->row(listItem));
-		deleteLater();
-	}
-
-	const CheatMetadata& getMetadata() { return metadata; }
-	void setMetadata(const CheatMetadata& metadata) { this->metadata = metadata; }
-
-  private:
-	void checkboxChanged(int state);
-	void editClicked();
-
-	Emulator* emu;
-	CheatMetadata metadata;
-	u32 handle;
-	QLabel* name;
-	QCheckBox* enabled;
-	QListWidget* cheatList;
-	QListWidgetItem* listItem;
-};
-
-class CheatEditDialog : public QDialog {
-  public:
-	CheatEditDialog(Emulator* emu, CheatEntryWidget& cheatEntry);
-
-	void accepted();
-	void rejected();
-
-  private:
-	Emulator* emu;
-	CheatEntryWidget& cheatEntry;
-	QTextEdit* codeEdit;
-	QLineEdit* nameEdit;
-};
 
 CheatEntryWidget::CheatEntryWidget(Emulator* emu, CheatMetadata metadata, QListWidget* parent)
 	: QWidget(), emu(emu), metadata(metadata), cheatList(parent) {
@@ -219,7 +159,7 @@ void CheatEditDialog::rejected() {
 
 CheatsWindow::CheatsWindow(Emulator* emu, const std::filesystem::path& cheatPath, QWidget* parent)
 	: QWidget(parent, Qt::Window), emu(emu), cheatPath(cheatPath) {
-    mainWindow = static_cast<MainWindow*>(parent);
+	mainWindow = static_cast<MainWindow*>(parent);
 
 	QVBoxLayout* layout = new QVBoxLayout;
 	layout->setContentsMargins(6, 6, 6, 6);

--- a/src/panda_qt/mappings.cpp
+++ b/src/panda_qt/mappings.cpp
@@ -1,6 +1,6 @@
-#include "input_mappings.hpp"
-
 #include <QKeyEvent>
+
+#include "input_mappings.hpp"
 
 InputMappings InputMappings::defaultKeyboardMappings() {
 	InputMappings mappings;

--- a/src/panda_qt/shader_editor.cpp
+++ b/src/panda_qt/shader_editor.cpp
@@ -1,8 +1,9 @@
+#include "panda_qt/shader_editor.hpp"
+
 #include <QPushButton>
 #include <QVBoxLayout>
 
 #include "panda_qt/main_window.hpp"
-#include "panda_qt/shader_editor.hpp"
 
 using namespace Zep;
 


### PR DESCRIPTION
Fixes some unconventional code that would crash Qt Linguist due to declaring Q_OBJECT classes in .cpp files, necessary for doing translations (Partially supersedes #421)