### PR TITLE
Thread scheduling fixes

### DIFF
--- a/include/kernel/kernel.hpp
+++ b/include/kernel/kernel.hpp
@@ -95,6 +95,8 @@ public:
 	void signalArbiter(u32 waitingAddress, s32 threadCount);
 	void sleepThread(s64 ns);
 	void sleepThreadOnArbiter(u32 waitingAddress);
+	void sleepThreadOnArbiterWithTimeout(u32 waitingAddress, s64 timeoutNs);
+
 	void switchThread(int newThreadIndex);
 	void sortThreads();
 	std::optional<int> getNextThread();

--- a/include/kernel/kernel.hpp
+++ b/include/kernel/kernel.hpp
@@ -58,6 +58,7 @@ class Kernel {
 	// Top 8 bits are the major version, bottom 8 are the minor version
 	u16 kernelVersion = 0;
 
+	u64 nextScheduledWakeupTick = std::numeric_limits<u64>::max();
 	// Shows whether a reschedule will be need
 	bool needReschedule = false;
 
@@ -214,6 +215,8 @@ public:
 		}
 	}
 
+	void addWakeupEvent(u64 tick);
+
 	Handle makeObject(KernelObjectType type) {
 		if (handleCounter > KernelHandles::Max) [[unlikely]] {
 			Helpers::panic("Hlep we somehow created enough kernel objects to overflow this thing");
@@ -253,5 +256,7 @@ public:
 	void sendGPUInterrupt(GPUInterrupt type) { serviceManager.sendGPUInterrupt(type); }
 	void clearInstructionCache();
 	void clearInstructionCacheRange(u32 start, u32 size);
+	void pollThreadWakeups();
+
 	u32 getSharedFontVaddr();
 };

--- a/include/kernel/kernel_types.hpp
+++ b/include/kernel/kernel_types.hpp
@@ -98,16 +98,17 @@ struct Session {
 };
 
 enum class ThreadStatus {
-	Running,      // Currently running
-	Ready,        // Ready to run
-	WaitArbiter,  // Waiting on an address arbiter
-	WaitSleep,    // Waiting due to a SleepThread SVC
-	WaitSync1,    // Waiting for the single object in the wait list to be ready
-	WaitSyncAny,  // Wait for one object of the many that might be in the wait list to be ready
-	WaitSyncAll,  // Waiting for ALL sync objects in its wait list to be ready
-	WaitIPC,      // Waiting for the reply from an IPC request
-	Dormant,      // Created but not yet made ready
-	Dead          // Run to completion, or forcefully terminated
+	Running,             // Currently running
+	Ready,               // Ready to run
+	WaitArbiter,         // Waiting on an address arbiter
+	WaitArbiterTimeout,  // Waiting on an address arbiter with timeout
+	WaitSleep,           // Waiting due to a SleepThread SVC
+	WaitSync1,           // Waiting for the single object in the wait list to be ready
+	WaitSyncAny,         // Wait for one object of the many that might be in the wait list to be ready
+	WaitSyncAll,         // Waiting for ALL sync objects in its wait list to be ready
+	WaitIPC,             // Waiting for the reply from an IPC request
+	Dormant,             // Created but not yet made ready
+	Dead                 // Run to completion, or forcefully terminated
 };
 
 struct Thread {

--- a/include/scheduler.hpp
+++ b/include/scheduler.hpp
@@ -11,7 +11,8 @@ struct Scheduler {
 		VBlank = 0,          // End of frame event
 		UpdateTimers = 1,    // Update kernel timer objects
 		RunDSP = 2,          // Make the emulated DSP run for one audio frame
-		SignalY2R = 3,       // Signal that a Y2R conversion has finished
+		ThreadWakeup = 3,    // A thread is going to wake up and we need to reschedule threads
+		SignalY2R = 4,       // Signal that a Y2R conversion has finished
 		Panic = 4,           // Dummy event that is always pending and should never be triggered (Timestamp = UINT64_MAX)
 		TotalNumberOfEvents  // How many event types do we have in total?
 	};

--- a/src/core/kernel/address_arbiter.cpp
+++ b/src/core/kernel/address_arbiter.cpp
@@ -79,6 +79,14 @@ void Kernel::arbitrateAddress() {
 			break;
 		}
 
+		case ArbitrationType::WaitIfLessTimeout: {
+			s32 word = static_cast<s32>(mem.read32(address));  // Yes this is meant to be signed
+			if (word < value) {
+				sleepThreadOnArbiterWithTimeout(address, ns);
+			}
+			break;
+		}
+
 		case ArbitrationType::Signal:
 			signalArbiter(address, value);
 			break;

--- a/src/core/kernel/events.cpp
+++ b/src/core/kernel/events.cpp
@@ -137,6 +137,7 @@ void Kernel::waitSynchronization1() {
 		// Add the current thread to the object's wait list
 		object->getWaitlist() |= (1ull << currentThreadIndex);
 
+		addWakeupEvent(t.wakeupTick);
 		requireReschedule();
 	}
 }
@@ -231,6 +232,7 @@ void Kernel::waitSynchronizationN() {
 			waitObjects[i].second->getWaitlist() |= (1ull << currentThreadIndex); // And add the thread to the object's waitlist
 		}
 
+		addWakeupEvent(t.wakeupTick);
 		requireReschedule();
 	} else {
 		Helpers::panic("WaitSynchronizationN with waitAll");

--- a/src/core/kernel/kernel.cpp
+++ b/src/core/kernel/kernel.cpp
@@ -1,7 +1,10 @@
-#include <cassert>
 #include "kernel.hpp"
-#include "kernel_types.hpp"
+
+#include <cassert>
+#include <limits>
+
 #include "cpu.hpp"
+#include "kernel_types.hpp"
 
 Kernel::Kernel(CPU& cpu, Memory& mem, GPU& gpu, const EmulatorConfig& config)
 	: cpu(cpu), regs(cpu.regs()), mem(mem), handleCounter(0), serviceManager(regs, mem, gpu, currentProcess, *this, config) {
@@ -159,6 +162,7 @@ void Kernel::reset() {
 	threadIndices.clear();
 	serviceManager.reset();
 
+	nextScheduledWakeupTick = std::numeric_limits<u64>::max();
 	needReschedule = false;
 
 	// Allocate handle #0 to a dummy object and make a main process object

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -177,6 +177,7 @@ void Emulator::pollScheduler() {
 				break;
 			}
 
+			case Scheduler::EventType::ThreadWakeup: kernel.pollThreadWakeups(); break;
 			case Scheduler::EventType::UpdateTimers: kernel.pollTimers(); break;
 			case Scheduler::EventType::RunDSP: {
 				dsp->runAudioFrame(time);


### PR DESCRIPTION
Properly trigger preemption on thread wakeups/timeouts & implement more threading stuff. Improves or fixes several games (Senran Kagura Burst, Detective Pikachu, ...). Not being merged yet in order to consider if there's some more performant way of implementing some things.