### PR TITLE
Shadergen: Pre-allocate space for shadergen string

### DIFF
--- a/src/core/PICA/shader_gen_glsl.cpp
+++ b/src/core/PICA/shader_gen_glsl.cpp
@@ -34,6 +34,8 @@ static constexpr const char* uniformDefinition = R"(
 
 std::string FragmentGenerator::getDefaultVertexShader() {
 	std::string ret = "";
+	// Reserve some space (128KB) in the output string to avoid too many allocations later
+	ret.reserve(128 * 1024);
 
 	switch (api) {
 		case API::GL: ret += "#version 410 core"; break;


### PR DESCRIPTION
Speeds up shader compilation semi-significantly by avoiding several unecessary allocations