### PR TITLE
Audio: Properly close audio device on emulator destruction

### DIFF
--- a/include/audio/miniaudio_device.hpp
+++ b/include/audio/miniaudio_device.hpp
@@ -21,10 +21,12 @@ class MiniAudioDevice {
 	bool running = false;
 
 	std::vector<std::string> audioDevices;
+
   public:
 	MiniAudioDevice();
 	// If safe is on, we create a null audio device
 	void init(Samples& samples, bool safe = false);
+	void close();
 
 	void start();
 	void stop();

--- a/src/core/audio/miniaudio_device.cpp
+++ b/src/core/audio/miniaudio_device.cpp
@@ -27,8 +27,8 @@ void MiniAudioDevice::init(Samples& samples, bool safe) {
 
 			// TODO: Make backend selectable here
 			found = true;
-			//count = 1;
-			//backends[0] = backend;
+			// count = 1;
+			// backends[0] = backend;
 		}
 
 		if (!found) {
@@ -81,8 +81,8 @@ void MiniAudioDevice::init(Samples& samples, bool safe) {
 	deviceConfig.playback.format = ma_format_s16;
 	deviceConfig.playback.channels = channelCount;
 	deviceConfig.sampleRate = sampleRate;
-	//deviceConfig.periodSizeInFrames = 64;
-	//deviceConfig.periods = 16;
+	// deviceConfig.periodSizeInFrames = 64;
+	// deviceConfig.periods = 16;
 	deviceConfig.pUserData = this;
 	deviceConfig.aaudio.usage = ma_aaudio_usage_game;
 	deviceConfig.wasapi.noAutoConvertSRC = true;
@@ -130,7 +130,7 @@ void MiniAudioDevice::start() {
 
 void MiniAudioDevice::stop() {
 	if (!initialized) {
-		Helpers::warn("MiniAudio device not initialized, can't start");
+		Helpers::warn("MiniAudio device not initialized, can't stop");
 		return;
 	}
 
@@ -139,6 +139,17 @@ void MiniAudioDevice::stop() {
 
 		if (ma_device_stop(&device) != MA_SUCCESS) {
 			Helpers::warn("Failed to stop audio device");
-		} 
+		}
+	}
+}
+
+void MiniAudioDevice::close() {
+	stop();
+
+	if (initialized) {
+		initialized = false;
+
+		ma_device_uninit(&device);
+		ma_context_uninit(&context);
 	}
 }

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -250,7 +250,7 @@ bool Emulator::loadROM(const std::filesystem::path& path) {
 		success = loadELF(path);
 	else if (extension == ".3ds" || extension == ".cci")
 		success = loadNCSD(path, ROMType::NCSD);
-	else if (extension == ".cxi" || extension == ".app")
+	else if (extension == ".cxi" || extension == ".app" || extension == ".ncch")
 		success = loadNCSD(path, ROMType::CXI);
 	else if (extension == ".3dsx")
 		success = load3DSX(path);

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -50,6 +50,7 @@ Emulator::Emulator()
 Emulator::~Emulator() {
 	config.save();
 	lua.close();
+	audioDevice.close();
 
 #ifdef PANDA3DS_ENABLE_DISCORD_RPC
 	discordRpc.stop();
@@ -249,7 +250,7 @@ bool Emulator::loadROM(const std::filesystem::path& path) {
 		success = loadELF(path);
 	else if (extension == ".3ds" || extension == ".cci")
 		success = loadNCSD(path, ROMType::NCSD);
-	else if (extension == ".cxi" || extension == ".app" || extension == ".ncch")
+	else if (extension == ".cxi" || extension == ".app")
 		success = loadNCSD(path, ROMType::CXI);
 	else if (extension == ".3dsx")
 		success = load3DSX(path);


### PR DESCRIPTION
Fixes audio bugs & crashes on Android in HLE-audio-enabled builds.