### PR TITLE
Decouple data save paths from Emulator

### DIFF
--- a/include/emulator.hpp
+++ b/include/emulator.hpp
@@ -28,6 +28,8 @@
 #include "gl/context.h"
 #endif
 
+static const std::string EmulatorConfigFilename = "config.toml";
+
 struct SDL_Window;
 
 enum class ROMType {
@@ -50,6 +52,8 @@ class Emulator {
 	Crypto::AESEngine aesEngine;
 	MiniAudioDevice audioDevice;
 	Cheats cheats;
+
+	std::filesystem::path appDataPath;
 
   public:
 	static constexpr u32 width = 400;
@@ -85,7 +89,7 @@ class Emulator {
 	// Used in CPU::runFrame
 	bool frameDone = false;
 
-	Emulator();
+	Emulator(std::vector<std::filesystem::path> configSearchPaths, std::filesystem::path appDataPath);
 	~Emulator();
 
 	void step();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -27,6 +27,7 @@ void EmulatorConfig::load() {
 		return;
 	}
 
+	printf("Loading existing configuration file %s\n", path.string().c_str());
 	toml::value data;
 
 	try {

--- a/src/hydra_core.cpp
+++ b/src/hydra_core.cpp
@@ -50,7 +50,7 @@ class HC_GLOBAL HydraCore final : public hydra::IBase,
 	void* getProcAddress = nullptr;
 };
 
-HydraCore::HydraCore() : emulator(new Emulator) {
+HydraCore::HydraCore() : emulator(new Emulator({ std::filesystem::current_path() / EmulatorConfigFilename }, std::filesystem::current_path())) {
 	if (emulator->getRendererType() != RendererType::OpenGL) {
 		throw std::runtime_error("HydraCore: Renderer is not OpenGL");
 	}

--- a/src/libretro_core.cpp
+++ b/src/libretro_core.cpp
@@ -15,20 +15,11 @@ static retro_input_poll_t inputPollCallback;
 static retro_input_state_t inputStateCallback;
 
 static retro_hw_render_callback hwRender;
-static std::filesystem::path savePath;
 
 static bool screenTouched;
 
 std::unique_ptr<Emulator> emulator;
 RendererGL* renderer;
-
-std::filesystem::path Emulator::getConfigPath() {
-	return std::filesystem::path(savePath / "config.toml");
-}
-
-std::filesystem::path Emulator::getAppDataRoot() {
-	return std::filesystem::path(savePath / "Emulator Files");
-}
 
 static void* getGLProcAddress(const char* name) {
 	return (void*)hwRender.get_proc_address(name);
@@ -276,15 +267,14 @@ void retro_init() {
 	envCallback(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &xrgb888);
 
 	char* saveDir = nullptr;
+	std::filesystem::path savePath = std::filesystem::path(saveDir);
 
 	if (!envCallback(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &saveDir) || saveDir == nullptr) {
 		Helpers::warn("No save directory provided by LibRetro.");
 		savePath = std::filesystem::current_path();
-	} else {
-		savePath = std::filesystem::path(saveDir);
 	}
 
-	emulator = std::make_unique<Emulator>();
+	emulator = std::make_unique<Emulator>(({ std::filesystem::path(savePath / EmulatorConfigFilename) }, std::filesystem::path(savePath / "Emulator Files")));
 }
 
 void retro_deinit() {

--- a/src/panda_qt/main_window.cpp
+++ b/src/panda_qt/main_window.cpp
@@ -14,7 +14,10 @@
 #include "version.hpp"
 
 MainWindow::MainWindow(QApplication* app, QWidget* parent) : QMainWindow(parent), keyboardMappings(InputMappings::defaultKeyboardMappings()) {
-	emu = new Emulator();
+	QCoreApplication::setApplicationName("Alber");
+
+	const std::filesystem::path appData(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation).toStdString());
+	emu = new Emulator({ std::filesystem::current_path() / EmulatorConfigFilename, appData / EmulatorConfigFilename }, appData);
 
 	loadTranslation();
 	setWindowTitle(tr("Alber"));

--- a/src/panda_sdl/frontend_sdl.cpp
+++ b/src/panda_sdl/frontend_sdl.cpp
@@ -6,7 +6,14 @@
 #include "sdl_sensors.hpp"
 #include "version.hpp"
 
-FrontendSDL::FrontendSDL() : keyboardMappings(InputMappings::defaultKeyboardMappings()) {
+std::filesystem::path getAppDataPath() {
+	auto appData = SDL_GetPrefPath(nullptr, "Alber");
+	auto appDataPath = std::filesystem::path(appData);
+	SDL_free(appData);
+	return appDataPath;
+}
+
+FrontendSDL::FrontendSDL() : emu({ std::filesystem::current_path() / EmulatorConfigFilename, getAppDataPath() / EmulatorConfigFilename }, getAppDataPath()), keyboardMappings(InputMappings::defaultKeyboardMappings()) {
 	if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS) < 0) {
 		Helpers::panic("Failed to initialize SDL2");
 	}


### PR DESCRIPTION
This change allows the frontend to select the appdata and configuration file locations when instantiating the emulator, allowing for more flexibility in placing the files.

This also fixes configuration not working in MacOS app bundles, as it will now look for config.toml in the user's "Application Support" directory and default there.