### PR TITLE
AppDataDocumentProvider: Add missing ``COLUMN_FLAGS`` in the default …

### DIFF
--- a/src/pandroid/app/src/main/java/com/panda3ds/pandroid/app/provider/AppDataDocumentProvider.java
+++ b/src/pandroid/app/src/main/java/com/panda3ds/pandroid/app/provider/AppDataDocumentProvider.java
@@ -38,6 +38,7 @@ public class AppDataDocumentProvider extends DocumentsProvider {
             Document.COLUMN_DISPLAY_NAME,
             Document.COLUMN_MIME_TYPE,
             Document.COLUMN_LAST_MODIFIED,
+            Document.COLUMN_FLAGS,
             Document.COLUMN_SIZE
     };
 


### PR DESCRIPTION
…document projectation

Fixes unable to copy files from device to app's internal storage problem