### PR TITLE
Lua services interception upgrade

### DIFF
--- a/include/lua_manager.hpp
+++ b/include/lua_manager.hpp
@@ -48,7 +48,8 @@ class LuaManager {
 		}
 	}
 
-	bool signalInterceptedService(const std::string& service, u32 function, u32 messagePointer);
+	bool signalInterceptedService(int callback_ref, const std::string& service, u32 function, u32 messagePointer);
+	void removeInterceptedService(const std::string& service, u32 function, int callback_ref);
 };
 
 #else  // Lua not enabled, Lua manager does nothing
@@ -62,6 +63,7 @@ class LuaManager {
 	void loadString(const std::string& code) {}
 	void reset() {}
 	void signalEvent(LuaEvent e) {}
-	bool signalInterceptedService(const std::string& service, u32 function, u32 messagePointer) { return false; }
+	bool signalInterceptedService(int callback_ref, const std::string& service, u32 function, u32 messagePointer) { return false; }
+	void removeInterceptedService(const std::string& service, u32 function, int callback_ref) {}
 };
 #endif

--- a/include/services/service_manager.hpp
+++ b/include/services/service_manager.hpp
@@ -3,7 +3,7 @@
 #include <optional>
 #include <span>
 #include <string>
-#include <unordered_set>
+#include <unordered_map>
 
 #include "kernel_types.hpp"
 #include "logger.hpp"
@@ -94,9 +94,10 @@ class ServiceManager {
 	// For example, if we want to intercept dsp::DSP ReadPipe (Header: 0x000E00C0), the "serviceName" field would be "dsp::DSP"
 	// and the "function" field would be 0x000E00C0
 	LuaManager& lua;
-	std::unordered_set<InterceptedService> interceptedServices = {};
+	std::unordered_map<InterceptedService, int> interceptedServices = {};
 	// Calling std::unordered_set<T>::size() compiles to a fairly non-trivial function call on Clang, so we store this
 	// separately and check it on service calls, for performance reasons
+	// TODO: changed from unordered_set to unordered_map, still the case?
 	bool haveServiceIntercepts = false;
 
 	// Checks for whether a service call is intercepted by Lua and handles it. Returns true if Lua told us not to handle the function,
@@ -134,12 +135,22 @@ class ServiceManager {
 	Y2RService& getY2R() { return y2r; }
 	IRUserService& getIRUser() { return ir_user; }
 
-	void addServiceIntercept(const std::string& service, u32 function) {
-		interceptedServices.insert(InterceptedService(service, function));
+	void addServiceIntercept(const std::string& service, u32 function, int callback_ref) {
+		auto success = interceptedServices.try_emplace(InterceptedService(service, function), callback_ref);
+		if(!success.second) {
+			// this intercept already exists
+			// remove the old callback and set the new one
+			lua.removeInterceptedService(service, function, success.first->second);
+			success.first->second = callback_ref;
+		}
+		// otherwise, insertion was already successful with the new callback
 		haveServiceIntercepts = true;
 	}
 
 	void clearServiceIntercepts() {
+		for(const auto& [interceptedService, callback_ref] : interceptedServices) {
+			lua.removeInterceptedService(interceptedService.serviceName, interceptedService.function, callback_ref);
+		}
 		interceptedServices.clear();
 		haveServiceIntercepts = false;
 	}

--- a/src/core/services/service_manager.cpp
+++ b/src/core/services/service_manager.cpp
@@ -271,13 +271,13 @@ bool ServiceManager::checkForIntercept(u32 messagePointer, Handle handle) {
 	// Check if there's a Lua handler for this function and call it
 	const u32 function = mem.read32(messagePointer);
 
-	for (auto [serviceName, serviceHandle] : serviceMap) {
+	for (const auto& [serviceName, serviceHandle] : serviceMap) {
 		if (serviceHandle == handle) {
 			auto intercept = InterceptedService(std::string(serviceName), function);
-			if (interceptedServices.contains(intercept)) {
+			if (auto intercept_it = interceptedServices.find(intercept); intercept_it != interceptedServices.end()) {
 				// If the Lua handler returns true, it means the service is handled entirely
 				// From Lua, and we shouldn't do anything else here.
-				return lua.signalInterceptedService(intercept.serviceName, function, messagePointer);
+				return lua.signalInterceptedService(intercept_it->second, intercept.serviceName, function, messagePointer);
 			}
 
 			break;


### PR DESCRIPTION
That feature was great, good work! Some design decisions werent my favourite though, as we discussed on discord, so I'm PRing this, see if you want it

- Faster and better lookup of the service names from handles should improve the frame drops you noticed sometimes
  - first commit: prevent unnecessary string copies
  - second commit: use a reverse form of serviceMap so the better algorithm from the data structure kicks in
- Pand.addServiceIntercept in the Lua code now takes a third callback argument, so "interceptService" in the Lua code is no longer implicitly the handler for all the intercepts
  - Easier to make separate handlers for separate things, or even anonymous ones (see comments in lua.cpp:addServiceInterceptThunk)
  - This should also make the intercepts faster because of looking up an integer key in the registry instead of a string key in the global scope