### PR TITLE
Audio: Add more settings

### DIFF
--- a/include/audio/aac_decoder.hpp
+++ b/include/audio/aac_decoder.hpp
@@ -18,7 +18,8 @@ namespace Audio::AAC {
 
 	  public:
 		// Decode function. Takes in a reference to the AAC response & request, and a callback for paddr -> pointer conversions
-		void decode(AAC::Message& response, const AAC::Message& request, PaddrCallback paddrCallback);
+		// We also allow for optionally muting the AAC output (setting all of it to 0) instead of properly decoding it, for debug/research purposes
+		void decode(AAC::Message& response, const AAC::Message& request, PaddrCallback paddrCallback, bool enableAudio = false);
 		~Decoder();
 	};
 }  // namespace Audio::AAC

--- a/include/audio/dsp_core.hpp
+++ b/include/audio/dsp_core.hpp
@@ -14,6 +14,7 @@
 // The DSP core must have access to the DSP service to be able to trigger interrupts properly
 class DSPService;
 class Memory;
+struct EmulatorConfig;
 
 namespace Audio {
 	// There are 160 stereo samples in 1 audio frame, so 320 samples total
@@ -31,6 +32,7 @@ namespace Audio {
 		Memory& mem;
 		Scheduler& scheduler;
 		DSPService& dspService;
+		EmulatorConfig& settings;
 
 		Samples sampleBuffer;
 		bool audioEnabled = false;
@@ -39,7 +41,8 @@ namespace Audio {
 
 	  public:
 		enum class Type { Null, Teakra, HLE };
-		DSPCore(Memory& mem, Scheduler& scheduler, DSPService& dspService) : mem(mem), scheduler(scheduler), dspService(dspService) {}
+		DSPCore(Memory& mem, Scheduler& scheduler, DSPService& dspService, EmulatorConfig& settings)
+			: mem(mem), scheduler(scheduler), dspService(dspService), settings(settings) {}
 		virtual ~DSPCore() {}
 
 		virtual void reset() = 0;
@@ -62,5 +65,5 @@ namespace Audio {
 		virtual void setAudioEnabled(bool enable) { audioEnabled = enable; }
 	};
 
-	std::unique_ptr<DSPCore> makeDSPCore(DSPCore::Type type, Memory& mem, Scheduler& scheduler, DSPService& dspService);
+	std::unique_ptr<DSPCore> makeDSPCore(EmulatorConfig& config, Memory& mem, Scheduler& scheduler, DSPService& dspService);
 }  // namespace Audio

--- a/include/audio/hle_core.hpp
+++ b/include/audio/hle_core.hpp
@@ -206,7 +206,7 @@ namespace Audio {
 		SampleBuffer decodeADPCM(const u8* data, usize sampleCount, Source& source);
 
 	  public:
-		HLE_DSP(Memory& mem, Scheduler& scheduler, DSPService& dspService);
+		HLE_DSP(Memory& mem, Scheduler& scheduler, DSPService& dspService, EmulatorConfig& config);
 		~HLE_DSP() override {}
 
 		void reset() override;

--- a/include/audio/miniaudio_device.hpp
+++ b/include/audio/miniaudio_device.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 
+#include "config.hpp"
 #include "helpers.hpp"
 #include "miniaudio.h"
 #include "ring_buffer.hpp"
@@ -12,11 +13,13 @@ class MiniAudioDevice {
 	static constexpr ma_uint32 sampleRate = 32768;  // 3DS sample rate
 	static constexpr ma_uint32 channelCount = 2;    // Audio output is stereo
 
+	ma_device device;
 	ma_context context;
 	ma_device_config deviceConfig;
-	ma_device device;
 	ma_resampler resampler;
 	Samples* samples = nullptr;
+
+	AudioDeviceConfig& audioSettings;
 
 	bool initialized = false;
 	bool running = false;
@@ -26,7 +29,8 @@ class MiniAudioDevice {
 	std::vector<std::string> audioDevices;
 
   public:
-	MiniAudioDevice();
+	MiniAudioDevice(AudioDeviceConfig& audioSettings);
+
 	// If safe is on, we create a null audio device
 	void init(Samples& samples, bool safe = false);
 	void close();

--- a/include/audio/null_core.hpp
+++ b/include/audio/null_core.hpp
@@ -23,7 +23,7 @@ namespace Audio {
 		bool loaded = false;  // Have we loaded a component?
 
 	  public:
-		NullDSP(Memory& mem, Scheduler& scheduler, DSPService& dspService) : DSPCore(mem, scheduler, dspService) {}
+		NullDSP(Memory& mem, Scheduler& scheduler, DSPService& dspService, EmulatorConfig& config) : DSPCore(mem, scheduler, dspService, config) {}
 		~NullDSP() override {}
 
 		void reset() override;

--- a/include/audio/teakra_core.hpp
+++ b/include/audio/teakra_core.hpp
@@ -77,7 +77,7 @@ namespace Audio {
 		}
 
 	  public:
-		TeakraDSP(Memory& mem, Scheduler& scheduler, DSPService& dspService);
+		TeakraDSP(Memory& mem, Scheduler& scheduler, DSPService& dspService, EmulatorConfig& config);
 		~TeakraDSP() override {}
 
 		void reset() override;

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -41,6 +41,7 @@ struct EmulatorConfig {
 
 	bool audioEnabled = false;
 	bool vsyncEnabled = true;
+	bool aacEnabled = true;  // Enable AAC audio?
 
 	bool enableRenderdoc = false;
 	bool printAppVersion = true;

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -4,6 +4,19 @@
 #include "audio/dsp_core.hpp"
 #include "renderer.hpp"
 
+struct AudioDeviceConfig {
+	float volumeRaw = 1.0f;
+	bool muteAudio = false;
+
+	float getVolume() const {
+		if (muteAudio) {
+			return 0.0f;
+		}
+
+		return volumeRaw;
+	}
+};
+
 // Remember to initialize every field here to its default value otherwise bad things will happen
 struct EmulatorConfig {
 	// Only enable the shader JIT by default on platforms where it's completely tested
@@ -71,6 +84,7 @@ struct EmulatorConfig {
 	};
 
 	WindowSettings windowSettings;
+	AudioDeviceConfig audioDeviceConfig;
 
 	EmulatorConfig(const std::filesystem::path& path);
 	void load();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -99,6 +99,11 @@ void EmulatorConfig::load() {
 			
 			audioEnabled = toml::find_or<toml::boolean>(audio, "EnableAudio", false);
 			aacEnabled = toml::find_or<toml::boolean>(audio, "EnableAACAudio", true);
+
+			audioDeviceConfig.muteAudio = toml::find_or<toml::boolean>(audio, "MuteAudio", false);
+			// Our volume ranges from 0.0 (muted) to 2.0 (boosted, using a logarithmic scale). 1.0 is the "default" volume, ie we don't adjust the PCM
+			// samples at all.
+			audioDeviceConfig.volumeRaw = float(std::clamp(toml::find_or<toml::floating>(audio, "AudioVolume", 1.0), 0.0, 2.0));
 		}
 	}
 
@@ -170,6 +175,8 @@ void EmulatorConfig::save() {
 	data["Audio"]["DSPEmulation"] = std::string(Audio::DSPCore::typeToString(dspType));
 	data["Audio"]["EnableAudio"] = audioEnabled;
 	data["Audio"]["EnableAACAudio"] = aacEnabled;
+	data["Audio"]["MuteAudio"] = audioDeviceConfig.muteAudio;
+	data["Audio"]["AudioVolume"] = double(audioDeviceConfig.volumeRaw);
 
 	data["Battery"]["ChargerPlugged"] = chargerPlugged;
 	data["Battery"]["BatteryPercentage"] = batteryPercentage;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -96,7 +96,9 @@ void EmulatorConfig::load() {
 
 			auto dspCoreName = toml::find_or<std::string>(audio, "DSPEmulation", "HLE");
 			dspType = Audio::DSPCore::typeFromString(dspCoreName);
+			
 			audioEnabled = toml::find_or<toml::boolean>(audio, "EnableAudio", false);
+			aacEnabled = toml::find_or<toml::boolean>(audio, "EnableAACAudio", true);
 		}
 	}
 
@@ -167,6 +169,7 @@ void EmulatorConfig::save() {
 
 	data["Audio"]["DSPEmulation"] = std::string(Audio::DSPCore::typeToString(dspType));
 	data["Audio"]["EnableAudio"] = audioEnabled;
+	data["Audio"]["EnableAACAudio"] = aacEnabled;
 
 	data["Battery"]["ChargerPlugged"] = chargerPlugged;
 	data["Battery"]["BatteryPercentage"] = batteryPercentage;

--- a/src/core/audio/aac_decoder.cpp
+++ b/src/core/audio/aac_decoder.cpp
@@ -5,7 +5,7 @@
 #include <vector>
 using namespace Audio;
 
-void AAC::Decoder::decode(AAC::Message& response, const AAC::Message& request, AAC::Decoder::PaddrCallback paddrCallback) {
+void AAC::Decoder::decode(AAC::Message& response, const AAC::Message& request, AAC::Decoder::PaddrCallback paddrCallback, bool enableAudio) {
 	// Copy the command and mode fields of the request to the response
 	response.command = request.command;
 	response.mode = request.mode;
@@ -95,9 +95,18 @@ void AAC::Decoder::decode(AAC::Message& response, const AAC::Message& request, A
 				}
 			}
 
-			for (int sample = 0; sample < info->frameSize; sample++) {
-				for (int stream = 0; stream < channels; stream++) {
-					audioStreams[stream].push_back(frame[(sample * channels) + stream]);
+			if (enableAudio) {
+				for (int sample = 0; sample < info->frameSize; sample++) {
+					for (int stream = 0; stream < channels; stream++) {
+						audioStreams[stream].push_back(frame[(sample * channels) + stream]);
+					}
+				}
+			} else {
+				// If audio is not enabled, push 0s
+				for (int sample = 0; sample < info->frameSize; sample++) {
+					for (int stream = 0; stream < channels; stream++) {
+						audioStreams[stream].push_back(0);
+					}
 				}
 			}
 		} else {

--- a/src/core/audio/aac_decoder.cpp
+++ b/src/core/audio/aac_decoder.cpp
@@ -103,10 +103,8 @@ void AAC::Decoder::decode(AAC::Message& response, const AAC::Message& request, A
 				}
 			} else {
 				// If audio is not enabled, push 0s
-				for (int sample = 0; sample < info->frameSize; sample++) {
-					for (int stream = 0; stream < channels; stream++) {
-						audioStreams[stream].push_back(0);
-					}
+				for (int stream = 0; stream < channels; stream++) {
+					audioStreams[stream].resize(audioStreams[stream].size() + info->frameSize, 0);
 				}
 			}
 		} else {

--- a/src/core/audio/dsp_core.cpp
+++ b/src/core/audio/dsp_core.cpp
@@ -8,17 +8,17 @@
 #include "audio/null_core.hpp"
 #include "audio/teakra_core.hpp"
 
-std::unique_ptr<Audio::DSPCore> Audio::makeDSPCore(DSPCore::Type type, Memory& mem, Scheduler& scheduler, DSPService& dspService) {
+std::unique_ptr<Audio::DSPCore> Audio::makeDSPCore(EmulatorConfig& config, Memory& mem, Scheduler& scheduler, DSPService& dspService) {
 	std::unique_ptr<DSPCore> core;
 
-	switch (type) {
-		case DSPCore::Type::Null: core = std::make_unique<NullDSP>(mem, scheduler, dspService); break;
-		case DSPCore::Type::Teakra: core = std::make_unique<TeakraDSP>(mem, scheduler, dspService); break;
-		case DSPCore::Type::HLE: core = std::make_unique<HLE_DSP>(mem, scheduler, dspService); break;
+	switch (config.dspType) {
+		case DSPCore::Type::Null: core = std::make_unique<NullDSP>(mem, scheduler, dspService, config); break;
+		case DSPCore::Type::Teakra: core = std::make_unique<TeakraDSP>(mem, scheduler, dspService, config); break;
+		case DSPCore::Type::HLE: core = std::make_unique<HLE_DSP>(mem, scheduler, dspService, config); break;
 
 		default:
 			Helpers::warn("Invalid DSP core selected!");
-			core = std::make_unique<NullDSP>(mem, scheduler, dspService);
+			core = std::make_unique<NullDSP>(mem, scheduler, dspService, config);
 			break;
 	}
 

--- a/src/core/audio/hle_core.cpp
+++ b/src/core/audio/hle_core.cpp
@@ -8,6 +8,7 @@
 
 #include "audio/aac_decoder.hpp"
 #include "audio/dsp_simd.hpp"
+#include "config.hpp"
 #include "services/dsp.hpp"
 
 namespace Audio {
@@ -20,7 +21,8 @@ namespace Audio {
 		};
 	}
 
-	HLE_DSP::HLE_DSP(Memory& mem, Scheduler& scheduler, DSPService& dspService) : DSPCore(mem, scheduler, dspService) {
+	HLE_DSP::HLE_DSP(Memory& mem, Scheduler& scheduler, DSPService& dspService, EmulatorConfig& config)
+		: DSPCore(mem, scheduler, dspService, config) {
 		// Set up source indices
 		for (int i = 0; i < sources.size(); i++) {
 			sources[i].index = i;
@@ -713,9 +715,8 @@ namespace Audio {
 				response.command = request.command;
 				response.mode = request.mode;
 
-				// TODO: Make this a toggle in config.toml. Currently we have it on by default.
-				constexpr bool enableAAC = true;
-				if (enableAAC) {
+				// We allow disabling AAC audio. Mostly useful for debugging & figuring out if an audio track is AAC or not.
+				if (settings.aacEnabled) {
 					aacDecoder->decode(response, request, [this](u32 paddr) { return getPointerPhys<u8>(paddr); });
 				}
 				break;

--- a/src/core/audio/hle_core.cpp
+++ b/src/core/audio/hle_core.cpp
@@ -704,20 +704,9 @@ namespace Audio {
 		AAC::Message response;
 
 		switch (request.command) {
-			case AAC::Command::EncodeDecode: {
-				// Dummy response to stop games from hanging
-				response.resultCode = AAC::ResultCode::Success;
-				response.decodeResponse.channelCount = 2;
-				response.decodeResponse.sampleCount = 1024;
-				response.decodeResponse.size = 0;
-				response.decodeResponse.sampleRate = AAC::SampleRate::Rate48000;
-
-				response.command = request.command;
-				response.mode = request.mode;
-
+			case AAC::Command::EncodeDecode:
 				aacDecoder->decode(response, request, [this](u32 paddr) { return getPointerPhys<u8>(paddr); }, settings.aacEnabled);
 				break;
-			}
 
 			case AAC::Command::Init:
 			case AAC::Command::Shutdown:

--- a/src/core/audio/hle_core.cpp
+++ b/src/core/audio/hle_core.cpp
@@ -715,10 +715,7 @@ namespace Audio {
 				response.command = request.command;
 				response.mode = request.mode;
 
-				// We allow disabling AAC audio. Mostly useful for debugging & figuring out if an audio track is AAC or not.
-				if (settings.aacEnabled) {
-					aacDecoder->decode(response, request, [this](u32 paddr) { return getPointerPhys<u8>(paddr); });
-				}
+				aacDecoder->decode(response, request, [this](u32 paddr) { return getPointerPhys<u8>(paddr); }, settings.aacEnabled);
 				break;
 			}
 

--- a/src/core/audio/teakra_core.cpp
+++ b/src/core/audio/teakra_core.cpp
@@ -36,8 +36,8 @@ struct Dsp1 {
 	Segment segments[10];
 };
 
-TeakraDSP::TeakraDSP(Memory& mem, Scheduler& scheduler, DSPService& dspService)
-	: DSPCore(mem, scheduler, dspService), pipeBaseAddr(0), running(false) {
+TeakraDSP::TeakraDSP(Memory& mem, Scheduler& scheduler, DSPService& dspService, EmulatorConfig& config)
+	: DSPCore(mem, scheduler, dspService, config), pipeBaseAddr(0), running(false) {
 	// Set up callbacks for Teakra
 	Teakra::AHBMCallback ahbm;
 

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -20,7 +20,7 @@ __declspec(dllexport) DWORD AmdPowerXpressRequestHighPerformance = 1;
 
 Emulator::Emulator()
 	: config(getConfigPath()), kernel(cpu, memory, gpu, config), cpu(memory, kernel, *this), gpu(memory, config), memory(cpu.getTicksRef(), config),
-	  cheats(memory, kernel.getServiceManager().getHID()), lua(*this), running(false)
+	  cheats(memory, kernel.getServiceManager().getHID()), audioDevice(config.audioDeviceConfig), lua(*this), running(false)
 #ifdef PANDA3DS_ENABLE_HTTP_SERVER
 	  ,
 	  httpServer(this)

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -28,7 +28,7 @@ Emulator::Emulator()
 {
 	DSPService& dspService = kernel.getServiceManager().getDSP();
 
-	dsp = Audio::makeDSPCore(config.dspType, memory, scheduler, dspService);
+	dsp = Audio::makeDSPCore(config, memory, scheduler, dspService);
 	dspService.setDSPCore(dsp.get());
 
 	audioDevice.init(dsp->getSamples());

--- a/src/libretro_core.cpp
+++ b/src/libretro_core.cpp
@@ -172,13 +172,16 @@ static void configInit() {
 		{"panda3ds_use_vsync", "Enable VSync; enabled|disabled"},
 		{"panda3ds_dsp_emulation", "DSP emulation; HLE|LLE|Null"},
 		{"panda3ds_use_audio", "Enable audio; disabled|enabled"},
+		{"panda3ds_audio_volume", "Audio volume; 100|0|10|20|40|60|80|90|100|120|140|150|180|200"},
+		{"panda3ds_mute_audio", "Mute audio; disabled|enabled"},
+
 		{"panda3ds_enable_aac", "Enable AAC audio; enabled|disabled"},
+		{"panda3ds_ubershader_lighting_override", "Force shadergen when rendering lights; enabled|disabled"},
+		{"panda3ds_ubershader_lighting_override_threshold", "Light threshold for forcing shadergen; 1|2|3|4|5|6|7|8"},
 		{"panda3ds_use_virtual_sd", "Enable virtual SD card; enabled|disabled"},
 		{"panda3ds_write_protect_virtual_sd", "Write protect virtual SD card; disabled|enabled"},
 		{"panda3ds_battery_level", "Battery percentage; 5|10|20|30|50|70|90|100"},
 		{"panda3ds_use_charger", "Charger plugged; enabled|disabled"},
-		{"panda3ds_ubershader_lighting_override", "Force shadergen when rendering lights; enabled|disabled"},
-		{"panda3ds_ubershader_lighting_override_threshold", "Light threshold for forcing shadergen; 1|2|3|4|5|6|7|8"},
 		{nullptr, nullptr},
 	};
 
@@ -196,6 +199,8 @@ static void configUpdate() {
 	config.dspType = Audio::DSPCore::typeFromString(fetchVariable("panda3ds_dsp_emulation", "null"));
 	config.audioEnabled = fetchVariableBool("panda3ds_use_audio", false);
 	config.aacEnabled = fetchVariableBool("panda3ds_enable_aac", true);
+	config.audioDeviceConfig.muteAudio = fetchVariableBool("panda3ds_mute_audio", false);
+	config.audioDeviceConfig.volumeRaw = float(fetchVariableRange("panda3ds_audio_volume", 0, 200)) / 100.0f;
 
 	config.sdCardInserted = fetchVariableBool("panda3ds_use_virtual_sd", true);
 	config.sdWriteProtected = fetchVariableBool("panda3ds_write_protect_virtual_sd", false);

--- a/src/libretro_core.cpp
+++ b/src/libretro_core.cpp
@@ -172,6 +172,7 @@ static void configInit() {
 		{"panda3ds_use_vsync", "Enable VSync; enabled|disabled"},
 		{"panda3ds_dsp_emulation", "DSP emulation; HLE|LLE|Null"},
 		{"panda3ds_use_audio", "Enable audio; disabled|enabled"},
+		{"panda3ds_enable_aac", "Enable AAC audio; enabled|disabled"},
 		{"panda3ds_use_virtual_sd", "Enable virtual SD card; enabled|disabled"},
 		{"panda3ds_write_protect_virtual_sd", "Write protect virtual SD card; disabled|enabled"},
 		{"panda3ds_battery_level", "Battery percentage; 5|10|20|30|50|70|90|100"},
@@ -194,6 +195,8 @@ static void configUpdate() {
 	config.batteryPercentage = fetchVariableRange("panda3ds_battery_level", 5, 100);
 	config.dspType = Audio::DSPCore::typeFromString(fetchVariable("panda3ds_dsp_emulation", "null"));
 	config.audioEnabled = fetchVariableBool("panda3ds_use_audio", false);
+	config.aacEnabled = fetchVariableBool("panda3ds_enable_aac", true);
+
 	config.sdCardInserted = fetchVariableBool("panda3ds_use_virtual_sd", true);
 	config.sdWriteProtected = fetchVariableBool("panda3ds_write_protect_virtual_sd", false);
 	config.accurateShaderMul = fetchVariableBool("panda3ds_accurate_shader_mul", false);


### PR DESCRIPTION
Adds some audio-related settings to both the regular frontends and the libretro core

- A volume slider that lets the user control the emulator volume, as well as letting them amplify audio (Using a logarithmic volume scale and a hard clipper). This allows users to control the audio volume from within the app (Which is particularly important on MacOS due to Mac not having an OS volume mixer) as well as letting them boost the game audio above normal volume.
- A mute audio setting
- A setting to control whether AAC audio is enabled, for debugging & researching which games use AAC and for which tracks.