### PR TITLE
Make filesystem decent, part 1

### DIFF
--- a/src/core/fs/archive_card_spi.cpp
+++ b/src/core/fs/archive_card_spi.cpp
@@ -26,7 +26,7 @@ FileDescriptor CardSPIArchive::openFile(const FSPath& path, const FilePerms& per
 }
 
 Rust::Result<ArchiveBase*, HorizonResult> CardSPIArchive::openArchive(const FSPath& path) {
-	if (path.type != PathType::Empty) {
+	if (!path.isEmptyType()) {
 		Helpers::panic("Unimplemented path type for CardSPIArchive::OpenArchive");
 	}
 

--- a/src/core/fs/archive_ncch.cpp
+++ b/src/core/fs/archive_ncch.cpp
@@ -32,7 +32,7 @@ HorizonResult NCCHArchive::deleteFile(const FSPath& path) {
 }
 
 FileDescriptor NCCHArchive::openFile(const FSPath& path, const FilePerms& perms) {
-	if (path.type != PathType::Binary || path.binary.size() != 20) {
+	if (!path.isBinary() || path.binary.size() != 20) {
 		Helpers::panic("NCCHArchive::OpenFile: Invalid path");
 	}
 
@@ -49,7 +49,7 @@ FileDescriptor NCCHArchive::openFile(const FSPath& path, const FilePerms& perms)
 }
 
 Rust::Result<ArchiveBase*, HorizonResult> NCCHArchive::openArchive(const FSPath& path) {
-	if (path.type != PathType::Binary || path.binary.size() != 16) {
+	if (!path.isBinary() || path.binary.size() != 16) {
 		Helpers::panic("NCCHArchive::OpenArchive: Invalid path");
 	}
 

--- a/src/core/fs/archive_save_data.cpp
+++ b/src/core/fs/archive_save_data.cpp
@@ -5,7 +5,7 @@
 namespace fs = std::filesystem;
 
 HorizonResult SaveDataArchive::createFile(const FSPath& path, u64 size) {
-	if (path.type == PathType::UTF16) {
+	if (path.isUTF16()) {
 		if (!isPathSafe<PathType::UTF16>(path))
 			Helpers::panic("Unsafe path in SaveData::CreateFile");
 
@@ -39,7 +39,7 @@ HorizonResult SaveDataArchive::createFile(const FSPath& path, u64 size) {
 }
 
 HorizonResult SaveDataArchive::createDirectory(const FSPath& path) {
-	if (path.type == PathType::UTF16) {
+	if (path.isUTF16()) {
 		if (!isPathSafe<PathType::UTF16>(path)) {
 			Helpers::panic("Unsafe path in SaveData::OpenFile");
 		}
@@ -63,7 +63,7 @@ HorizonResult SaveDataArchive::createDirectory(const FSPath& path) {
 }
 
 HorizonResult SaveDataArchive::deleteFile(const FSPath& path) {
-	if (path.type == PathType::UTF16) {
+	if (path.isUTF16()) {
 		if (!isPathSafe<PathType::UTF16>(path)) {
 			Helpers::panic("Unsafe path in SaveData::DeleteFile");
 		}
@@ -96,7 +96,7 @@ HorizonResult SaveDataArchive::deleteFile(const FSPath& path) {
 }
 
 FileDescriptor SaveDataArchive::openFile(const FSPath& path, const FilePerms& perms) {
-	if (path.type == PathType::UTF16) {
+	if (path.isUTF16()) {
 		if (!isPathSafe<PathType::UTF16>(path)) {
 			Helpers::panic("Unsafe path in SaveData::OpenFile");
 		}
@@ -132,7 +132,7 @@ FileDescriptor SaveDataArchive::openFile(const FSPath& path, const FilePerms& pe
 }
 
 Rust::Result<DirectorySession, HorizonResult> SaveDataArchive::openDirectory(const FSPath& path) {
-	if (path.type == PathType::UTF16) {
+	if (path.isUTF16()) {
 		if (!isPathSafe<PathType::UTF16>(path)) {
 			Helpers::panic("Unsafe path in SaveData::OpenDirectory");
 		}
@@ -193,7 +193,7 @@ void SaveDataArchive::format(const FSPath& path, const ArchiveBase::FormatInfo& 
 }
 
 Rust::Result<ArchiveBase*, HorizonResult> SaveDataArchive::openArchive(const FSPath& path) {
-	if (path.type != PathType::Empty) {
+	if (!path.isEmptyType()) {
 		Helpers::panic("Unimplemented path type for SaveData archive: %d\n", path.type);
 		return Err(Result::FS::NotFoundInvalid);
 	}

--- a/src/core/fs/archive_sdmc.cpp
+++ b/src/core/fs/archive_sdmc.cpp
@@ -4,13 +4,13 @@
 namespace fs = std::filesystem;
 
 HorizonResult SDMCArchive::createFile(const FSPath& path, u64 size) {
-	if (path.type == PathType::UTF16) {
-		if (!isPathSafe<PathType::UTF16>(path)) {
+	if (path.isTextPath()) {
+		if (!isSafeTextPath(path)) {
 			Helpers::panic("Unsafe path in SDMC::CreateFile");
 		}
 
 		fs::path p = IOFile::getAppData() / "SDMC";
-		p += fs::path(path.utf16_string).make_preferred();
+		appendPath(p, path);
 
 		if (fs::exists(p)) {
 			return Result::FS::AlreadyExists;
@@ -39,13 +39,13 @@ HorizonResult SDMCArchive::createFile(const FSPath& path, u64 size) {
 }
 
 HorizonResult SDMCArchive::deleteFile(const FSPath& path) {
-	if (path.type == PathType::UTF16) {
-		if (!isPathSafe<PathType::UTF16>(path)) {
+	if (path.isTextPath()) {
+		if (!isSafeTextPath(path)) {
 			Helpers::panic("Unsafe path in SDMC::DeleteFile");
 		}
 
 		fs::path p = IOFile::getAppData() / "SDMC";
-		p += fs::path(path.utf16_string).make_preferred();
+		appendPath(p, path);
 
 		if (fs::is_directory(p)) {
 			Helpers::panic("SDMC::DeleteFile: Tried to delete directory");
@@ -171,13 +171,13 @@ Rust::Result<DirectorySession, HorizonResult> SDMCArchive::openDirectory(const F
 		return Err(Result::FS::UnexpectedFileOrDir);
 	}
 
-	if (path.type == PathType::UTF16) {
-		if (!isPathSafe<PathType::UTF16>(path)) {
+	if (path.isTextPath()) {
+		if (!isSafeTextPath(path)) {
 			Helpers::panic("Unsafe path in SDMC::OpenDirectory");
 		}
 
 		fs::path p = IOFile::getAppData() / "SDMC";
-		p += fs::path(path.utf16_string).make_preferred();
+		appendPath(p, path);
 
 		if (fs::is_regular_file(p)) {
 			printf("SDMC: OpenDirectory used with a file path");
@@ -197,7 +197,7 @@ Rust::Result<DirectorySession, HorizonResult> SDMCArchive::openDirectory(const F
 
 Rust::Result<ArchiveBase*, HorizonResult> SDMCArchive::openArchive(const FSPath& path) {
 	// TODO: Fail here if the SD is disabled in the connfig.
-	if (path.type != PathType::Empty) {
+	if (!path.isEmptyType()) {
 		Helpers::panic("Unimplemented path type for SDMC::OpenArchive");
 	}
 

--- a/src/core/fs/archive_self_ncch.cpp
+++ b/src/core/fs/archive_self_ncch.cpp
@@ -26,7 +26,7 @@ FileDescriptor SelfNCCHArchive::openFile(const FSPath& path, const FilePerms& pe
 		return FileError;
 	}
 
-	if (path.type != PathType::Binary || path.binary.size() != 12) {
+	if (!path.isBinary() || path.binary.size() != 12) {
 		printf("Invalid SelfNCCH path type\n");
 		return FileError;
 	}
@@ -42,7 +42,7 @@ FileDescriptor SelfNCCHArchive::openFile(const FSPath& path, const FilePerms& pe
 }
 
 Rust::Result<ArchiveBase*, HorizonResult> SelfNCCHArchive::openArchive(const FSPath& path) {
-	if (path.type != PathType::Empty) {
+	if (!path.isEmptyType()) {
 		Helpers::panic("Invalid path type for SelfNCCH archive: %d\n", path.type);
 		return Err(Result::FS::NotFoundInvalid);
 	}

--- a/src/core/fs/archive_system_save_data.cpp
+++ b/src/core/fs/archive_system_save_data.cpp
@@ -4,7 +4,7 @@
 namespace fs = std::filesystem;
 
 Rust::Result<ArchiveBase*, HorizonResult> SystemSaveDataArchive::openArchive(const FSPath& path) {
-	if (path.type != PathType::Binary) {
+	if (!path.isBinary()) {
 		Helpers::panic("Unimplemented path type for SystemSaveData::OpenArchive");
 	}
 
@@ -14,7 +14,7 @@ Rust::Result<ArchiveBase*, HorizonResult> SystemSaveDataArchive::openArchive(con
 FileDescriptor SystemSaveDataArchive::openFile(const FSPath& path, const FilePerms& perms) {
 	// TODO: Validate this. Temporarily copied from SaveData archive
 
-	if (path.type == PathType::UTF16) {
+	if (path.isUTF16()) {
 		if (!isPathSafe<PathType::UTF16>(path)) {
 			Helpers::panic("Unsafe path in SystemSaveData::OpenFile");
 		}
@@ -50,7 +50,7 @@ FileDescriptor SystemSaveDataArchive::openFile(const FSPath& path, const FilePer
 }
 
 HorizonResult SystemSaveDataArchive::createFile(const FSPath& path, u64 size) {
-	if (path.type == PathType::UTF16) {
+	if (path.isUTF16()) {
 		if (!isPathSafe<PathType::UTF16>(path)) {
 			Helpers::panic("Unsafe path in SystemSaveData::CreateFile");
 		}
@@ -85,7 +85,7 @@ HorizonResult SystemSaveDataArchive::createFile(const FSPath& path, u64 size) {
 }
 
 HorizonResult SystemSaveDataArchive::createDirectory(const FSPath& path) {
-	if (path.type == PathType::UTF16) {
+	if (path.isUTF16()) {
 		if (!isPathSafe<PathType::UTF16>(path)) {
 			Helpers::panic("Unsafe path in SystemSaveData::CreateDirectory");
 		}
@@ -110,7 +110,7 @@ HorizonResult SystemSaveDataArchive::createDirectory(const FSPath& path) {
 
 
 HorizonResult SystemSaveDataArchive::deleteFile(const FSPath& path) {
-	if (path.type == PathType::UTF16) {
+	if (path.isUTF16()) {
 		if (!isPathSafe<PathType::UTF16>(path)) {
 			Helpers::panic("Unsafe path in SystemSaveData::DeleteFile");
 		}
@@ -143,7 +143,7 @@ HorizonResult SystemSaveDataArchive::deleteFile(const FSPath& path) {
 }
 
 Rust::Result<DirectorySession, HorizonResult> SystemSaveDataArchive::openDirectory(const FSPath& path) {
-	if (path.type == PathType::UTF16) {
+	if (path.isUTF16()) {
 		if (!isPathSafe<PathType::UTF16>(path)) {
 			Helpers::warn("Unsafe path in SystemSaveData::OpenDirectory");
 			return Err(Result::FS::FileNotFoundAlt);

--- a/src/core/fs/archive_twl_photo.cpp
+++ b/src/core/fs/archive_twl_photo.cpp
@@ -26,7 +26,7 @@ FileDescriptor TWLPhotoArchive::openFile(const FSPath& path, const FilePerms& pe
 }
 
 Rust::Result<ArchiveBase*, HorizonResult> TWLPhotoArchive::openArchive(const FSPath& path) {
-	if (path.type != PathType::Empty) {
+	if (!path.isEmptyType()) {
 		Helpers::panic("Unimplemented path type for TWLPhotoArchive::OpenArchive");
 	}
 

--- a/src/core/fs/archive_twl_sound.cpp
+++ b/src/core/fs/archive_twl_sound.cpp
@@ -26,7 +26,7 @@ FileDescriptor TWLSoundArchive::openFile(const FSPath& path, const FilePerms& pe
 }
 
 Rust::Result<ArchiveBase*, HorizonResult> TWLSoundArchive::openArchive(const FSPath& path) {
-	if (path.type != PathType::Empty) {
+	if (!path.isEmptyType()) {
 		Helpers::panic("Unimplemented path type for TWLSoundArchive::OpenArchive");
 	}
 

--- a/src/core/fs/archive_user_save_data.cpp
+++ b/src/core/fs/archive_user_save_data.cpp
@@ -6,13 +6,15 @@
 namespace fs = std::filesystem;
 
 HorizonResult UserSaveDataArchive::createFile(const FSPath& path, u64 size) {
-	if (path.type == PathType::UTF16) {
+	if (path.isUTF16()) {
 		if (!isPathSafe<PathType::UTF16>(path)) Helpers::panic("Unsafe path in UserSaveData::CreateFile");
 
 		fs::path p = IOFile::getAppData() / "SaveData";
 		p += fs::path(path.utf16_string).make_preferred();
 
-		if (fs::exists(p)) return Result::FS::AlreadyExists;
+		if (fs::exists(p)) {
+			return Result::FS::AlreadyExists;
+		}
 
 		IOFile file(p.string().c_str(), "wb");
 
@@ -37,8 +39,10 @@ HorizonResult UserSaveDataArchive::createFile(const FSPath& path, u64 size) {
 }
 
 HorizonResult UserSaveDataArchive::createDirectory(const FSPath& path) {
-	if (path.type == PathType::UTF16) {
-		if (!isPathSafe<PathType::UTF16>(path)) Helpers::panic("Unsafe path in UserSaveData::OpenFile");
+	if (path.isUTF16()) {
+		if (!isPathSafe<PathType::UTF16>(path)) {
+			Helpers::panic("Unsafe path in UserSaveData::OpenFile");
+		}
 
 		fs::path p = IOFile::getAppData() / "SaveData";
 		p += fs::path(path.utf16_string).make_preferred();
@@ -56,7 +60,7 @@ HorizonResult UserSaveDataArchive::createDirectory(const FSPath& path) {
 }
 
 HorizonResult UserSaveDataArchive::deleteFile(const FSPath& path) {
-	if (path.type == PathType::UTF16) {
+	if (path.isUTF16()) {
 		if (!isPathSafe<PathType::UTF16>(path)) Helpers::panic("Unsafe path in UserSaveData::DeleteFile");
 
 		fs::path p = IOFile::getAppData() / "SaveData";
@@ -87,7 +91,7 @@ HorizonResult UserSaveDataArchive::deleteFile(const FSPath& path) {
 }
 
 FileDescriptor UserSaveDataArchive::openFile(const FSPath& path, const FilePerms& perms) {
-	if (path.type == PathType::UTF16) {
+	if (path.isUTF16()) {
 		if (!isPathSafe<PathType::UTF16>(path)) Helpers::panic("Unsafe path in UserSaveData::OpenFile");
 
 		if (perms.raw == 0 || (perms.create() && !perms.write())) Helpers::panic("[UserSaveData] Unsupported flags for OpenFile");
@@ -119,7 +123,7 @@ FileDescriptor UserSaveDataArchive::openFile(const FSPath& path, const FilePerms
 }
 
 Rust::Result<DirectorySession, HorizonResult> UserSaveDataArchive::openDirectory(const FSPath& path) {
-	if (path.type == PathType::UTF16) {
+	if (path.isUTF16()) {
 		if (!isPathSafe<PathType::UTF16>(path)) Helpers::panic("Unsafe path in UserSaveData::OpenDirectory");
 
 		fs::path p = IOFile::getAppData() / "SaveData";

--- a/src/core/services/service_manager.cpp
+++ b/src/core/services/service_manager.cpp
@@ -95,6 +95,7 @@ void ServiceManager::registerClient(u32 messagePointer) {
 // clang-format off
 static std::map<std::string, HorizonHandle> serviceMap = {
 	{ "ac:u", KernelHandles::AC },
+	{ "ac:i", KernelHandles::AC },
 	{ "act:a", KernelHandles::ACT },
 	{ "act:u", KernelHandles::ACT },
 	{ "am:app", KernelHandles::AM },


### PR DESCRIPTION
Makes filesystem code human-readable, makes it easier to support both UTF16 and ASCII paths in the same archive, allows more things to boot like Anemone3DS

![image](https://github.com/user-attachments/assets/9d177a3c-a51d-4865-9e89-ae9c11bfbd6d)
