### PR TITLE
Support GLES on desktop

### DIFF
--- a/.github/gles.patch
+++ b/.github/gles.patch
@@ -1,25 +1,3 @@
-diff --git a/src/host_shaders/opengl_display.frag b/src/host_shaders/opengl_display.frag
-index 612671c8..1937f711 100644
---- a/src/host_shaders/opengl_display.frag
-+++ b/src/host_shaders/opengl_display.frag
-@@ -1,4 +1,5 @@
--#version 410 core
-+#version 300 es
-+precision mediump float;
- in vec2 UV;
- out vec4 FragColor;
- 
-diff --git a/src/host_shaders/opengl_display.vert b/src/host_shaders/opengl_display.vert
-index 990e2f80..2e7842ac 100644
---- a/src/host_shaders/opengl_display.vert
-+++ b/src/host_shaders/opengl_display.vert
-@@ -1,4 +1,5 @@
--#version 410 core
-+#version 300 es
-+precision mediump float;
- out vec2 UV;
- 
- void main() {
 diff --git a/src/host_shaders/opengl_fragment_shader.frag b/src/host_shaders/opengl_fragment_shader.frag
 index 9f07df0b..96a35afa 100644
 --- a/src/host_shaders/opengl_fragment_shader.frag

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,8 +465,9 @@ if(ENABLE_OPENGL)
 
     set(RENDERER_GL_SOURCE_FILES src/core/renderer_gl/renderer_gl.cpp
         src/core/renderer_gl/textures.cpp src/core/renderer_gl/etc1.cpp
-        src/core/renderer_gl/gl_state.cpp src/host_shaders/opengl_display.frag
-        src/host_shaders/opengl_display.vert src/host_shaders/opengl_vertex_shader.vert
+        src/core/renderer_gl/gl_state.cpp src/host_shaders/opengl_display.vert
+        src/host_shaders/opengl_display.frag src/host_shaders/opengl_es_display.vert
+        src/host_shaders/opengl_es_display.frag src/host_shaders/opengl_vertex_shader.vert
         src/host_shaders/opengl_fragment_shader.frag
     )
 
@@ -479,8 +480,10 @@ if(ENABLE_OPENGL)
         resources_renderer_gl
         NAMESPACE RendererGL
         WHENCE "src/host_shaders/"
-        "src/host_shaders/opengl_display.frag"
         "src/host_shaders/opengl_display.vert"
+        "src/host_shaders/opengl_display.frag"
+        "src/host_shaders/opengl_es_display.vert"
+        "src/host_shaders/opengl_es_display.frag"
         "src/host_shaders/opengl_vertex_shader.vert"
         "src/host_shaders/opengl_fragment_shader.frag"
     )

--- a/include/emulator.hpp
+++ b/include/emulator.hpp
@@ -89,7 +89,6 @@ class Emulator {
 	~Emulator();
 
 	void step();
-	void render();
 	void reset(ReloadOption reload);
 	void runFrame();
 	// Poll the scheduler for events

--- a/include/renderer.hpp
+++ b/include/renderer.hpp
@@ -81,6 +81,10 @@ class Renderer {
 	virtual std::string getUbershader() { return ""; }
 	virtual void setUbershader(const std::string& shader) {}
 
+	// Only relevant for OpenGL renderer and other OpenGL-based backends (eg software)
+	// Called to notify the core to use OpenGL ES and not desktop GL
+	virtual void setupGLES() {}
+
 	// This function is called on every draw call before parsing vertex data.
 	// It is responsible for things like looking up which vertex/fragment shaders to use, recompiling them if they don't exist, choosing between
 	// ubershaders and shadergen, and so on.

--- a/include/renderer_gl/renderer_gl.hpp
+++ b/include/renderer_gl/renderer_gl.hpp
@@ -40,7 +40,7 @@ class RendererGL final : public Renderer {
 	OpenGL::VertexArray hwShaderVAO;
 	OpenGL::VertexBuffer vbo;
 
-	// Data 
+	// Data
 	struct {
 		// TEV configuration uniform locations
 		GLint textureEnvSourceLoc = -1;
@@ -157,6 +157,7 @@ class RendererGL final : public Renderer {
 	void initGraphicsContextInternal();
 
 	void accelerateVertexUpload(ShaderUnit& shaderUnit, PICA::DrawAcceleration* accel);
+	void compileDisplayShader();
 
   public:
 	RendererGL(GPU& gpu, const std::array<u32, regNum>& internalRegs, const std::array<u32, extRegNum>& externalRegs)
@@ -169,14 +170,15 @@ class RendererGL final : public Renderer {
 	void clearBuffer(u32 startAddress, u32 endAddress, u32 value, u32 control) override;  // Clear a GPU buffer in VRAM
 	void displayTransfer(u32 inputAddr, u32 outputAddr, u32 inputSize, u32 outputSize, u32 flags) override;  // Perform display transfer
 	void textureCopy(u32 inputAddr, u32 outputAddr, u32 totalBytes, u32 inputSize, u32 outputSize, u32 flags) override;
-	void drawVertices(PICA::PrimType primType, std::span<const PICA::Vertex> vertices) override;             // Draw the given vertices
+	void drawVertices(PICA::PrimType primType, std::span<const PICA::Vertex> vertices) override;  // Draw the given vertices
 	void deinitGraphicsContext() override;
 
 	virtual bool supportsShaderReload() override { return true; }
 	virtual std::string getUbershader() override;
 	virtual void setUbershader(const std::string& shader) override;
 	virtual bool prepareForDraw(ShaderUnit& shaderUnit, PICA::DrawAcceleration* accel) override;
-	
+	virtual void setupGLES() override;
+
 	std::optional<ColourBuffer> getColourBuffer(u32 addr, PICA::ColorFmt format, u32 width, u32 height, bool createIfnotFound = true);
 
 	// Note: The caller is responsible for deleting the currently bound FBO before calling this

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -117,7 +117,6 @@ std::filesystem::path Emulator::getConfigPath() {
 #endif
 
 void Emulator::step() {}
-void Emulator::render() {}
 
 // Only resume if a ROM is properly loaded
 void Emulator::resume() {

--- a/src/host_shaders/opengl_es_display.frag
+++ b/src/host_shaders/opengl_es_display.frag
@@ -1,0 +1,10 @@
+#version 310 es
+precision mediump float;
+
+in vec2 UV;
+out vec4 FragColor;
+
+uniform sampler2D u_texture;
+void main() {
+	FragColor = texture(u_texture, UV);
+}

--- a/src/host_shaders/opengl_es_display.vert
+++ b/src/host_shaders/opengl_es_display.vert
@@ -1,0 +1,25 @@
+#version 310 es
+precision mediump float;
+
+out vec2 UV;
+
+void main() {
+	const vec4 positions[4] = vec4[](
+		vec4(-1.0, 1.0, 1.0, 1.0),   // Top-left
+		vec4(1.0, 1.0, 1.0, 1.0),    // Top-right
+		vec4(-1.0, -1.0, 1.0, 1.0),  // Bottom-left
+		vec4(1.0, -1.0, 1.0, 1.0)    // Bottom-right
+	);
+
+	// The 3DS displays both screens' framebuffer rotated 90 deg counter clockwise
+	// So we adjust our texcoords accordingly
+	const vec2 texcoords[4] = vec2[](
+		vec2(1.0, 1.0),  // Top-right
+		vec2(1.0, 0.0),  // Bottom-right
+		vec2(0.0, 1.0),  // Top-left
+		vec2(0.0, 0.0)   // Bottom-left
+	);
+
+	gl_Position = positions[gl_VertexID];
+	UV = texcoords[gl_VertexID];
+}

--- a/src/hydra_core.cpp
+++ b/src/hydra_core.cpp
@@ -118,6 +118,7 @@ void HydraCore::resetContext() {
 	if (!gladLoadGLES2Loader(reinterpret_cast<GLADloadproc>(getProcAddress))) {
 		Helpers::panic("OpenGL ES init failed");
 	}
+	emulator->getRenderer()->setupGLES();
 #else
 	if (!gladLoadGLLoader(reinterpret_cast<GLADloadproc>(getProcAddress))) {
 		Helpers::panic("OpenGL init failed");

--- a/src/jni_driver.cpp
+++ b/src/jni_driver.cpp
@@ -78,6 +78,7 @@ AlberFunction(void, Initialize)(JNIEnv* env, jobject obj) {
 	}
 
 	__android_log_print(ANDROID_LOG_INFO, "AlberDriver", "OpenGL ES %d.%d", GLVersion.major, GLVersion.minor);
+	emulator->getRenderer()->setupGLES();
 	emulator->initGraphicsContext(nullptr);
 }
 
@@ -153,7 +154,6 @@ int AndroidUtils::openDocument(const char* path, const char* perms) {
 
     jstring uri = env->NewStringUTF(path);
     jstring jmode = env->NewStringUTF(perms);
-
     jint result = env->CallStaticIntMethod(alberClass, alberClassOpenDocument, uri, jmode);
 
     env->DeleteLocalRef(uri);

--- a/src/panda_qt/main_window.cpp
+++ b/src/panda_qt/main_window.cpp
@@ -140,6 +140,10 @@ MainWindow::MainWindow(QApplication* app, QWidget* parent) : QMainWindow(parent)
 			glContext->MakeCurrent();
 			glContext->SetSwapInterval(emu->getConfig().vsyncEnabled ? 1 : 0);
 
+			if (glContext->IsGLES()) {
+				emu->getRenderer()->setupGLES();
+			}
+
 			emu->initGraphicsContext(glContext);
 		} else if (usingVk) {
 			Helpers::panic("Vulkan on Qt is currently WIP, try the SDL frontend instead!");

--- a/src/panda_qt/screen.cpp
+++ b/src/panda_qt/screen.cpp
@@ -60,11 +60,12 @@ void ScreenWidget::resizeSurface(u32 width, u32 height) {
 }
 
 bool ScreenWidget::createGLContext() {
-	// List of GL context versions we will try. Anything 4.1+ is good
-	static constexpr std::array<GL::Context::Version, 6> versionsToTry = {
+	// List of GL context versions we will try. Anything 4.1+ is good for desktop OpenGL, and 3.1+ for OpenGL ES
+	static constexpr std::array<GL::Context::Version, 8> versionsToTry = {
 		GL::Context::Version{GL::Context::Profile::Core, 4, 6}, GL::Context::Version{GL::Context::Profile::Core, 4, 5},
 		GL::Context::Version{GL::Context::Profile::Core, 4, 4}, GL::Context::Version{GL::Context::Profile::Core, 4, 3},
 		GL::Context::Version{GL::Context::Profile::Core, 4, 2}, GL::Context::Version{GL::Context::Profile::Core, 4, 1},
+		GL::Context::Version{GL::Context::Profile::ES, 3, 2},   GL::Context::Version{GL::Context::Profile::ES, 3, 1},
 	};
 
 	std::optional<WindowInfo> windowInfo = getWindowInfo();
@@ -72,6 +73,10 @@ bool ScreenWidget::createGLContext() {
 		this->windowInfo = *windowInfo;
 
 		glContext = GL::Context::Create(*getWindowInfo(), versionsToTry);
+		if (glContext == nullptr) {
+			return false;
+		}
+
 		glContext->DoneCurrent();
 	}
 


### PR DESCRIPTION
This should fix GLES support on desktop platforms on both SDL and Qt.

Several devices such as the Raspberry Pi 5 and emulation handhelds (eg RK3588) don't support desktop GL. This allows users to play games on those, and also turns off ubershaders on them since none of them can actually run any well with them on.