### PR TITLE
Qt: Fix Wayland support

### DIFF
--- a/src/panda_qt/main.cpp
+++ b/src/panda_qt/main.cpp
@@ -7,6 +7,5 @@ int main(int argc, char *argv[]) {
 	QApplication app(argc, argv);
 	MainWindow window(&app);
 
-	window.show();
 	return app.exec();
 }

--- a/src/panda_qt/main_window.cpp
+++ b/src/panda_qt/main_window.cpp
@@ -22,6 +22,7 @@ MainWindow::MainWindow(QApplication* app, QWidget* parent) : QMainWindow(parent)
 	// Enable drop events for loading ROMs
 	setAcceptDrops(true);
 	resize(800, 240 * 4);
+	show();
 
 	// We pass a callback to the screen widget that will be triggered every time we resize the screen
 	screen = new ScreenWidget([this](u32 width, u32 height) { handleScreenResize(width, height); }, this);

--- a/src/panda_qt/main_window.cpp
+++ b/src/panda_qt/main_window.cpp
@@ -28,9 +28,7 @@ MainWindow::MainWindow(QApplication* app, QWidget* parent) : QMainWindow(parent)
 	screen = new ScreenWidget([this](u32 width, u32 height) { handleScreenResize(width, height); }, this);
 	setCentralWidget(screen);
 
-	screen->show();
 	appRunning = true;
-
 	// Set our menu bar up
 	menuBar = new QMenuBar(nullptr);
 

--- a/src/panda_qt/screen.cpp
+++ b/src/panda_qt/screen.cpp
@@ -29,6 +29,7 @@ ScreenWidget::ScreenWidget(ResizeCallback resizeCallback, QWidget* parent) : QWi
 	setAttribute(Qt::WA_KeyCompression, false);
 	setFocusPolicy(Qt::StrongFocus);
 	setMouseTracking(true);
+	show();
 
 	if (!createGLContext()) {
 		Helpers::panic("Failed to create GL context for display");
@@ -84,7 +85,7 @@ bool ScreenWidget::createGLContext() {
 }
 
 qreal ScreenWidget::devicePixelRatioFromScreen() const {
-	const QScreen* screenForRatio = window()->windowHandle()->screen();
+	const QScreen* screenForRatio = windowHandle()->screen();
 	if (!screenForRatio) {
 		screenForRatio = QGuiApplication::primaryScreen();
 	}


### PR DESCRIPTION
Qt will only create a Wayland surface when show() is called on the main window and on the ScreenWidget. Thus, call the function before creating the GL context.

Doesn't cause regressions on XWayland, untested in other platforms.

Fixes #586