### PR TITLE
Set CI build to use Windows-2022 instead of latest

### DIFF
--- a/.github/workflows/Qt_Build.yml
+++ b/.github/workflows/Qt_Build.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   Windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Debugging an issue with latest Windows builds not properly loading games