### PR TITLE
GL: Use StreamBuffer for shadergen UBOs

### DIFF
--- a/include/renderer_gl/renderer_gl.hpp
+++ b/include/renderer_gl/renderer_gl.hpp
@@ -92,11 +92,12 @@ class RendererGL final : public Renderer {
 	// The "default" vertex shader to use when using specialized shaders but not PICA vertex shader -> GLSL recompilation
 	// We can compile this once and then link it with all other generated fragment shaders
 	OpenGL::Shader defaultShadergenVs;
-	GLuint shadergenFragmentUBO;
-	// UBO for uploading the PICA uniforms when using hw shaders
-	GLuint hwShaderUniformUBO;
 
 	using StreamBuffer = OpenGLStreamBuffer;
+
+	std::unique_ptr<StreamBuffer> shadergenFragmentUBO;
+	// UBO for uploading the PICA uniforms when using hw shaders
+	std::unique_ptr<StreamBuffer> hwShaderUniformUBO;
 	std::unique_ptr<StreamBuffer> hwVertexBuffer;
 	std::unique_ptr<StreamBuffer> hwIndexBuffer;
 

--- a/src/core/renderer_gl/renderer_gl.cpp
+++ b/src/core/renderer_gl/renderer_gl.cpp
@@ -71,11 +71,13 @@ void RendererGL::initGraphicsContextInternal() {
 	// Create stream buffers for vertex, index and uniform buffers
 	static constexpr usize hwIndexBufferSize = 2_MB;
 	static constexpr usize hwVertexBufferSize = 16_MB;
+	static constexpr usize hwShaderUniformUBOSize = 4_MB;
+	static constexpr usize shadergenFragmentUBOSize = 4_MB;
 
 	hwIndexBuffer = StreamBuffer::Create(GL_ELEMENT_ARRAY_BUFFER, hwIndexBufferSize);
 	hwVertexBuffer = StreamBuffer::Create(GL_ARRAY_BUFFER, hwVertexBufferSize);
-	hwShaderUniformUBO = StreamBuffer::Create(GL_UNIFORM_BUFFER, 1_MB);
-	shadergenFragmentUBO = StreamBuffer::Create(GL_UNIFORM_BUFFER, 1_MB);
+	hwShaderUniformUBO = StreamBuffer::Create(GL_UNIFORM_BUFFER, hwShaderUniformUBOSize);
+	shadergenFragmentUBO = StreamBuffer::Create(GL_UNIFORM_BUFFER, shadergenFragmentUBOSize);
 
 	vbo.createFixedSize(sizeof(Vertex) * vertexBufferSize * 2, GL_STREAM_DRAW);
 	vbo.bind();


### PR DESCRIPTION
Improves performance a *lot* on devices where glBufferSubData is slow, as UBOs now use persistent-mapped storage. Tested on an M3 Mac, where games with lots of buffer upload would completely choke on uploading data to the GPU.