### PR TITLE
Store configuration file in AppData root if not in working directory

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -27,6 +27,7 @@ void EmulatorConfig::load() {
 		return;
 	}
 
+	printf("Loading existing configuration file %s\n", path.string().c_str());
 	toml::value data;
 
 	try {

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -105,7 +105,11 @@ std::filesystem::path Emulator::getConfigPath() {
 	if constexpr (Helpers::isAndroid()) {
 		return getAndroidAppPath() / "config.toml";
 	} else {
-		return std::filesystem::current_path() / "config.toml";
+		if (std::filesystem::exists(std::filesystem::current_path() / "config.toml")) {
+			return std::filesystem::current_path() / "config.toml";
+		} else {
+			return getAppDataRoot() / "config.toml";
+		}
 	}
 }
 #endif

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -105,7 +105,7 @@ std::filesystem::path Emulator::getConfigPath() {
 	if constexpr (Helpers::isAndroid()) {
 		return getAndroidAppPath() / "config.toml";
 	} else {
-		std::filesystem::path localPath = std::filesystem::current_path() / "config.toml");
+		std::filesystem::path localPath = std::filesystem::current_path() / "config.toml";
 
 		if (std::filesystem::exists(localPath)) {
 			return localPath;

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -105,8 +105,10 @@ std::filesystem::path Emulator::getConfigPath() {
 	if constexpr (Helpers::isAndroid()) {
 		return getAndroidAppPath() / "config.toml";
 	} else {
-		if (std::filesystem::exists(std::filesystem::current_path() / "config.toml")) {
-			return std::filesystem::current_path() / "config.toml";
+		std::filesystem::path localPath = std::filesystem::current_path() / "config.toml");
+
+		if (std::filesystem::exists(localPath)) {
+			return localPath;
 		} else {
 			return getAppDataRoot() / "config.toml";
 		}


### PR DESCRIPTION
This fixes MacOS app bundles, as the emulator cannot write the config file into the app bundle.