### PR TITLE
Qt UI: fix menu bar on MacOS

### DIFF
--- a/src/panda_qt/main_window.cpp
+++ b/src/panda_qt/main_window.cpp
@@ -31,8 +31,7 @@ MainWindow::MainWindow(QApplication* app, QWidget* parent) : QMainWindow(parent)
 	appRunning = true;
 
 	// Set our menu bar up
-	menuBar = new QMenuBar(this);
-	setMenuBar(menuBar);
+	menuBar = new QMenuBar(nullptr);
 
 	// Create menu bar menus
 	auto fileMenu = menuBar->addMenu(tr("File"));
@@ -77,6 +76,7 @@ MainWindow::MainWindow(QApplication* app, QWidget* parent) : QMainWindow(parent)
 
 	auto aboutAction = aboutMenu->addAction(tr("About Panda3DS"));
 	connect(aboutAction, &QAction::triggered, this, &MainWindow::showAboutMenu);
+	setMenuBar(menuBar);
 
 	emu->setOutputSize(screen->surfaceWidth, screen->surfaceHeight);
 


### PR DESCRIPTION
MacOS requires a 'global' menubar to be available (e.g. QtMenuBar(nullptr)).

Please test if this doesn't break anything on Windows/Linux..

![image](https://github.com/user-attachments/assets/613daedb-a844-4f2f-bb76-bb2821181c0c)
