### PR TITLE
Qt: Optionally remember window pos/size

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -21,7 +21,7 @@ struct EmulatorConfig {
 	static constexpr bool ubershaderDefault = true;
 #endif
 	static constexpr bool accelerateShadersDefault = true;
-	
+
 	bool shaderJitEnabled = shaderJitDefault;
 	bool useUbershaders = ubershaderDefault;
 	bool accelerateShaders = accelerateShadersDefault;
@@ -41,10 +41,9 @@ struct EmulatorConfig {
 
 	bool audioEnabled = false;
 	bool vsyncEnabled = true;
-	
+
 	bool enableRenderdoc = false;
 	bool printAppVersion = true;
-	bool appVersionOnWindow = false;
 
 	bool chargerPlugged = true;
 	// Default to 3% battery to make users suffer
@@ -53,6 +52,24 @@ struct EmulatorConfig {
 	// Default ROM path to open in Qt and misc frontends
 	std::filesystem::path defaultRomPath = "";
 	std::filesystem::path filePath;
+
+	// Frontend window settings
+	struct WindowSettings {
+		static constexpr int defaultX = 200;
+		static constexpr int defaultY = 200;
+		static constexpr int defaultWidth = 800;
+		static constexpr int defaultHeight = 240 * 2;
+
+		bool rememberPosition = false;  // Remember window position & size
+		bool showAppVersion = false;
+
+		int x = defaultX;
+		int y = defaultY;
+		int width = defaultHeight;
+		int height = defaultHeight;
+	};
+
+	WindowSettings windowSettings;
 
 	EmulatorConfig(const std::filesystem::path& path);
 	void load();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -43,7 +43,21 @@ void EmulatorConfig::load() {
 			defaultRomPath = toml::find_or<std::string>(general, "DefaultRomPath", "");
 
 			printAppVersion = toml::find_or<toml::boolean>(general, "PrintAppVersion", true);
-			appVersionOnWindow = toml::find_or<toml::boolean>(general, "AppVersionOnWindow", false);
+		}
+	}
+
+	if (data.contains("Window")) {
+		auto windowResult = toml::expect<toml::value>(data.at("Window"));
+		if (windowResult.is_ok()) {
+			auto window = windowResult.unwrap();
+
+			windowSettings.showAppVersion = toml::find_or<toml::boolean>(window, "AppVersionOnWindow", false);
+			windowSettings.rememberPosition = toml::find_or<toml::boolean>(window, "RememberWindowPosition", false);
+
+			windowSettings.x = toml::find_or<toml::integer>(window, "WindowPosX", WindowSettings::defaultX);
+			windowSettings.y = toml::find_or<toml::integer>(window, "WindowPosY", WindowSettings::defaultY);
+			windowSettings.width = toml::find_or<toml::integer>(window, "WindowWidth", WindowSettings::defaultWidth);
+			windowSettings.height = toml::find_or<toml::integer>(window, "WindowHeight", WindowSettings::defaultHeight);
 		}
 	}
 
@@ -133,7 +147,13 @@ void EmulatorConfig::save() {
 	data["General"]["UsePortableBuild"] = usePortableBuild;
 	data["General"]["DefaultRomPath"] = defaultRomPath.string();
 	data["General"]["PrintAppVersion"] = printAppVersion;
-	data["General"]["AppVersionOnWindow"] = appVersionOnWindow;
+
+	data["Window"]["AppVersionOnWindow"] = windowSettings.showAppVersion;
+	data["Window"]["RememberWindowPosition"] = windowSettings.rememberPosition;
+	data["Window"]["WindowPosX"] = windowSettings.x;
+	data["Window"]["WindowPosY"] = windowSettings.y;
+	data["Window"]["WindowWidth"] = windowSettings.width;
+	data["Window"]["WindowHeight"] = windowSettings.height;
 	
 	data["GPU"]["EnableShaderJIT"] = shaderJitEnabled;
 	data["GPU"]["Renderer"] = std::string(Renderer::typeToString(rendererType));

--- a/src/panda_qt/main_window.cpp
+++ b/src/panda_qt/main_window.cpp
@@ -99,12 +99,22 @@ MainWindow::MainWindow(QApplication* app, QWidget* parent) : QMainWindow(parent)
 		}
 	}
 
-	if (emu->getConfig().appVersionOnWindow) {
-		setWindowTitle("Alber v" PANDA3DS_VERSION);
-	}
+	// Handle UI configs before setting up the emulator thread
+	{
+		auto& config = emu->getConfig();
+		auto& windowSettings = config.windowSettings;
 
-	if (emu->getConfig().printAppVersion) {
-		printf("Welcome to Panda3DS v%s!\n", PANDA3DS_VERSION);
+		if (windowSettings.showAppVersion) {
+			setWindowTitle("Alber v" PANDA3DS_VERSION);
+		}
+
+		if (windowSettings.rememberPosition) {
+			setGeometry(windowSettings.x, windowSettings.y, windowSettings.width, config.windowSettings.height);
+		}
+
+		if (config.printAppVersion) {
+			printf("Welcome to Panda3DS v%s!\n", PANDA3DS_VERSION);
+		}
 	}
 
 	// The emulator graphics context for the thread should be initialized in the emulator thread due to how GL contexts work
@@ -221,6 +231,15 @@ void MainWindow::closeEvent(QCloseEvent *event) {
 	if (emuThread.joinable()) {
 		emuThread.join();
 	}
+
+	// Cache window position/size in config file to restore next time
+	const QRect& windowGeometry = geometry();
+	auto& windowConfig = emu->getConfig().windowSettings;
+
+	windowConfig.x = windowGeometry.x();
+	windowConfig.y = windowGeometry.y();
+	windowConfig.width = windowGeometry.width();
+	windowConfig.height = windowGeometry.height();
 }
 
 // Cleanup when the main window closes

--- a/src/panda_sdl/frontend_sdl.cpp
+++ b/src/panda_sdl/frontend_sdl.cpp
@@ -35,7 +35,7 @@ FrontendSDL::FrontendSDL() : keyboardMappings(InputMappings::defaultKeyboardMapp
 	needOpenGL = needOpenGL || (config.rendererType == RendererType::OpenGL);
 #endif
 
-	const char* windowTitle = config.appVersionOnWindow ? ("Alber v" PANDA3DS_VERSION) : "Alber";
+	const char* windowTitle = config.windowSettings.showAppVersion ? ("Alber v" PANDA3DS_VERSION) : "Alber";
 	if (config.printAppVersion) {
 		printf("Welcome to Panda3DS v%s!\n", PANDA3DS_VERSION);
 	}


### PR DESCRIPTION
Optionally remembers window position and size between runs so people don't have to readjust it on every run.
Currently disabled by default to avoid the same funny oddities that sometimes happen with this setting in Redux, can be enabled from the config file though (Or the config UI in the near future)