### PR TITLE
ci: add Linux aarch64 and Android x86_64 builds (+ fix cryptopp on ARMv8)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,6 +62,18 @@ libretro-build-linux-x64:
     - .libretro-linux-cmake-x86_64
     - .core-defs
 
+# Linux aarch64
+# No image override here: the :backports tag exists only for the amd64 image,
+# while the aarch64 one installs gcc-12 in its main Dockerfile, so the same
+# compiler the x64 job asks for is already on PATH.
+libretro-build-linux-aarch64:
+  variables:
+    CC: /usr/bin/gcc-12
+    CXX: /usr/bin/g++-12
+  extends:
+    - .libretro-linux-cmake-aarch64
+    - .core-defs
+
 # Windows 64-bit
 libretro-build-windows-x64:
   extends:

--- a/third_party/cryptopp/CMakeLists.txt
+++ b/third_party/cryptopp/CMakeLists.txt
@@ -426,6 +426,50 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU
       endif ()
     endif ()
   endif ()
+
+  # ARMv8 (aarch64). CRC32 and the crypto extensions are optional parts of the
+  # architecture, so the sources that use them have to be compiled with the
+  # matching -march or the assembler rejects the instructions outright:
+  #   crc_simd.cpp: Error: selected processor does not support `crc32w w0,w0,w2'
+  # Apple and Android toolchains already imply these, so only probe elsewhere.
+  if (CRYPTOPP_ARMV8 AND NOT APPLE AND NOT ANDROID AND NOT CRYPTOPP_DISABLE_ASM)
+    CheckCompileLinkOption("-march=armv8-a+crc -I${SRC_DIR} -DCRYPTOPP_ARM_NEON_HEADER=1" CRYPTOPP_ARMV8_CRC32
+                           "${TEST_PROG_DIR}/test_arm_crc.cpp")
+    CheckCompileLinkOption("-march=armv8-a+crypto -I${SRC_DIR} -DCRYPTOPP_ARM_NEON_HEADER=1" CRYPTOPP_ARMV8_AES
+                           "${TEST_PROG_DIR}/test_arm_aes.cpp")
+    CheckCompileLinkOption("-march=armv8-a+crypto -I${SRC_DIR} -DCRYPTOPP_ARM_NEON_HEADER=1" CRYPTOPP_ARMV8_PMULL
+                           "${TEST_PROG_DIR}/test_arm_pmull.cpp")
+    CheckCompileLinkOption("-march=armv8-a+crypto -I${SRC_DIR} -DCRYPTOPP_ARM_NEON_HEADER=1" CRYPTOPP_ARMV8_SHA256
+                           "${TEST_PROG_DIR}/test_arm_sha256.cpp")
+
+    if (CRYPTOPP_ARMV8_CRC32)
+      set_source_files_properties(${SRC_DIR}/crc_simd.cpp PROPERTIES
+                                  COMPILE_FLAGS "-march=armv8-a+crc")
+    else ()
+      list(APPEND CRYPTOPP_COMPILE_OPTIONS "-DCRYPTOPP_DISABLE_ARM_CRC32")
+    endif ()
+
+    if (CRYPTOPP_ARMV8_AES)
+      set_source_files_properties(${SRC_DIR}/rijndael_simd.cpp PROPERTIES
+                                  COMPILE_FLAGS "-march=armv8-a+crypto")
+    else ()
+      list(APPEND CRYPTOPP_COMPILE_OPTIONS "-DCRYPTOPP_DISABLE_ARM_AES")
+    endif ()
+
+    if (CRYPTOPP_ARMV8_PMULL)
+      set_source_files_properties(${SRC_DIR}/gcm_simd.cpp ${SRC_DIR}/gf2n_simd.cpp
+                                  PROPERTIES COMPILE_FLAGS "-march=armv8-a+crypto")
+    else ()
+      list(APPEND CRYPTOPP_COMPILE_OPTIONS "-DCRYPTOPP_DISABLE_ARM_PMULL")
+    endif ()
+
+    if (CRYPTOPP_ARMV8_SHA256)
+      set_source_files_properties(${SRC_DIR}/sha_simd.cpp ${SRC_DIR}/shacal2_simd.cpp
+                                  PROPERTIES COMPILE_FLAGS "-march=armv8-a+crypto")
+    else ()
+      list(APPEND CRYPTOPP_COMPILE_OPTIONS "-DCRYPTOPP_DISABLE_ARM_SHA")
+    endif ()
+  endif ()
 endif ()
 
 #============================================================================


### PR DESCRIPTION
Two targets the libretro buildbot does not currently ship.

**Linux aarch64** — the job needs cryptopp's SIMD sources to be given their `-march` flags on ARMv8, otherwise the build fails on the NEON/crypto intrinsics; that fix is the second commit.

**Android x86_64** — enables the job that was already sketched out (commented) in `.gitlab-ci.yml`, mirroring arm64-v8a with the same NDK pin. It is the ABI used by Android emulators and x86 Chromebooks. 32-bit x86 stays commented out: the core needs a 64-bit address space.

Rebased on current master.