### PR TITLE
Temporarily give 80MB of FCRAM to all apps

### DIFF
--- a/include/kernel/kernel.hpp
+++ b/include/kernel/kernel.hpp
@@ -253,4 +253,5 @@ public:
 	void sendGPUInterrupt(GPUInterrupt type) { serviceManager.sendGPUInterrupt(type); }
 	void clearInstructionCache();
 	void clearInstructionCacheRange(u32 start, u32 size);
+	u32 getSharedFontVaddr();
 };

--- a/include/kernel/resource_limits.hpp
+++ b/include/kernel/resource_limits.hpp
@@ -19,7 +19,7 @@ struct ResourceLimitValues {
 // APPLICATION resource limit
 static constexpr ResourceLimitValues appResourceLimits = {
 	.maxPriority = 0x18,
-	.maxCommit = 0x4000000,
+	.maxCommit = 64_MB + 16_MB,  // We're currently giving 80MB to all apps. TODO: Implement extended memory properly
 	.maxThreads = 0x20,
 	.maxEvents = 0x20,
 	.maxMutexes = 0x20,
@@ -33,7 +33,7 @@ static constexpr ResourceLimitValues appResourceLimits = {
 // SYS_APPLET resource limit
 static constexpr ResourceLimitValues sysAppletResourceLimits = {
 	.maxPriority = 0x4,
-	.maxCommit = 0x5E00000,
+	.maxCommit = 0x5E00000 - 16_MB,
 	.maxThreads = 0x1D,
 	.maxEvents = 0xB,
 	.maxMutexes = 0x8,

--- a/include/memory.hpp
+++ b/include/memory.hpp
@@ -132,7 +132,7 @@ public:
 	static constexpr u32 totalPageCount = 1 << (32 - pageShift);
 	
 	static constexpr u32 FCRAM_SIZE = u32(128_MB);
-	static constexpr u32 FCRAM_APPLICATION_SIZE = u32(64_MB);
+	static constexpr u32 FCRAM_APPLICATION_SIZE = u32(80_MB);
 	static constexpr u32 FCRAM_PAGE_COUNT = FCRAM_SIZE / pageSize;
 	static constexpr u32 FCRAM_APPLICATION_PAGE_COUNT = FCRAM_APPLICATION_SIZE / pageSize;
 

--- a/src/core/kernel/memory_management.cpp
+++ b/src/core/kernel/memory_management.cpp
@@ -122,7 +122,10 @@ void Kernel::mapMemoryBlock() {
 	}
 
 	if (KernelHandles::isSharedMemHandle(block)) {
-		if (block == KernelHandles::FontSharedMemHandle && addr == 0) addr = 0x18000000;
+		if (block == KernelHandles::FontSharedMemHandle && addr == 0) {
+			addr = getSharedFontVaddr();
+		}
+
 		u8* ptr = mem.mapSharedMemory(block, addr, myPerms, otherPerms); // Map shared memory block
 
 		// Pass pointer to shared memory to the appropriate service
@@ -215,4 +218,9 @@ void Kernel::unmapMemoryBlock() {
 
 	Helpers::warn("Stubbed svcUnmapMemoryBlock!");
 	regs[0] = Result::Success;
+}
+
+u32 Kernel::getSharedFontVaddr() {
+	// Place shared font at the very beginning of system FCRAM
+	return mem.getLinearHeapVaddr() + Memory::FCRAM_APPLICATION_SIZE;
 }

--- a/src/core/services/apt.cpp
+++ b/src/core/services/apt.cpp
@@ -391,7 +391,7 @@ void APTService::setScreencapPostPermission(u32 messagePointer) {
 void APTService::getSharedFont(u32 messagePointer) {
 	log("APT::GetSharedFont\n");
 
-	constexpr u32 fontVaddr = 0x18000000;
+	const u32 fontVaddr = kernel.getSharedFontVaddr();
 	mem.write32(messagePointer, IPC::responseHeader(0x44, 2, 2));
 	mem.write32(messagePointer + 4, Result::Success);
 	mem.write32(messagePointer + 8, fontVaddr);


### PR DESCRIPTION
Should improve stability in most games that use extended memory, such as Pokemon SM/USUM, Smash Bros, Mario Maker, and so on