### PR TITLE
material_switch_widget: remove unnecessary scalling

### DIFF
--- a/src/pandroid/app/src/main/res/layout/material_switch_widget.xml
+++ b/src/pandroid/app/src/main/res/layout/material_switch_widget.xml
@@ -6,6 +6,4 @@
     android:layout_height="wrap_content"
     android:background="@null"
     android:clickable="false"
-    android:focusable="false"
-    android:scaleX="0.75"
-    android:scaleY="0.75"/>
+    android:focusable="false" />


### PR DESCRIPTION

<img width="1280" height="820" alt="20260422_104725" src="https://github.com/user-attachments/assets/6d29f30b-454e-4697-bb84-1da6c01ad617" />
removes material switch unnecessary manual scaling which causes the switch to appear way smaller than it actually was