### PR TITLE
Add service call intercepts via Lua & thread debugger draft

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -732,10 +732,12 @@ if(NOT BUILD_HYDRA_CORE AND NOT BUILD_LIBRETRO_CORE)
         set(FRONTEND_SOURCE_FILES src/panda_qt/main.cpp src/panda_qt/screen.cpp src/panda_qt/main_window.cpp src/panda_qt/about_window.cpp
             src/panda_qt/config_window.cpp src/panda_qt/zep.cpp src/panda_qt/text_editor.cpp src/panda_qt/cheats_window.cpp src/panda_qt/mappings.cpp
             src/panda_qt/patch_window.cpp src/panda_qt/elided_label.cpp src/panda_qt/shader_editor.cpp src/panda_qt/translations.cpp
+            src/panda_qt/thread_debugger.cpp
         )
         set(FRONTEND_HEADER_FILES include/panda_qt/screen.hpp include/panda_qt/main_window.hpp include/panda_qt/about_window.hpp
             include/panda_qt/config_window.hpp include/panda_qt/text_editor.hpp include/panda_qt/cheats_window.hpp
             include/panda_qt/patch_window.hpp include/panda_qt/elided_label.hpp include/panda_qt/shader_editor.hpp
+            include/panda_qt/thread_debugger.hpp
         )
 
         source_group("Source Files\\Qt" FILES ${FRONTEND_SOURCE_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -415,7 +415,7 @@ set(HEADER_FILES include/emulator.hpp include/helpers.hpp include/termcolor.hpp 
                  include/services/dsp_firmware_db.hpp include/frontend_settings.hpp include/fs/archive_twl_photo.hpp
                  include/fs/archive_twl_sound.hpp include/fs/archive_card_spi.hpp include/services/ns.hpp include/audio/audio_device.hpp
                  include/audio/audio_device_interface.hpp include/audio/libretro_audio_device.hpp include/services/ir/ir_types.hpp
-                 include/services/ir/ir_device.hpp include/services/ir/circlepad_pro.hpp
+                 include/services/ir/ir_device.hpp include/services/ir/circlepad_pro.hpp include/services/service_intercept.hpp
 )
 
 if(IOS)

--- a/include/emulator.hpp
+++ b/include/emulator.hpp
@@ -127,6 +127,7 @@ class Emulator {
 	Scheduler& getScheduler() { return scheduler; }
 	Memory& getMemory() { return memory; }
 	AudioDeviceInterface& getAudioDevice() { return audioDevice; }
+	Kernel& getKernel() { return kernel; }
 
 	RendererType getRendererType() const { return config.rendererType; }
 	Renderer* getRenderer() { return gpu.getRenderer(); }

--- a/include/kernel/kernel.hpp
+++ b/include/kernel/kernel.hpp
@@ -48,12 +48,12 @@ class Kernel {
 	Handle currentProcess;
 	Handle mainThread;
 	int currentThreadIndex;
-	Handle srvHandle; // Handle for the special service manager port "srv:"
-	Handle errorPortHandle; // Handle for the err:f port used for displaying errors
+	Handle srvHandle;        // Handle for the special service manager port "srv:"
+	Handle errorPortHandle;  // Handle for the err:f port used for displaying errors
 
 	u32 arbiterCount;
-	u32 threadCount; // How many threads in our thread pool have been used as of now (Up to 32)
-	u32 aliveThreadCount; // How many of these threads are actually alive?
+	u32 threadCount;       // How many threads in our thread pool have been used as of now (Up to 32)
+	u32 aliveThreadCount;  // How many of these threads are actually alive?
 	ServiceManager serviceManager;
 
 	// Top 8 bits are the major version, bottom 8 are the minor version
@@ -66,10 +66,10 @@ class Kernel {
 	Handle makeProcess(u32 id);
 	Handle makePort(const char* name);
 	Handle makeSession(Handle port);
-	Handle makeThread(u32 entrypoint, u32 initialSP, u32 priority, ProcessorID id, u32 arg,ThreadStatus status = ThreadStatus::Dormant);
+	Handle makeThread(u32 entrypoint, u32 initialSP, u32 priority, ProcessorID id, u32 arg, ThreadStatus status = ThreadStatus::Dormant);
 	Handle makeMemoryBlock(u32 addr, u32 size, u32 myPermission, u32 otherPermission);
 
-public:
+  public:
 	// Needs to be public to be accessible to the APT/HID services
 	Handle makeEvent(ResetType resetType, Event::CallbackType callback = Event::CallbackType::None);
 	// Needs to be public to be accessible to the APT/DSP services
@@ -199,7 +199,7 @@ public:
 	void closeDirectory(u32 messagePointer, Handle directory);
 	void readDirectory(u32 messagePointer, Handle directory);
 
-public:
+  public:
 	Kernel(CPU& cpu, Memory& mem, GPU& gpu, const EmulatorConfig& config, LuaManager& lua);
 	void initializeFS() { return serviceManager.initializeFS(); }
 	void setVersion(u8 major, u8 minor);
@@ -225,9 +225,7 @@ public:
 		return handleCounter++;
 	}
 
-	std::vector<KernelObject>& getObjects() {
-		return objects;
-	}
+	std::vector<KernelObject>& getObjects() { return objects; }
 
 	// Get pointer to the object with the specified handle
 	KernelObject* getObject(Handle handle) {
@@ -255,4 +253,14 @@ public:
 	void clearInstructionCache();
 	void clearInstructionCacheRange(u32 start, u32 size);
 	u32 getSharedFontVaddr();
+
+	// For debuggers: Returns information about the main process' (alive) threads in a vector for the frontend to display
+	std::vector<Thread> getMainProcessThreads();
+
+	// For debuggers: Sets the entrypoint and initial SP for the main thread (thread 0) so that the debugger can display them
+	void setMainThreadEntrypointAndSP(u32 entrypoint, u32 initialSP) {
+		auto& t = threads[0];
+		t.entrypoint = entrypoint;
+		t.initialSP = initialSP;
+	}
 };

--- a/include/kernel/kernel.hpp
+++ b/include/kernel/kernel.hpp
@@ -15,6 +15,7 @@
 #include "services/service_manager.hpp"
 
 class CPU;
+class LuaManager;
 struct Scheduler;
 
 class Kernel {
@@ -199,7 +200,7 @@ public:
 	void readDirectory(u32 messagePointer, Handle directory);
 
 public:
-	Kernel(CPU& cpu, Memory& mem, GPU& gpu, const EmulatorConfig& config);
+	Kernel(CPU& cpu, Memory& mem, GPU& gpu, const EmulatorConfig& config, LuaManager& lua);
 	void initializeFS() { return serviceManager.initializeFS(); }
 	void setVersion(u8 major, u8 minor);
 	void serviceSVC(u32 svc);

--- a/include/lua_manager.hpp
+++ b/include/lua_manager.hpp
@@ -47,6 +47,8 @@ class LuaManager {
 			signalEventInternal(e);
 		}
 	}
+
+	bool signalInterceptedService(const std::string& service, u32 function, u32 messagePointer);
 };
 
 #else  // Lua not enabled, Lua manager does nothing
@@ -60,5 +62,5 @@ class LuaManager {
 	void loadString(const std::string& code) {}
 	void reset() {}
 	void signalEvent(LuaEvent e) {}
-};
+	bool signalInterceptedService(const std::string& service, u32 function, u32 messagePointer) { return false; }
 #endif

--- a/include/lua_manager.hpp
+++ b/include/lua_manager.hpp
@@ -63,4 +63,5 @@ class LuaManager {
 	void reset() {}
 	void signalEvent(LuaEvent e) {}
 	bool signalInterceptedService(const std::string& service, u32 function, u32 messagePointer) { return false; }
+};
 #endif

--- a/include/panda_qt/main_window.hpp
+++ b/include/panda_qt/main_window.hpp
@@ -21,6 +21,7 @@
 #include "panda_qt/screen.hpp"
 #include "panda_qt/shader_editor.hpp"
 #include "panda_qt/text_editor.hpp"
+#include "panda_qt/thread_debugger.hpp"
 #include "services/hid.hpp"
 
 struct CheatMessage {
@@ -109,6 +110,7 @@ class MainWindow : public QMainWindow {
 	TextEditorWindow* luaEditor;
 	PatchWindow* patchWindow;
 	ShaderEditorWindow* shaderEditor;
+	ThreadDebugger* threadDebugger;
 
 	// We use SDL's game controller API since it's the sanest API that supports as many controllers as possible
 	SDL_GameController* gameController = nullptr;
@@ -157,4 +159,7 @@ class MainWindow : public QMainWindow {
 
 	void handleScreenResize(u32 width, u32 height);
 	void handleTouchscreenPress(QMouseEvent* event);
+
+  signals:
+	void emulatorPaused();
 };

--- a/include/panda_qt/thread_debugger.hpp
+++ b/include/panda_qt/thread_debugger.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QString>
+#include <QTableWidget>
+#include <QTimer>
+#include <QVBoxLayout>
+#include <QtWidgets>
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include "emulator.hpp"
+
+class ThreadDebugger : public QWidget {
+	Q_OBJECT
+	Emulator* emu;
+
+	QVBoxLayout* mainLayout;
+	QTableWidget* threadTable;
+
+  public:
+	ThreadDebugger(Emulator* emu, QWidget* parent = nullptr);
+	void update();
+
+  private:
+	void setListItem(int row, int column, const QString& str);
+	void setListItem(int row, int column, const std::string& str);
+};

--- a/include/services/service_intercept.hpp
+++ b/include/services/service_intercept.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#include <functional>
+#include <string>
+
+#include "helpers.hpp"
+
+// We allow Lua scripts to intercept service calls and allow their own code to be ran on SyncRequests
+// For example, if we want to intercept dsp::DSP ReadPipe (Header: 0x000E00C0), the "serviceName" field would be "dsp::DSP"
+// and the "function" field would be 0x000E00C0
+struct InterceptedService {
+	std::string serviceName;  // Name of the service whose function
+	u32 function;             // Header of the function to intercept
+
+	InterceptedService(const std::string& name, u32 header) : serviceName(name), function(header) {}
+	bool operator==(const InterceptedService& other) const { return serviceName == other.serviceName && function == other.function; }
+};
+
+// Define hashing function for InterceptedService to use it with unordered_map
+namespace std {
+	template <>
+	struct hash<InterceptedService> {
+		usize operator()(const InterceptedService& s) const noexcept {
+			const usize hash1 = std::hash<std::string>{}(s.serviceName);
+			const usize hash2 = std::hash<u32>{}(s.function);
+			return hash1 ^ (hash2 << 1);
+		}
+	};
+}  // namespace std

--- a/src/core/kernel/idle_thread.cpp
+++ b/src/core/kernel/idle_thread.cpp
@@ -1,4 +1,5 @@
 #include <cstring>
+
 #include "arm_defs.hpp"
 #include "kernel.hpp"
 
@@ -35,13 +36,14 @@ void Kernel::setupIdleThread() {
 	if (!vaddr.has_value() || vaddr.value() != codeAddress) {
 		Helpers::panic("Failed to setup idle thread");
 	}
-	
+
 	// Copy idle thread code to the allocated FCRAM
 	std::memcpy(&mem.getFCRAM()[fcramIndex], idleThreadCode, sizeof(idleThreadCode));
 
 	t.entrypoint = codeAddress;
+	t.initialSP = 0;
 	t.tlsBase = 0;
-	t.gprs[13] = 0; // Set SP & LR to 0 just in case. The idle thread should never access memory, but let's be safe
+	t.gprs[13] = 0;  // Set SP & LR to 0 just in case. The idle thread should never access memory, but let's be safe
 	t.gprs[14] = 0;
 	t.gprs[15] = codeAddress;
 	t.cpsr = CPSR::UserMode;

--- a/src/core/kernel/kernel.cpp
+++ b/src/core/kernel/kernel.cpp
@@ -3,9 +3,9 @@
 #include "kernel_types.hpp"
 #include "cpu.hpp"
 
-Kernel::Kernel(CPU& cpu, Memory& mem, GPU& gpu, const EmulatorConfig& config)
-	: cpu(cpu), regs(cpu.regs()), mem(mem), handleCounter(0), serviceManager(regs, mem, gpu, currentProcess, *this, config) {
-	objects.reserve(512); // Make room for a few objects to avoid further memory allocs later
+Kernel::Kernel(CPU& cpu, Memory& mem, GPU& gpu, const EmulatorConfig& config, LuaManager& lua)
+	: cpu(cpu), regs(cpu.regs()), mem(mem), handleCounter(0), serviceManager(regs, mem, gpu, currentProcess, *this, config, lua) {
+	objects.reserve(512);  // Make room for a few objects to avoid further memory allocs later
 	mutexHandles.reserve(8);
 	portHandles.reserve(32);
 	threadIndices.reserve(appResourceLimits.maxThreads);

--- a/src/core/kernel/threads.cpp
+++ b/src/core/kernel/threads.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <bit>
 #include <cassert>
 #include <cstring>
@@ -696,4 +697,19 @@ bool Kernel::shouldWaitOnObject(KernelObject* object) {
 			Helpers::panic("Not sure whether to wait on object (type: %s)", object->getTypeName());
 			return true;
 	}
+}
+
+std::vector<Thread> Kernel::getMainProcessThreads() {
+	// Sort the thread indices so that they appear nicer in the debugger
+	auto indices = threadIndices;
+	std::sort(indices.begin(), indices.end());
+
+	std::vector<Thread> ret;
+	ret.reserve(indices.size());
+
+	for (const auto& index : indices) {
+		ret.push_back(threads[index]);
+	}
+
+	return ret;
 }

--- a/src/core/services/service_manager.cpp
+++ b/src/core/services/service_manager.cpp
@@ -5,8 +5,10 @@
 #include "ipc.hpp"
 #include "kernel.hpp"
 
-ServiceManager::ServiceManager(std::span<u32, 16> regs, Memory& mem, GPU& gpu, u32& currentPID, Kernel& kernel, const EmulatorConfig& config)
-	: regs(regs), mem(mem), kernel(kernel), ac(mem), am(mem), boss(mem), act(mem), apt(mem, kernel), cam(mem, kernel), cecd(mem, kernel),
+ServiceManager::ServiceManager(
+	std::span<u32, 16> regs, Memory& mem, GPU& gpu, u32& currentPID, Kernel& kernel, const EmulatorConfig& config, LuaManager& lua
+)
+	: regs(regs), mem(mem), kernel(kernel), lua(lua), ac(mem), am(mem), boss(mem), act(mem), apt(mem, kernel), cam(mem, kernel), cecd(mem, kernel),
 	  cfg(mem, config), csnd(mem, kernel), dlp_srvr(mem), dsp(mem, kernel, config), hid(mem, kernel), http(mem), ir_user(mem, hid, config, kernel),
 	  frd(mem), fs(mem, kernel, config), gsp_gpu(mem, gpu, kernel, currentPID), gsp_lcd(mem), ldr(mem, kernel), mcu_hwc(mem, config),
 	  mic(mem, kernel), nfc(mem, kernel), nim(mem), ndm(mem), news_u(mem), ns(mem), nwm_uds(mem, kernel), ptm(mem, config), soc(mem), ssl(mem),
@@ -214,6 +216,28 @@ void ServiceManager::publishToSubscriber(u32 messagePointer) {
 }
 
 void ServiceManager::sendCommandToService(u32 messagePointer, Handle handle) {
+	if (interceptedServices.size() != 0) [[unlikely]] {
+		// Check if there's a Lua handler for this function and call it
+		u32 function = mem.read32(messagePointer);
+
+		for (auto [serviceName, serviceHandle] : serviceMap) {
+			if (serviceHandle == handle) {
+				auto intercept = InterceptedService(std::string(serviceName), function);
+				if (interceptedServices.contains(intercept)) {
+					printf("Call to intercepted service\n");
+
+					// If the Lua handler returns true, it means the service is handled entirely
+					// From Lua, and we shouldn't do anything else here.
+					if (lua.signalInterceptedService(intercept.serviceName, function, messagePointer)) {
+						return;
+					}
+				}
+
+				break;
+			}
+		}
+	}
+
 	switch (handle) {
 		// Breaking alphabetical order a bit to place the ones I think are most common at the top
 		case KernelHandles::GPU: [[likely]] gsp_gpu.handleSyncRequest(messagePointer); break;

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -272,6 +272,11 @@ bool Emulator::loadROM(const std::filesystem::path& path) {
 		romType = ROMType::None;
 	}
 
+	if (success) {
+		// Update the main thread entrypoint and SP so that the thread debugger can display them.
+		kernel.setMainThreadEntrypointAndSP(cpu.getReg(15), cpu.getReg(13));
+	}
+
 	resume();  // Start the emulator
 	return success;
 }

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -19,8 +19,9 @@ __declspec(dllexport) DWORD AmdPowerXpressRequestHighPerformance = 1;
 #endif
 
 Emulator::Emulator()
-	: config(getConfigPath()), kernel(cpu, memory, gpu, config), cpu(memory, kernel, *this), gpu(memory, config), memory(cpu.getTicksRef(), config),
-	  cheats(memory, kernel.getServiceManager().getHID()), audioDevice(config.audioDeviceConfig), lua(*this), running(false)
+	: config(getConfigPath()), kernel(cpu, memory, gpu, config, lua), cpu(memory, kernel, *this), gpu(memory, config),
+	  memory(cpu.getTicksRef(), config), cheats(memory, kernel.getServiceManager().getHID()), audioDevice(config.audioDeviceConfig), lua(*this),
+	  running(false)
 #ifdef PANDA3DS_ENABLE_HTTP_SERVER
 	  ,
 	  httpServer(this)

--- a/src/panda_qt/thread_debugger.cpp
+++ b/src/panda_qt/thread_debugger.cpp
@@ -1,0 +1,76 @@
+#include "panda_qt/thread_debugger.hpp"
+
+#include <fmt/format.h>
+
+static QString threadStatusToQString(ThreadStatus status) {
+	switch (status) {
+		case ThreadStatus::Running: return QObject::tr("Running");
+		case ThreadStatus::Ready: return QObject::tr("Ready");
+		case ThreadStatus::WaitArbiter: return QObject::tr("Waiting on arbiter");
+		case ThreadStatus::WaitSleep: return QObject::tr("Sleeping");
+		case ThreadStatus::WaitSync1: return QObject::tr("WaitSync (1)");
+		case ThreadStatus::WaitSyncAny: return QObject::tr("WaitSync (Any)");
+		case ThreadStatus::WaitSyncAll: return QObject::tr("WaitSync (All)");
+		case ThreadStatus::WaitIPC: return QObject::tr("Waiting for IPC");
+		case ThreadStatus::Dormant: return QObject::tr("Dormant");
+		case ThreadStatus::Dead: return QObject::tr("Dead");
+		default: return QObject::tr("Unknown thread status");
+	}
+}
+
+ThreadDebugger::ThreadDebugger(Emulator* emu, QWidget* parent) : emu(emu), QWidget(parent, Qt::Window) {
+	setWindowTitle(tr("Thread Debugger"));
+	resize(700, 600);
+
+	mainLayout = new QVBoxLayout(this);
+	threadTable = new QTableWidget(this);
+	threadTable->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+
+	mainLayout->addWidget(threadTable);
+}
+
+void ThreadDebugger::update() {
+	threadTable->clear();
+
+	threadTable->setSelectionMode(QAbstractItemView::NoSelection);
+	threadTable->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+	threadTable->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
+	threadTable->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+	threadTable->setColumnCount(5);
+	threadTable->verticalHeader()->setVisible(false);
+	threadTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+	threadTable->setHorizontalHeaderLabels(QStringList({"ID", "Status", "PC", "Entrypoint", "Stack Top"}));
+
+	const auto threads = emu->getKernel().getMainProcessThreads();
+	const usize count = threads.size();
+	threadTable->setRowCount(count);
+
+	for (int i = 0; i < count; i++) {
+		const auto& thread = threads[i];
+		setListItem(i, 0, fmt::format("{}", thread.index));
+		setListItem(i, 1, threadStatusToQString(thread.status));
+		setListItem(i, 2, fmt::format("{:08X}", thread.gprs[15]));
+		setListItem(i, 3, fmt::format("{:08X}", thread.entrypoint));
+		setListItem(i, 4, fmt::format("{:08X}", thread.initialSP));
+	}
+}
+
+void ThreadDebugger::setListItem(int row, int column, const std::string& str) { setListItem(row, column, QString::fromStdString(str)); }
+
+void ThreadDebugger::setListItem(int row, int column, const QString& str) {
+	QTableWidgetItem* item = new QTableWidgetItem();
+	QWidget* widget = new QWidget(this);
+	QVBoxLayout* layout = new QVBoxLayout(widget);
+	QLabel* label = new QLabel(widget);
+
+	layout->setAlignment(Qt::AlignVCenter);
+	layout->setContentsMargins(5, 0, 5, 0);
+
+	label->setText(str);
+	layout->addWidget(label);
+	widget->setLayout(layout);
+
+	threadTable->setItem(row, column, item);
+	threadTable->setCellWidget(row, column, widget);
+}


### PR DESCRIPTION
Service call intercepts (Allows you to inject Lua code when sysmodule functions are called, or handle the sysmodule entirely from Lua):
![image](https://github.com/user-attachments/assets/bee49b21-b9d4-4d9d-83a4-cef13632c56f)

```lua
OpenFile = 0x080201C2
Pand.addServiceIntercept("fs:USER", OpenFile)

function interceptService(service, func, buffer)
   print("Intercepted a function from the", service, "module")

   if service == "fs:USER" and func == OpenFile then
    print("OpenFile was called, let's nuke it")
    Pand.write32(buffer + 4, -1)

    -- Tell the C++ side we handled this service call ourselves and it doesn't need to do anything
    return true
   end

  -- Let C++ handle the service call
  return false
end
```

Thread debugger draft:
![image](https://github.com/user-attachments/assets/1765f80f-a13b-479f-86cb-929bfc78bd3c)
