### PR TITLE
Add Luma icache SVCs and don't flush entire code cache when loading/unloading CROs

### DIFF
--- a/include/cpu_dynarmic.hpp
+++ b/include/cpu_dynarmic.hpp
@@ -181,5 +181,7 @@ class CPU {
     void addTicks(u64 ticks) { env.AddTicks(ticks); }
 
     void clearCache() { jit->ClearCache(); }
+    void clearCacheRange(u32 start, u32 size) { jit->InvalidateCacheRange(start, size); }
+
     void runFrame();
 };

--- a/include/kernel/kernel.hpp
+++ b/include/kernel/kernel.hpp
@@ -175,6 +175,8 @@ public:
 	void svcSignalEvent();
 	void svcSetTimer();
 	void svcSleepThread();
+	void svcInvalidateInstructionCacheRange();
+	void svcInvalidateEntireInstructionCache();
 	void connectToPort();
 	void outputDebugString();
 	void waitSynchronization1();

--- a/include/kernel/kernel.hpp
+++ b/include/kernel/kernel.hpp
@@ -250,4 +250,5 @@ public:
 
 	void sendGPUInterrupt(GPUInterrupt type) { serviceManager.sendGPUInterrupt(type); }
 	void clearInstructionCache();
+	void clearInstructionCacheRange(u32 start, u32 size);
 };

--- a/src/core/kernel/kernel.cpp
+++ b/src/core/kernel/kernel.cpp
@@ -69,6 +69,10 @@ void Kernel::serviceSVC(u32 svc) {
 		case 0x3A: getResourceLimitCurrentValues(); break;
 		case 0x3B: getThreadContext(); break;
 		case 0x3D: outputDebugString(); break;
+
+		// Luma SVCs
+		case 0x93: svcInvalidateInstructionCacheRange(); break;
+		case 0x94: svcInvalidateEntireInstructionCache(); break;
 		default: Helpers::panic("Unimplemented svc: %X @ %08X", svc, regs[15]); break;
 	}
 
@@ -299,6 +303,19 @@ void Kernel::duplicateHandle() {
 
 void Kernel::clearInstructionCache() { cpu.clearCache(); }
 void Kernel::clearInstructionCacheRange(u32 start, u32 size) { cpu.clearCacheRange(start, size); }
+
+void Kernel::svcInvalidateInstructionCacheRange() {
+	const u32 start = regs[0];
+	const u32 size = regs[1];
+
+	clearInstructionCacheRange(start, size);
+	regs[0] = Result::Success;
+}
+
+void Kernel::svcInvalidateEntireInstructionCache() {
+	clearInstructionCache();
+	regs[0] = Result::Success;
+}
 
 namespace SystemInfoType {
 	enum : u32 {

--- a/src/core/kernel/kernel.cpp
+++ b/src/core/kernel/kernel.cpp
@@ -298,6 +298,7 @@ void Kernel::duplicateHandle() {
 }
 
 void Kernel::clearInstructionCache() { cpu.clearCache(); }
+void Kernel::clearInstructionCacheRange(u32 start, u32 size) { cpu.clearCacheRange(start, size); }
 
 namespace SystemInfoType {
 	enum : u32 {

--- a/src/core/kernel/kernel.cpp
+++ b/src/core/kernel/kernel.cpp
@@ -307,12 +307,15 @@ void Kernel::clearInstructionCacheRange(u32 start, u32 size) { cpu.clearCacheRan
 void Kernel::svcInvalidateInstructionCacheRange() {
 	const u32 start = regs[0];
 	const u32 size = regs[1];
+	logSVC("svcInvalidateInstructionCacheRange(start = %08X, size = %08X)\n", start, size);
 
 	clearInstructionCacheRange(start, size);
 	regs[0] = Result::Success;
 }
 
 void Kernel::svcInvalidateEntireInstructionCache() {
+	logSVC("svcInvalidateEntireInstructionCache()\n");
+
 	clearInstructionCache();
 	regs[0] = Result::Success;
 }


### PR DESCRIPTION
Significantly reduces stutter in games like Pokemon X/Y and ORAS that constantly switch between CROs