### PR TITLE
[WIP] Libretro: Add audio support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,7 +402,8 @@ set(HEADER_FILES include/emulator.hpp include/helpers.hpp include/termcolor.hpp 
                  include/align.hpp include/audio/aac_decoder.hpp include/PICA/pica_simd.hpp include/services/fonts.hpp
                  include/audio/audio_interpolation.hpp include/audio/hle_mixer.hpp include/audio/dsp_simd.hpp
                  include/services/dsp_firmware_db.hpp include/frontend_settings.hpp include/fs/archive_twl_photo.hpp
-                 include/fs/archive_twl_sound.hpp include/fs/archive_card_spi.hpp include/services/ns.hpp
+                 include/fs/archive_twl_sound.hpp include/fs/archive_card_spi.hpp include/services/ns.hpp include/audio/audio_device.hpp
+                 include/audio/libretro_audio_device.hpp
 )
 
 cmrc_add_resource_library(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -403,7 +403,7 @@ set(HEADER_FILES include/emulator.hpp include/helpers.hpp include/termcolor.hpp 
                  include/audio/audio_interpolation.hpp include/audio/hle_mixer.hpp include/audio/dsp_simd.hpp
                  include/services/dsp_firmware_db.hpp include/frontend_settings.hpp include/fs/archive_twl_photo.hpp
                  include/fs/archive_twl_sound.hpp include/fs/archive_card_spi.hpp include/services/ns.hpp include/audio/audio_device.hpp
-                 include/audio/libretro_audio_device.hpp
+                 include/audio/audio_device_interface.hpp include/audio/libretro_audio_device.hpp
 )
 
 cmrc_add_resource_library(

--- a/include/audio/audio_device.hpp
+++ b/include/audio/audio_device.hpp
@@ -1,34 +1,7 @@
-#pragma once
-#include <array>
-
-#include "config.hpp"
-#include "helpers.hpp"
-#include "ring_buffer.hpp"
-
-class AudioDeviceInterface {
-  protected:
-	using Samples = Common::RingBuffer<s16, 0x2000 * 2>;
-	using RenderBatchCallback = usize (*)(const s16*, usize);
-
-	Samples* samples = nullptr;
-
-	const AudioDeviceConfig& audioSettings;
-	// Store the last stereo sample we output. We play this when underruning to avoid pops.
-	std::array<s16, 2> lastStereoSample{};
-
-  public:
-	AudioDeviceInterface(Samples* samples, const AudioDeviceConfig& audioSettings) : samples(samples), audioSettings(audioSettings) {}
-
-	bool running = false;
-	Samples* getSamples() { return samples; }
-
-	// If safe is on, we create a null audio device
-	virtual void init(Samples& samples, bool safe = false) = 0;
-	virtual void close() = 0;
-
-	virtual void start() = 0;
-	virtual void stop() = 0;
-
-	// Only used for audio devices that render multiple audio frames in one go, eg the libretro audio device.
-	virtual void renderBatch(RenderBatchCallback callback) {}
-};
+#ifndef __LIBRETRO__
+#include "audio/miniaudio_device.hpp"
+using AudioDevice = MiniAudioDevice;
+#else
+#include "audio/libretro_audio_device.hpp"
+using AudioDevice = LibretroAudioDevice;
+#endif

--- a/include/audio/audio_device.hpp
+++ b/include/audio/audio_device.hpp
@@ -1,0 +1,31 @@
+#pragma once
+#include <array>
+
+#include "config.hpp"
+#include "helpers.hpp"
+#include "ring_buffer.hpp"
+
+class AudioDeviceInterface {
+  protected:
+	using Samples = Common::RingBuffer<s16, 0x2000 * 2>;
+	Samples* samples = nullptr;
+
+	const AudioDeviceConfig& audioSettings;
+
+  public:
+	AudioDeviceInterface(Samples* samples, const AudioDeviceConfig& audioSettings) : samples(samples), audioSettings(audioSettings) {}
+
+	// Store the last stereo sample we output. We play this when underruning to avoid pops.
+	// TODO: Make this protected again before merging!!!
+	std::array<s16, 2> lastStereoSample{};
+
+	bool running = false;
+	Samples* getSamples() { return samples; }
+
+	// If safe is on, we create a null audio device
+	virtual void init(Samples& samples, bool safe = false) = 0;
+	virtual void close() = 0;
+
+	virtual void start() = 0;
+	virtual void stop() = 0;
+};

--- a/include/audio/audio_device.hpp
+++ b/include/audio/audio_device.hpp
@@ -8,16 +8,16 @@
 class AudioDeviceInterface {
   protected:
 	using Samples = Common::RingBuffer<s16, 0x2000 * 2>;
+	using RenderBatchCallback = usize (*)(const s16*, usize);
+
 	Samples* samples = nullptr;
 
 	const AudioDeviceConfig& audioSettings;
+	// Store the last stereo sample we output. We play this when underruning to avoid pops.
+	std::array<s16, 2> lastStereoSample{};
 
   public:
 	AudioDeviceInterface(Samples* samples, const AudioDeviceConfig& audioSettings) : samples(samples), audioSettings(audioSettings) {}
-
-	// Store the last stereo sample we output. We play this when underruning to avoid pops.
-	// TODO: Make this protected again before merging!!!
-	std::array<s16, 2> lastStereoSample{};
 
 	bool running = false;
 	Samples* getSamples() { return samples; }
@@ -28,4 +28,7 @@ class AudioDeviceInterface {
 
 	virtual void start() = 0;
 	virtual void stop() = 0;
+
+	// Only used for audio devices that render multiple audio frames in one go, eg the libretro audio device.
+	virtual void renderBatch(RenderBatchCallback callback) {}
 };

--- a/include/audio/audio_device.hpp
+++ b/include/audio/audio_device.hpp
@@ -1,7 +1,9 @@
-#ifndef __LIBRETRO__
-#include "audio/miniaudio_device.hpp"
-using AudioDevice = MiniAudioDevice;
-#else
+#pragma once
+
+#ifdef __LIBRETRO__
 #include "audio/libretro_audio_device.hpp"
 using AudioDevice = LibretroAudioDevice;
+#else
+#include "audio/miniaudio_device.hpp"
+using AudioDevice = MiniAudioDevice;
 #endif

--- a/include/audio/audio_device_interface.hpp
+++ b/include/audio/audio_device_interface.hpp
@@ -1,0 +1,34 @@
+#pragma once
+#include <array>
+
+#include "config.hpp"
+#include "helpers.hpp"
+#include "ring_buffer.hpp"
+
+class AudioDeviceInterface {
+  protected:
+	using Samples = Common::RingBuffer<s16, 0x2000 * 2>;
+	using RenderBatchCallback = usize (*)(const s16*, usize);
+
+	Samples* samples = nullptr;
+
+	const AudioDeviceConfig& audioSettings;
+	// Store the last stereo sample we output. We play this when underruning to avoid pops.
+	std::array<s16, 2> lastStereoSample{};
+
+  public:
+	AudioDeviceInterface(Samples* samples, const AudioDeviceConfig& audioSettings) : samples(samples), audioSettings(audioSettings) {}
+
+	bool running = false;
+	Samples* getSamples() { return samples; }
+
+	// If safe is on, we create a null audio device
+	virtual void init(Samples& samples, bool safe = false) = 0;
+	virtual void close() = 0;
+
+	virtual void start() = 0;
+	virtual void stop() = 0;
+
+	// Only used for audio devices that render multiple audio frames in one go, eg the libretro audio device.
+	virtual void renderBatch(RenderBatchCallback callback) {}
+};

--- a/include/audio/audio_device_interface.hpp
+++ b/include/audio/audio_device_interface.hpp
@@ -7,7 +7,9 @@
 
 class AudioDeviceInterface {
   protected:
-	using Samples = Common::RingBuffer<s16, 0x2000 * 2>;
+	static constexpr usize maxFrameCount = 0x2000;
+
+	using Samples = Common::RingBuffer<s16, maxFrameCount * 2>;
 	using RenderBatchCallback = usize (*)(const s16*, usize);
 
 	Samples* samples = nullptr;

--- a/include/audio/libretro_audio_device.hpp
+++ b/include/audio/libretro_audio_device.hpp
@@ -28,7 +28,7 @@ class LibretroAudioDevice : public AudioDeviceInterface {
 
 	void renderBatch(RenderBatchCallback callback) override {
 		if (running) {
-			static constexpr int frameCount = 547;
+			static constexpr int frameCount = maxFrameCount;
 			static constexpr int channelCount = 2;
 			static s16 audioBuffer[frameCount * channelCount];
 

--- a/include/audio/libretro_audio_device.hpp
+++ b/include/audio/libretro_audio_device.hpp
@@ -28,7 +28,7 @@ class LibretroAudioDevice : public AudioDeviceInterface {
 
 	void renderBatch(RenderBatchCallback callback) override {
 		if (running) {
-			static constexpr usize frameCount = maxFrameCount;
+			static constexpr usize frameCount = 774;
 			static constexpr usize channelCount = 2;
 			static s16 audioBuffer[frameCount * channelCount];
 
@@ -52,7 +52,7 @@ class LibretroAudioDevice : public AudioDeviceInterface {
 				}
 			}
 
-			callback(audioBuffer, sizeof(audioBuffer) / (2 * sizeof(s16)));
+			callback(audioBuffer, sizeof(audioBuffer) / (channelCount * sizeof(s16)));
 		}
 	}
 

--- a/include/audio/libretro_audio_device.hpp
+++ b/include/audio/libretro_audio_device.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <cstring>
 
-#include "audio/audio_device.hpp"
+#include "audio/audio_device_interface.hpp"
 
 class LibretroAudioDevice : public AudioDeviceInterface {
 	bool initialized = false;

--- a/include/audio/libretro_audio_device.hpp
+++ b/include/audio/libretro_audio_device.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <atomic>
+#include <string>
+#include <vector>
+
+#include "audio/audio_device.hpp"
+
+class LibretroAudioDevice : public AudioDeviceInterface {
+	bool initialized = false;
+
+  public:
+	LibretroAudioDevice(const AudioDeviceConfig& audioSettings) : AudioDeviceInterface(nullptr, audioSettings), initialized(false) {
+		running = false;
+	}
+
+	void init(Samples& samples, bool safe = false) override {
+		this->samples = &samples;
+
+		initialized = true;
+		running = false;
+	}
+
+	void close() override {
+		initialized = false;
+		running = false;
+	};
+
+	void start() override { running = true; }
+	void stop() override { running = false; };
+
+	bool isInitialized() const { return initialized; }
+	bool isRunning() const { return running; }
+};

--- a/include/audio/libretro_audio_device.hpp
+++ b/include/audio/libretro_audio_device.hpp
@@ -28,8 +28,8 @@ class LibretroAudioDevice : public AudioDeviceInterface {
 
 	void renderBatch(RenderBatchCallback callback) override {
 		if (running) {
-			static constexpr int frameCount = maxFrameCount;
-			static constexpr int channelCount = 2;
+			static constexpr usize frameCount = maxFrameCount;
+			static constexpr usize channelCount = 2;
 			static s16 audioBuffer[frameCount * channelCount];
 
 			usize samplesWritten = 0;

--- a/include/audio/miniaudio_device.hpp
+++ b/include/audio/miniaudio_device.hpp
@@ -3,40 +3,31 @@
 #include <string>
 #include <vector>
 
-#include "config.hpp"
-#include "helpers.hpp"
+#include "audio/audio_device.hpp"
 #include "miniaudio.h"
-#include "ring_buffer.hpp"
 
-class MiniAudioDevice {
-	public:
-	using Samples = Common::RingBuffer<ma_int16, 0x2000 * 2>;
+class MiniAudioDevice : public AudioDeviceInterface {
 	static constexpr ma_uint32 sampleRate = 32768;  // 3DS sample rate
 	static constexpr ma_uint32 channelCount = 2;    // Audio output is stereo
+
+	bool initialized = false;
 
 	ma_device device;
 	ma_context context;
 	ma_device_config deviceConfig;
-	Samples* samples = nullptr;
-
-	const AudioDeviceConfig& audioSettings;
-
-	bool initialized = false;
-	bool running = false;
 
 	// Store the last stereo sample we output. We play this when underruning to avoid pops.
-	std::array<s16, 2> lastStereoSample;
 	std::vector<std::string> audioDevices;
 
   public:
 	MiniAudioDevice(const AudioDeviceConfig& audioSettings);
 
 	// If safe is on, we create a null audio device
-	void init(Samples& samples, bool safe = false);
-	void close();
+	void init(Samples& samples, bool safe = false) override;
+	void close() override;
 
-	void start();
-	void stop();
+	void start() override;
+	void stop() override;
 
 	bool isInitialized() const { return initialized; }
 };

--- a/include/audio/miniaudio_device.hpp
+++ b/include/audio/miniaudio_device.hpp
@@ -9,6 +9,7 @@
 #include "ring_buffer.hpp"
 
 class MiniAudioDevice {
+	public:
 	using Samples = Common::RingBuffer<ma_int16, 0x2000 * 2>;
 	static constexpr ma_uint32 sampleRate = 32768;  // 3DS sample rate
 	static constexpr ma_uint32 channelCount = 2;    // Audio output is stereo

--- a/include/audio/miniaudio_device.hpp
+++ b/include/audio/miniaudio_device.hpp
@@ -3,7 +3,7 @@
 #include <string>
 #include <vector>
 
-#include "audio/audio_device.hpp"
+#include "audio/audio_device_interface.hpp"
 #include "miniaudio.h"
 
 class MiniAudioDevice : public AudioDeviceInterface {

--- a/include/emulator.hpp
+++ b/include/emulator.hpp
@@ -7,9 +7,8 @@
 #include <span>
 
 #include "PICA/gpu.hpp"
+#include "audio/audio_device.hpp"
 #include "audio/dsp_core.hpp"
-#include "audio/libretro_audio_device.hpp"
-#include "audio/miniaudio_device.hpp"
 #include "cheats.hpp"
 #include "config.hpp"
 #include "cpu.hpp"

--- a/include/emulator.hpp
+++ b/include/emulator.hpp
@@ -60,7 +60,7 @@ class Emulator {
 	static constexpr u32 width = 400;
 	static constexpr u32 height = 240 * 2;  // * 2 because 2 screens
 	ROMType romType = ROMType::None;
-	bool running = false;         // Is the emulator running a game?
+	bool running = false;  // Is the emulator running a game?
 
   private:
 #ifdef PANDA3DS_ENABLE_HTTP_SERVER

--- a/include/emulator.hpp
+++ b/include/emulator.hpp
@@ -8,6 +8,7 @@
 
 #include "PICA/gpu.hpp"
 #include "audio/dsp_core.hpp"
+#include "audio/libretro_audio_device.hpp"
 #include "audio/miniaudio_device.hpp"
 #include "cheats.hpp"
 #include "config.hpp"
@@ -48,7 +49,11 @@ class Emulator {
 	Scheduler scheduler;
 
 	Crypto::AESEngine aesEngine;
+#ifndef __LIBRETRO__
 	MiniAudioDevice audioDevice;
+#else
+	LibretroAudioDevice audioDevice;
+#endif
 	Cheats cheats;
 
   public:
@@ -126,6 +131,7 @@ class Emulator {
 	LuaManager& getLua() { return lua; }
 	Scheduler& getScheduler() { return scheduler; }
 	Memory& getMemory() { return memory; }
+	AudioDeviceInterface& getAudioDevice() { return audioDevice; }
 
 	RendererType getRendererType() const { return config.rendererType; }
 	Renderer* getRenderer() { return gpu.getRenderer(); }

--- a/include/emulator.hpp
+++ b/include/emulator.hpp
@@ -48,11 +48,7 @@ class Emulator {
 	Scheduler scheduler;
 
 	Crypto::AESEngine aesEngine;
-#ifndef __LIBRETRO__
-	MiniAudioDevice audioDevice;
-#else
-	LibretroAudioDevice audioDevice;
-#endif
+	AudioDevice audioDevice;
 	Cheats cheats;
 
   public:

--- a/src/core/audio/miniaudio_device.cpp
+++ b/src/core/audio/miniaudio_device.cpp
@@ -10,6 +10,7 @@
 MiniAudioDevice::MiniAudioDevice(const AudioDeviceConfig& audioSettings)
 	: initialized(false), running(false), samples(nullptr), audioSettings(audioSettings) {}
 
+#ifndef __LIBRETRO__
 void MiniAudioDevice::init(Samples& samples, bool safe) {
 	this->samples = &samples;
 	running = false;
@@ -213,3 +214,4 @@ void MiniAudioDevice::close() {
 		ma_context_uninit(&context);
 	}
 }
+#endif

--- a/src/core/audio/miniaudio_device.cpp
+++ b/src/core/audio/miniaudio_device.cpp
@@ -7,10 +7,10 @@
 
 #include "helpers.hpp"
 
-MiniAudioDevice::MiniAudioDevice(const AudioDeviceConfig& audioSettings)
-	: initialized(false), running(false), samples(nullptr), audioSettings(audioSettings) {}
+MiniAudioDevice::MiniAudioDevice(const AudioDeviceConfig& audioSettings) : AudioDeviceInterface(nullptr, audioSettings), initialized(false) {
+	running = false;
+}
 
-#ifndef __LIBRETRO__
 void MiniAudioDevice::init(Samples& samples, bool safe) {
 	this->samples = &samples;
 	running = false;
@@ -214,4 +214,3 @@ void MiniAudioDevice::close() {
 		ma_context_uninit(&context);
 	}
 }
-#endif

--- a/src/libretro_core.cpp
+++ b/src/libretro_core.cpp
@@ -22,6 +22,7 @@ static bool usingGLES = false;
 
 std::unique_ptr<Emulator> emulator;
 RendererGL* renderer;
+MiniAudioDevice* audioDevice;
 
 std::filesystem::path Emulator::getConfigPath() {
 	return std::filesystem::path(savePath / "config.toml");
@@ -29,6 +30,27 @@ std::filesystem::path Emulator::getConfigPath() {
 
 std::filesystem::path Emulator::getAppDataRoot() {
 	return std::filesystem::path(savePath / "Emulator Files");
+}
+
+void MiniAudioDevice::init(Samples& samples, bool safe) {
+	this->samples = &samples;
+	initialized = true;
+	running = false;
+
+	audioDevice = this;
+}
+
+void MiniAudioDevice::start() {
+	running = true;
+}
+
+void MiniAudioDevice::stop() {
+	running = false;
+}
+
+void MiniAudioDevice::close() {
+	running = false;
+	initialized = false;
 }
 
 static void* getGLProcAddress(const char* name) {
@@ -389,6 +411,38 @@ void retro_run() {
 	emulator->runFrame();
 
 	videoCallback(RETRO_HW_FRAME_BUFFER_VALID, emulator->width, emulator->height, 0);
+
+	if (audioDevice->running) {
+		static constexpr int frameCount = 547;
+		static constexpr int channelCount = 2;
+		static int16_t audioBuffer[frameCount * channelCount];
+
+		usize samplesWritten = 0;
+		samplesWritten += audioDevice->samples->pop(audioBuffer, frameCount * channelCount);
+
+		// Get the last sample for underrun handling
+		if (samplesWritten != 0) {
+			std::memcpy(
+				&audioDevice->lastStereoSample[0],
+				&audioBuffer[(samplesWritten - 1) * 2],
+				sizeof(audioDevice->lastStereoSample)
+			);
+		}
+
+		// If underruning, copy the last output sample
+		{
+			s16* pointer = &audioBuffer[samplesWritten * 2];
+			s16 l = audioDevice->lastStereoSample[0];
+			s16 r = audioDevice->lastStereoSample[1];
+
+			for (usize i = samplesWritten; i < frameCount; i++) {
+				*pointer++ = l;
+				*pointer++ = r;
+			}
+		}
+
+		audioBatchCallback(audioBuffer, sizeof(audioBuffer) / (2 * sizeof(int16_t)));
+	}
 }
 
 void retro_set_controller_port_device(uint port, uint device) {}


### PR DESCRIPTION
This adds support for audio to the libretro core. It is a working solution but a proper solution will require refactoring the MiniaudioDevice class to avoid code duplication. I’m open to any suggestions you may have.